### PR TITLE
Add 2016 general election precinct-level results for Floyd county.

### DIFF
--- a/2016/20161108__in__general__floyd__precinct.csv
+++ b/2016/20161108__in__general__floyd__precinct.csv
@@ -1,0 +1,1646 @@
+county,precinct,office,district,candidate,party,votes
+Floyd,FRANKLIN - 1,Voters,,Registered,,1042
+Floyd,FRANKLIN - 1,Voters,,Ballots Cast,,708
+Floyd,FRANKLIN - 1,Voters,,Straight Ticket,R,210
+Floyd,FRANKLIN - 1,Voters,,Straight Ticket,D,111
+Floyd,FRANKLIN - 1,Voters,,Straight Ticket,L,4
+Floyd,FRANKLIN - 1,President,,Donald J. Trump,R,467
+Floyd,FRANKLIN - 1,President,,Hillary Clinton,D,201
+Floyd,FRANKLIN - 1,President,,Gary Johnson,L,28
+Floyd,FRANKLIN - 1,President,,Write In,,8
+Floyd,FRANKLIN - 1,U.S. Senate,,Todd Young,R,420
+Floyd,FRANKLIN - 1,U.S. Senate,,Evan Bayh,D,254
+Floyd,FRANKLIN - 1,U.S. Senate,,Lucy Brenton,L,20
+Floyd,FRANKLIN - 1,U.S. Senate,,Write In,,0
+Floyd,FRANKLIN - 1,Governor,,Eric Holcomb,R,440
+Floyd,FRANKLIN - 1,Governor,,John R. Gregg,D,227
+Floyd,FRANKLIN - 1,Governor,,Rex Bell,L,17
+Floyd,FRANKLIN - 1,Governor,,Write In,,1
+Floyd,FRANKLIN - 1,Attorney General,,"Curtis T. Hill, Jr.",R,464
+Floyd,FRANKLIN - 1,Attorney General,,Lorenzo Arredondo,D,203
+Floyd,FRANKLIN - 1,Superintendent of Public Instruction,,Jennifer Mccormick,R,425
+Floyd,FRANKLIN - 1,Superintendent of Public Instruction,,Glenda Ritz,D,243
+Floyd,FRANKLIN - 1,U.S. House,9,Trey Hollingsworth,R,386
+Floyd,FRANKLIN - 1,U.S. House,9,Shelli Yoder,D,268
+Floyd,FRANKLIN - 1,U.S. House,9,Russell Brooksbank,L,33
+Floyd,FRANKLIN - 1,U.S. House,9,Write In,,1
+Floyd,FRANKLIN - 1,State House,70,Karen Engleman,R,436
+Floyd,FRANKLIN - 1,State House,70,Heidi Cade Sellers,D,240
+Floyd,GEORGETOWN - 1,Voters,,Registered,,1181
+Floyd,GEORGETOWN - 1,Voters,,Ballots Cast,,860
+Floyd,GEORGETOWN - 1,Voters,,Straight Ticket,R,219
+Floyd,GEORGETOWN - 1,Voters,,Straight Ticket,D,106
+Floyd,GEORGETOWN - 1,Voters,,Straight Ticket,L,4
+Floyd,GEORGETOWN - 1,President,,Donald J. Trump,R,525
+Floyd,GEORGETOWN - 1,President,,Hillary Clinton,D,276
+Floyd,GEORGETOWN - 1,President,,Gary Johnson,L,35
+Floyd,GEORGETOWN - 1,President,,Write In,,17
+Floyd,GEORGETOWN - 1,U.S. Senate,,Todd Young,R,527
+Floyd,GEORGETOWN - 1,U.S. Senate,,Evan Bayh,D,301
+Floyd,GEORGETOWN - 1,U.S. Senate,,Lucy Brenton,L,20
+Floyd,GEORGETOWN - 1,U.S. Senate,,Write In,,1
+Floyd,GEORGETOWN - 1,Governor,,Eric Holcomb,R,510
+Floyd,GEORGETOWN - 1,Governor,,John R. Gregg,D,300
+Floyd,GEORGETOWN - 1,Governor,,Rex Bell,L,17
+Floyd,GEORGETOWN - 1,Governor,,Write In,,0
+Floyd,GEORGETOWN - 1,Attorney General,,"Curtis T. Hill, Jr.",R,523
+Floyd,GEORGETOWN - 1,Attorney General,,Lorenzo Arredondo,D,262
+Floyd,GEORGETOWN - 1,Superintendent of Public Instruction,,Jennifer Mccormick,R,479
+Floyd,GEORGETOWN - 1,Superintendent of Public Instruction,,Glenda Ritz,D,317
+Floyd,GEORGETOWN - 1,U.S. House,9,Trey Hollingsworth,R,468
+Floyd,GEORGETOWN - 1,U.S. House,9,Shelli Yoder,D,336
+Floyd,GEORGETOWN - 1,U.S. House,9,Russell Brooksbank,L,28
+Floyd,GEORGETOWN - 1,U.S. House,9,Write In,,0
+Floyd,GEORGETOWN - 1,State House,72,Edward D. (Ed) Clere,R,533
+Floyd,GEORGETOWN - 1,State House,72,Steve Bonifer,D,287
+Floyd,GEORGETOWN - 2,Voters,,Registered,,1459
+Floyd,GEORGETOWN - 2,Voters,,Ballots Cast,,990
+Floyd,GEORGETOWN - 2,Voters,,Straight Ticket,R,280
+Floyd,GEORGETOWN - 2,Voters,,Straight Ticket,D,126
+Floyd,GEORGETOWN - 2,Voters,,Straight Ticket,L,12
+Floyd,GEORGETOWN - 2,President,,Donald J. Trump,R,639
+Floyd,GEORGETOWN - 2,President,,Hillary Clinton,D,278
+Floyd,GEORGETOWN - 2,President,,Gary Johnson,L,51
+Floyd,GEORGETOWN - 2,President,,Write In,,11
+Floyd,GEORGETOWN - 2,U.S. Senate,,Todd Young,R,602
+Floyd,GEORGETOWN - 2,U.S. Senate,,Evan Bayh,D,331
+Floyd,GEORGETOWN - 2,U.S. Senate,,Lucy Brenton,L,37
+Floyd,GEORGETOWN - 2,U.S. Senate,,Write In,,0
+Floyd,GEORGETOWN - 2,Governor,,Eric Holcomb,R,610
+Floyd,GEORGETOWN - 2,Governor,,John R. Gregg,D,315
+Floyd,GEORGETOWN - 2,Governor,,Rex Bell,L,29
+Floyd,GEORGETOWN - 2,Governor,,Write In,,0
+Floyd,GEORGETOWN - 2,Attorney General,,"Curtis T. Hill, Jr.",R,638
+Floyd,GEORGETOWN - 2,Attorney General,,Lorenzo Arredondo,D,284
+Floyd,GEORGETOWN - 2,Superintendent of Public Instruction,,Jennifer Mccormick,R,596
+Floyd,GEORGETOWN - 2,Superintendent of Public Instruction,,Glenda Ritz,D,332
+Floyd,GEORGETOWN - 2,U.S. House,9,Trey Hollingsworth,R,572
+Floyd,GEORGETOWN - 2,U.S. House,9,Shelli Yoder,D,348
+Floyd,GEORGETOWN - 2,U.S. House,9,Russell Brooksbank,L,40
+Floyd,GEORGETOWN - 2,U.S. House,9,Write In,,0
+Floyd,GEORGETOWN - 2,State House,72,Edward D. (Ed) Clere,R,632
+Floyd,GEORGETOWN - 2,State House,72,Steve Bonifer,D,317
+Floyd,GEORGETOWN - 3,Voters,,Registered,,1099
+Floyd,GEORGETOWN - 3,Voters,,Ballots Cast,,780
+Floyd,GEORGETOWN - 3,Voters,,Straight Ticket,R,233
+Floyd,GEORGETOWN - 3,Voters,,Straight Ticket,D,93
+Floyd,GEORGETOWN - 3,Voters,,Straight Ticket,L,3
+Floyd,GEORGETOWN - 3,President,,Donald J. Trump,R,510
+Floyd,GEORGETOWN - 3,President,,Hillary Clinton,D,219
+Floyd,GEORGETOWN - 3,President,,Gary Johnson,L,28
+Floyd,GEORGETOWN - 3,President,,Write In,,14
+Floyd,GEORGETOWN - 3,U.S. Senate,,Todd Young,R,514
+Floyd,GEORGETOWN - 3,U.S. Senate,,Evan Bayh,D,233
+Floyd,GEORGETOWN - 3,U.S. Senate,,Lucy Brenton,L,21
+Floyd,GEORGETOWN - 3,U.S. Senate,,Write In,,1
+Floyd,GEORGETOWN - 3,Governor,,Eric Holcomb,R,497
+Floyd,GEORGETOWN - 3,Governor,,John R. Gregg,D,246
+Floyd,GEORGETOWN - 3,Governor,,Rex Bell,L,12
+Floyd,GEORGETOWN - 3,Governor,,Write In,,0
+Floyd,GEORGETOWN - 3,Attorney General,,"Curtis T. Hill, Jr.",R,516
+Floyd,GEORGETOWN - 3,Attorney General,,Lorenzo Arredondo,D,207
+Floyd,GEORGETOWN - 3,Superintendent of Public Instruction,,Jennifer Mccormick,R,481
+Floyd,GEORGETOWN - 3,Superintendent of Public Instruction,,Glenda Ritz,D,248
+Floyd,GEORGETOWN - 3,U.S. House,9,Trey Hollingsworth,R,463
+Floyd,GEORGETOWN - 3,U.S. House,9,Shelli Yoder,D,258
+Floyd,GEORGETOWN - 3,U.S. House,9,Russell Brooksbank,L,36
+Floyd,GEORGETOWN - 3,U.S. House,9,Write In,,0
+Floyd,GEORGETOWN - 3,State House,72,Edward D. (Ed) Clere,R,521
+Floyd,GEORGETOWN - 3,State House,72,Steve Bonifer,D,221
+Floyd,GEORGETOWN - 4,Voters,,Registered,,1464
+Floyd,GEORGETOWN - 4,Voters,,Ballots Cast,,1077
+Floyd,GEORGETOWN - 4,Voters,,Straight Ticket,R,308
+Floyd,GEORGETOWN - 4,Voters,,Straight Ticket,D,115
+Floyd,GEORGETOWN - 4,Voters,,Straight Ticket,L,6
+Floyd,GEORGETOWN - 4,President,,Donald J. Trump,R,744
+Floyd,GEORGETOWN - 4,President,,Hillary Clinton,D,255
+Floyd,GEORGETOWN - 4,President,,Gary Johnson,L,56
+Floyd,GEORGETOWN - 4,President,,Write In,,11
+Floyd,GEORGETOWN - 4,U.S. Senate,,Todd Young,R,712
+Floyd,GEORGETOWN - 4,U.S. Senate,,Evan Bayh,D,309
+Floyd,GEORGETOWN - 4,U.S. Senate,,Lucy Brenton,L,45
+Floyd,GEORGETOWN - 4,U.S. Senate,,Write In,,0
+Floyd,GEORGETOWN - 4,Governor,,Eric Holcomb,R,727
+Floyd,GEORGETOWN - 4,Governor,,John R. Gregg,D,298
+Floyd,GEORGETOWN - 4,Governor,,Rex Bell,L,34
+Floyd,GEORGETOWN - 4,Governor,,Write In,,0
+Floyd,GEORGETOWN - 4,Attorney General,,"Curtis T. Hill, Jr.",R,772
+Floyd,GEORGETOWN - 4,Attorney General,,Lorenzo Arredondo,D,243
+Floyd,GEORGETOWN - 4,Superintendent of Public Instruction,,Jennifer Mccormick,R,700
+Floyd,GEORGETOWN - 4,Superintendent of Public Instruction,,Glenda Ritz,D,324
+Floyd,GEORGETOWN - 4,U.S. House,9,Trey Hollingsworth,R,680
+Floyd,GEORGETOWN - 4,U.S. House,9,Shelli Yoder,D,331
+Floyd,GEORGETOWN - 4,U.S. House,9,Russell Brooksbank,L,43
+Floyd,GEORGETOWN - 4,U.S. House,9,Write In,,0
+Floyd,GEORGETOWN - 4,State House,72,Edward D. (Ed) Clere,R,779
+Floyd,GEORGETOWN - 4,State House,72,Steve Bonifer,D,264
+Floyd,GEORGETOWN - 5,Voters,,Registered,,1490
+Floyd,GEORGETOWN - 5,Voters,,Ballots Cast,,1048
+Floyd,GEORGETOWN - 5,Voters,,Straight Ticket,R,289
+Floyd,GEORGETOWN - 5,Voters,,Straight Ticket,D,142
+Floyd,GEORGETOWN - 5,Voters,,Straight Ticket,L,11
+Floyd,GEORGETOWN - 5,President,,Donald J. Trump,R,641
+Floyd,GEORGETOWN - 5,President,,Hillary Clinton,D,324
+Floyd,GEORGETOWN - 5,President,,Gary Johnson,L,58
+Floyd,GEORGETOWN - 5,President,,Write In,,19
+Floyd,GEORGETOWN - 5,U.S. Senate,,Todd Young,R,631
+Floyd,GEORGETOWN - 5,U.S. Senate,,Evan Bayh,D,360
+Floyd,GEORGETOWN - 5,U.S. Senate,,Lucy Brenton,L,38
+Floyd,GEORGETOWN - 5,U.S. Senate,,Write In,,0
+Floyd,GEORGETOWN - 5,Governor,,Eric Holcomb,R,615
+Floyd,GEORGETOWN - 5,Governor,,John R. Gregg,D,370
+Floyd,GEORGETOWN - 5,Governor,,Rex Bell,L,27
+Floyd,GEORGETOWN - 5,Governor,,Write In,,0
+Floyd,GEORGETOWN - 5,Attorney General,,"Curtis T. Hill, Jr.",R,659
+Floyd,GEORGETOWN - 5,Attorney General,,Lorenzo Arredondo,D,326
+Floyd,GEORGETOWN - 5,Superintendent of Public Instruction,,Jennifer Mccormick,R,605
+Floyd,GEORGETOWN - 5,Superintendent of Public Instruction,,Glenda Ritz,D,393
+Floyd,GEORGETOWN - 5,U.S. House,9,Trey Hollingsworth,R,586
+Floyd,GEORGETOWN - 5,U.S. House,9,Shelli Yoder,D,383
+Floyd,GEORGETOWN - 5,U.S. House,9,Russell Brooksbank,L,49
+Floyd,GEORGETOWN - 5,U.S. House,9,Write In,,0
+Floyd,GEORGETOWN - 5,State House,72,Edward D. (Ed) Clere,R,680
+Floyd,GEORGETOWN - 5,State House,72,Steve Bonifer,D,326
+Floyd,GEORGETOWN - 6,Voters,,Registered,,1132
+Floyd,GEORGETOWN - 6,Voters,,Ballots Cast,,732
+Floyd,GEORGETOWN - 6,Voters,,Straight Ticket,R,199
+Floyd,GEORGETOWN - 6,Voters,,Straight Ticket,D,106
+Floyd,GEORGETOWN - 6,Voters,,Straight Ticket,L,12
+Floyd,GEORGETOWN - 6,President,,Donald J. Trump,R,460
+Floyd,GEORGETOWN - 6,President,,Hillary Clinton,D,210
+Floyd,GEORGETOWN - 6,President,,Gary Johnson,L,41
+Floyd,GEORGETOWN - 6,President,,Write In,,12
+Floyd,GEORGETOWN - 6,U.S. Senate,,Todd Young,R,435
+Floyd,GEORGETOWN - 6,U.S. Senate,,Evan Bayh,D,254
+Floyd,GEORGETOWN - 6,U.S. Senate,,Lucy Brenton,L,30
+Floyd,GEORGETOWN - 6,U.S. Senate,,Write In,,1
+Floyd,GEORGETOWN - 6,Governor,,Eric Holcomb,R,426
+Floyd,GEORGETOWN - 6,Governor,,John R. Gregg,D,256
+Floyd,GEORGETOWN - 6,Governor,,Rex Bell,L,25
+Floyd,GEORGETOWN - 6,Governor,,Write In,,0
+Floyd,GEORGETOWN - 6,Attorney General,,"Curtis T. Hill, Jr.",R,457
+Floyd,GEORGETOWN - 6,Attorney General,,Lorenzo Arredondo,D,227
+Floyd,GEORGETOWN - 6,Superintendent of Public Instruction,,Jennifer Mccormick,R,432
+Floyd,GEORGETOWN - 6,Superintendent of Public Instruction,,Glenda Ritz,D,255
+Floyd,GEORGETOWN - 6,U.S. House,9,Trey Hollingsworth,R,405
+Floyd,GEORGETOWN - 6,U.S. House,9,Shelli Yoder,D,261
+Floyd,GEORGETOWN - 6,U.S. House,9,Russell Brooksbank,L,40
+Floyd,GEORGETOWN - 6,U.S. House,9,Write In,,1
+Floyd,GEORGETOWN - 6,State House,70,Karen Engleman,R,440
+Floyd,GEORGETOWN - 6,State House,70,Heidi Cade Sellers,D,248
+Floyd,GEORGETOWN - 7,Voters,,Registered,,586
+Floyd,GEORGETOWN - 7,Voters,,Ballots Cast,,412
+Floyd,GEORGETOWN - 7,Voters,,Straight Ticket,R,127
+Floyd,GEORGETOWN - 7,Voters,,Straight Ticket,D,43
+Floyd,GEORGETOWN - 7,Voters,,Straight Ticket,L,4
+Floyd,GEORGETOWN - 7,President,,Donald J. Trump,R,287
+Floyd,GEORGETOWN - 7,President,,Hillary Clinton,D,103
+Floyd,GEORGETOWN - 7,President,,Gary Johnson,L,14
+Floyd,GEORGETOWN - 7,President,,Write In,,5
+Floyd,GEORGETOWN - 7,U.S. Senate,,Todd Young,R,270
+Floyd,GEORGETOWN - 7,U.S. Senate,,Evan Bayh,D,122
+Floyd,GEORGETOWN - 7,U.S. Senate,,Lucy Brenton,L,14
+Floyd,GEORGETOWN - 7,U.S. Senate,,Write In,,0
+Floyd,GEORGETOWN - 7,Governor,,Eric Holcomb,R,271
+Floyd,GEORGETOWN - 7,Governor,,John R. Gregg,D,125
+Floyd,GEORGETOWN - 7,Governor,,Rex Bell,L,2
+Floyd,GEORGETOWN - 7,Governor,,Write In,,0
+Floyd,GEORGETOWN - 7,Attorney General,,"Curtis T. Hill, Jr.",R,289
+Floyd,GEORGETOWN - 7,Attorney General,,Lorenzo Arredondo,D,100
+Floyd,GEORGETOWN - 7,Superintendent of Public Instruction,,Jennifer Mccormick,R,265
+Floyd,GEORGETOWN - 7,Superintendent of Public Instruction,,Glenda Ritz,D,128
+Floyd,GEORGETOWN - 7,U.S. House,9,Trey Hollingsworth,R,261
+Floyd,GEORGETOWN - 7,U.S. House,9,Shelli Yoder,D,126
+Floyd,GEORGETOWN - 7,U.S. House,9,Russell Brooksbank,L,12
+Floyd,GEORGETOWN - 7,U.S. House,9,Write In,,0
+Floyd,GEORGETOWN - 7,State House,72,Edward D. (Ed) Clere,R,276
+Floyd,GEORGETOWN - 7,State House,72,Steve Bonifer,D,118
+Floyd,GREENVILLE - 1,Voters,,Registered,,1216
+Floyd,GREENVILLE - 1,Voters,,Ballots Cast,,908
+Floyd,GREENVILLE - 1,Voters,,Straight Ticket,R,250
+Floyd,GREENVILLE - 1,Voters,,Straight Ticket,D,105
+Floyd,GREENVILLE - 1,Voters,,Straight Ticket,L,8
+Floyd,GREENVILLE - 1,President,,Donald J. Trump,R,613
+Floyd,GREENVILLE - 1,President,,Hillary Clinton,D,233
+Floyd,GREENVILLE - 1,President,,Gary Johnson,L,41
+Floyd,GREENVILLE - 1,President,,Write In,,11
+Floyd,GREENVILLE - 1,U.S. Senate,,Todd Young,R,577
+Floyd,GREENVILLE - 1,U.S. Senate,,Evan Bayh,D,293
+Floyd,GREENVILLE - 1,U.S. Senate,,Lucy Brenton,L,21
+Floyd,GREENVILLE - 1,U.S. Senate,,Write In,,0
+Floyd,GREENVILLE - 1,Governor,,Eric Holcomb,R,572
+Floyd,GREENVILLE - 1,Governor,,John R. Gregg,D,282
+Floyd,GREENVILLE - 1,Governor,,Rex Bell,L,19
+Floyd,GREENVILLE - 1,Governor,,Write In,,0
+Floyd,GREENVILLE - 1,Attorney General,,"Curtis T. Hill, Jr.",R,606
+Floyd,GREENVILLE - 1,Attorney General,,Lorenzo Arredondo,D,229
+Floyd,GREENVILLE - 1,Superintendent of Public Instruction,,Jennifer Mccormick,R,545
+Floyd,GREENVILLE - 1,Superintendent of Public Instruction,,Glenda Ritz,D,303
+Floyd,GREENVILLE - 1,U.S. House,9,Trey Hollingsworth,R,535
+Floyd,GREENVILLE - 1,U.S. House,9,Shelli Yoder,D,303
+Floyd,GREENVILLE - 1,U.S. House,9,Russell Brooksbank,L,41
+Floyd,GREENVILLE - 1,U.S. House,9,Write In,,2
+Floyd,GREENVILLE - 1,State House,70,Karen Engleman,R,562
+Floyd,GREENVILLE - 1,State House,70,Heidi Cade Sellers,D,292
+Floyd,GREENVILLE - 2,Voters,,Registered,,1011
+Floyd,GREENVILLE - 2,Voters,,Ballots Cast,,740
+Floyd,GREENVILLE - 2,Voters,,Straight Ticket,R,198
+Floyd,GREENVILLE - 2,Voters,,Straight Ticket,D,81
+Floyd,GREENVILLE - 2,Voters,,Straight Ticket,L,3
+Floyd,GREENVILLE - 2,President,,Donald J. Trump,R,466
+Floyd,GREENVILLE - 2,President,,Hillary Clinton,D,215
+Floyd,GREENVILLE - 2,President,,Gary Johnson,L,36
+Floyd,GREENVILLE - 2,President,,Write In,,15
+Floyd,GREENVILLE - 2,U.S. Senate,,Todd Young,R,468
+Floyd,GREENVILLE - 2,U.S. Senate,,Evan Bayh,D,244
+Floyd,GREENVILLE - 2,U.S. Senate,,Lucy Brenton,L,16
+Floyd,GREENVILLE - 2,U.S. Senate,,Write In,,0
+Floyd,GREENVILLE - 2,Governor,,Eric Holcomb,R,468
+Floyd,GREENVILLE - 2,Governor,,John R. Gregg,D,236
+Floyd,GREENVILLE - 2,Governor,,Rex Bell,L,11
+Floyd,GREENVILLE - 2,Governor,,Write In,,1
+Floyd,GREENVILLE - 2,Attorney General,,"Curtis T. Hill, Jr.",R,495
+Floyd,GREENVILLE - 2,Attorney General,,Lorenzo Arredondo,D,191
+Floyd,GREENVILLE - 2,Superintendent of Public Instruction,,Jennifer Mccormick,R,438
+Floyd,GREENVILLE - 2,Superintendent of Public Instruction,,Glenda Ritz,D,255
+Floyd,GREENVILLE - 2,U.S. House,9,Trey Hollingsworth,R,427
+Floyd,GREENVILLE - 2,U.S. House,9,Shelli Yoder,D,259
+Floyd,GREENVILLE - 2,U.S. House,9,Russell Brooksbank,L,33
+Floyd,GREENVILLE - 2,U.S. House,9,Write In,,0
+Floyd,GREENVILLE - 2,State House,70,Karen Engleman,R,463
+Floyd,GREENVILLE - 2,State House,70,Heidi Cade Sellers,D,240
+Floyd,GREENVILLE - 3,Voters,,Registered,,724
+Floyd,GREENVILLE - 3,Voters,,Ballots Cast,,535
+Floyd,GREENVILLE - 3,Voters,,Straight Ticket,R,158
+Floyd,GREENVILLE - 3,Voters,,Straight Ticket,D,48
+Floyd,GREENVILLE - 3,Voters,,Straight Ticket,L,5
+Floyd,GREENVILLE - 3,President,,Donald J. Trump,R,360
+Floyd,GREENVILLE - 3,President,,Hillary Clinton,D,141
+Floyd,GREENVILLE - 3,President,,Gary Johnson,L,21
+Floyd,GREENVILLE - 3,President,,Write In,,7
+Floyd,GREENVILLE - 3,U.S. Senate,,Todd Young,R,348
+Floyd,GREENVILLE - 3,U.S. Senate,,Evan Bayh,D,165
+Floyd,GREENVILLE - 3,U.S. Senate,,Lucy Brenton,L,20
+Floyd,GREENVILLE - 3,U.S. Senate,,Write In,,0
+Floyd,GREENVILLE - 3,Governor,,Eric Holcomb,R,345
+Floyd,GREENVILLE - 3,Governor,,John R. Gregg,D,156
+Floyd,GREENVILLE - 3,Governor,,Rex Bell,L,13
+Floyd,GREENVILLE - 3,Governor,,Write In,,0
+Floyd,GREENVILLE - 3,Attorney General,,"Curtis T. Hill, Jr.",R,358
+Floyd,GREENVILLE - 3,Attorney General,,Lorenzo Arredondo,D,126
+Floyd,GREENVILLE - 3,Superintendent of Public Instruction,,Jennifer Mccormick,R,324
+Floyd,GREENVILLE - 3,Superintendent of Public Instruction,,Glenda Ritz,D,167
+Floyd,GREENVILLE - 3,U.S. House,9,Trey Hollingsworth,R,329
+Floyd,GREENVILLE - 3,U.S. House,9,Shelli Yoder,D,163
+Floyd,GREENVILLE - 3,U.S. House,9,Russell Brooksbank,L,25
+Floyd,GREENVILLE - 3,U.S. House,9,Write In,,0
+Floyd,GREENVILLE - 3,State House,70,Karen Engleman,R,356
+Floyd,GREENVILLE - 3,State House,70,Heidi Cade Sellers,D,145
+Floyd,GREENVILLE - 4,Voters,,Registered,,1119
+Floyd,GREENVILLE - 4,Voters,,Ballots Cast,,831
+Floyd,GREENVILLE - 4,Voters,,Straight Ticket,R,209
+Floyd,GREENVILLE - 4,Voters,,Straight Ticket,D,99
+Floyd,GREENVILLE - 4,Voters,,Straight Ticket,L,4
+Floyd,GREENVILLE - 4,President,,Donald J. Trump,R,515
+Floyd,GREENVILLE - 4,President,,Hillary Clinton,D,251
+Floyd,GREENVILLE - 4,President,,Gary Johnson,L,43
+Floyd,GREENVILLE - 4,President,,Write In,,13
+Floyd,GREENVILLE - 4,U.S. Senate,,Todd Young,R,490
+Floyd,GREENVILLE - 4,U.S. Senate,,Evan Bayh,D,293
+Floyd,GREENVILLE - 4,U.S. Senate,,Lucy Brenton,L,38
+Floyd,GREENVILLE - 4,U.S. Senate,,Write In,,0
+Floyd,GREENVILLE - 4,Governor,,Eric Holcomb,R,498
+Floyd,GREENVILLE - 4,Governor,,John R. Gregg,D,294
+Floyd,GREENVILLE - 4,Governor,,Rex Bell,L,28
+Floyd,GREENVILLE - 4,Governor,,Write In,,0
+Floyd,GREENVILLE - 4,Attorney General,,"Curtis T. Hill, Jr.",R,545
+Floyd,GREENVILLE - 4,Attorney General,,Lorenzo Arredondo,D,243
+Floyd,GREENVILLE - 4,Superintendent of Public Instruction,,Jennifer Mccormick,R,505
+Floyd,GREENVILLE - 4,Superintendent of Public Instruction,,Glenda Ritz,D,294
+Floyd,GREENVILLE - 4,U.S. House,9,Trey Hollingsworth,R,467
+Floyd,GREENVILLE - 4,U.S. House,9,Shelli Yoder,D,304
+Floyd,GREENVILLE - 4,U.S. House,9,Russell Brooksbank,L,47
+Floyd,GREENVILLE - 4,U.S. House,9,Write In,,0
+Floyd,GREENVILLE - 4,State House,70,Karen Engleman,R,518
+Floyd,GREENVILLE - 4,State House,70,Heidi Cade Sellers,D,283
+Floyd,GREENVILLE - 5,Voters,,Registered,,1137
+Floyd,GREENVILLE - 5,Voters,,Ballots Cast,,760
+Floyd,GREENVILLE - 5,Voters,,Straight Ticket,R,207
+Floyd,GREENVILLE - 5,Voters,,Straight Ticket,D,90
+Floyd,GREENVILLE - 5,Voters,,Straight Ticket,L,6
+Floyd,GREENVILLE - 5,President,,Donald J. Trump,R,494
+Floyd,GREENVILLE - 5,President,,Hillary Clinton,D,207
+Floyd,GREENVILLE - 5,President,,Gary Johnson,L,39
+Floyd,GREENVILLE - 5,President,,Write In,,15
+Floyd,GREENVILLE - 5,U.S. Senate,,Todd Young,R,486
+Floyd,GREENVILLE - 5,U.S. Senate,,Evan Bayh,D,244
+Floyd,GREENVILLE - 5,U.S. Senate,,Lucy Brenton,L,23
+Floyd,GREENVILLE - 5,U.S. Senate,,Write In,,0
+Floyd,GREENVILLE - 5,Governor,,Eric Holcomb,R,473
+Floyd,GREENVILLE - 5,Governor,,John R. Gregg,D,235
+Floyd,GREENVILLE - 5,Governor,,Rex Bell,L,31
+Floyd,GREENVILLE - 5,Governor,,Write In,,0
+Floyd,GREENVILLE - 5,Attorney General,,"Curtis T. Hill, Jr.",R,503
+Floyd,GREENVILLE - 5,Attorney General,,Lorenzo Arredondo,D,206
+Floyd,GREENVILLE - 5,Superintendent of Public Instruction,,Jennifer Mccormick,R,462
+Floyd,GREENVILLE - 5,Superintendent of Public Instruction,,Glenda Ritz,D,260
+Floyd,GREENVILLE - 5,U.S. House,9,Trey Hollingsworth,R,458
+Floyd,GREENVILLE - 5,U.S. House,9,Shelli Yoder,D,250
+Floyd,GREENVILLE - 5,U.S. House,9,Russell Brooksbank,L,34
+Floyd,GREENVILLE - 5,U.S. House,9,Write In,,0
+Floyd,GREENVILLE - 5,State House,70,Karen Engleman,R,491
+Floyd,GREENVILLE - 5,State House,70,Heidi Cade Sellers,D,234
+Floyd,GREENVILLE - 6,Voters,,Registered,,491
+Floyd,GREENVILLE - 6,Voters,,Ballots Cast,,362
+Floyd,GREENVILLE - 6,Voters,,Straight Ticket,R,90
+Floyd,GREENVILLE - 6,Voters,,Straight Ticket,D,42
+Floyd,GREENVILLE - 6,Voters,,Straight Ticket,L,4
+Floyd,GREENVILLE - 6,President,,Donald J. Trump,R,242
+Floyd,GREENVILLE - 6,President,,Hillary Clinton,D,98
+Floyd,GREENVILLE - 6,President,,Gary Johnson,L,13
+Floyd,GREENVILLE - 6,President,,Write In,,4
+Floyd,GREENVILLE - 6,U.S. Senate,,Todd Young,R,227
+Floyd,GREENVILLE - 6,U.S. Senate,,Evan Bayh,D,116
+Floyd,GREENVILLE - 6,U.S. Senate,,Lucy Brenton,L,10
+Floyd,GREENVILLE - 6,U.S. Senate,,Write In,,0
+Floyd,GREENVILLE - 6,Governor,,Eric Holcomb,R,221
+Floyd,GREENVILLE - 6,Governor,,John R. Gregg,D,116
+Floyd,GREENVILLE - 6,Governor,,Rex Bell,L,10
+Floyd,GREENVILLE - 6,Governor,,Write In,,0
+Floyd,GREENVILLE - 6,Attorney General,,"Curtis T. Hill, Jr.",R,244
+Floyd,GREENVILLE - 6,Attorney General,,Lorenzo Arredondo,D,92
+Floyd,GREENVILLE - 6,Superintendent of Public Instruction,,Jennifer Mccormick,R,224
+Floyd,GREENVILLE - 6,Superintendent of Public Instruction,,Glenda Ritz,D,117
+Floyd,GREENVILLE - 6,U.S. House,9,Trey Hollingsworth,R,211
+Floyd,GREENVILLE - 6,U.S. House,9,Shelli Yoder,D,122
+Floyd,GREENVILLE - 6,U.S. House,9,Russell Brooksbank,L,15
+Floyd,GREENVILLE - 6,U.S. House,9,Write In,,0
+Floyd,GREENVILLE - 6,State House,70,Karen Engleman,R,229
+Floyd,GREENVILLE - 6,State House,70,Heidi Cade Sellers,D,114
+Floyd,LAFAYETTE - 1,Voters,,Registered,,1514
+Floyd,LAFAYETTE - 1,Voters,,Ballots Cast,,993
+Floyd,LAFAYETTE - 1,Voters,,Straight Ticket,R,254
+Floyd,LAFAYETTE - 1,Voters,,Straight Ticket,D,134
+Floyd,LAFAYETTE - 1,Voters,,Straight Ticket,L,11
+Floyd,LAFAYETTE - 1,President,,Donald J. Trump,R,632
+Floyd,LAFAYETTE - 1,President,,Hillary Clinton,D,291
+Floyd,LAFAYETTE - 1,President,,Gary Johnson,L,37
+Floyd,LAFAYETTE - 1,President,,Write In,,13
+Floyd,LAFAYETTE - 1,U.S. Senate,,Todd Young,R,649
+Floyd,LAFAYETTE - 1,U.S. Senate,,Evan Bayh,D,303
+Floyd,LAFAYETTE - 1,U.S. Senate,,Lucy Brenton,L,23
+Floyd,LAFAYETTE - 1,U.S. Senate,,Write In,,0
+Floyd,LAFAYETTE - 1,Governor,,Eric Holcomb,R,629
+Floyd,LAFAYETTE - 1,Governor,,John R. Gregg,D,308
+Floyd,LAFAYETTE - 1,Governor,,Rex Bell,L,20
+Floyd,LAFAYETTE - 1,Governor,,Write In,,0
+Floyd,LAFAYETTE - 1,Attorney General,,"Curtis T. Hill, Jr.",R,659
+Floyd,LAFAYETTE - 1,Attorney General,,Lorenzo Arredondo,D,269
+Floyd,LAFAYETTE - 1,Superintendent of Public Instruction,,Jennifer Mccormick,R,614
+Floyd,LAFAYETTE - 1,Superintendent of Public Instruction,,Glenda Ritz,D,315
+Floyd,LAFAYETTE - 1,U.S. House,9,Trey Hollingsworth,R,585
+Floyd,LAFAYETTE - 1,U.S. House,9,Shelli Yoder,D,341
+Floyd,LAFAYETTE - 1,U.S. House,9,Russell Brooksbank,L,33
+Floyd,LAFAYETTE - 1,U.S. House,9,Write In,,2
+Floyd,LAFAYETTE - 1,State House,72,Edward D. (Ed) Clere,R,652
+Floyd,LAFAYETTE - 1,State House,72,Steve Bonifer,D,309
+Floyd,LAFAYETTE - 2,Voters,,Registered,,746
+Floyd,LAFAYETTE - 2,Voters,,Ballots Cast,,530
+Floyd,LAFAYETTE - 2,Voters,,Straight Ticket,R,123
+Floyd,LAFAYETTE - 2,Voters,,Straight Ticket,D,77
+Floyd,LAFAYETTE - 2,Voters,,Straight Ticket,L,3
+Floyd,LAFAYETTE - 2,President,,Donald J. Trump,R,341
+Floyd,LAFAYETTE - 2,President,,Hillary Clinton,D,165
+Floyd,LAFAYETTE - 2,President,,Gary Johnson,L,13
+Floyd,LAFAYETTE - 2,President,,Write In,,3
+Floyd,LAFAYETTE - 2,U.S. Senate,,Todd Young,R,303
+Floyd,LAFAYETTE - 2,U.S. Senate,,Evan Bayh,D,202
+Floyd,LAFAYETTE - 2,U.S. Senate,,Lucy Brenton,L,14
+Floyd,LAFAYETTE - 2,U.S. Senate,,Write In,,0
+Floyd,LAFAYETTE - 2,Governor,,Eric Holcomb,R,300
+Floyd,LAFAYETTE - 2,Governor,,John R. Gregg,D,204
+Floyd,LAFAYETTE - 2,Governor,,Rex Bell,L,4
+Floyd,LAFAYETTE - 2,Governor,,Write In,,0
+Floyd,LAFAYETTE - 2,Attorney General,,"Curtis T. Hill, Jr.",R,330
+Floyd,LAFAYETTE - 2,Attorney General,,Lorenzo Arredondo,D,157
+Floyd,LAFAYETTE - 2,Superintendent of Public Instruction,,Jennifer Mccormick,R,295
+Floyd,LAFAYETTE - 2,Superintendent of Public Instruction,,Glenda Ritz,D,203
+Floyd,LAFAYETTE - 2,U.S. House,9,Trey Hollingsworth,R,280
+Floyd,LAFAYETTE - 2,U.S. House,9,Shelli Yoder,D,214
+Floyd,LAFAYETTE - 2,U.S. House,9,Russell Brooksbank,L,21
+Floyd,LAFAYETTE - 2,U.S. House,9,Write In,,0
+Floyd,LAFAYETTE - 2,State House,72,Edward D. (Ed) Clere,R,342
+Floyd,LAFAYETTE - 2,State House,72,Steve Bonifer,D,174
+Floyd,LAFAYETTE - 3,Voters,,Registered,,760
+Floyd,LAFAYETTE - 3,Voters,,Ballots Cast,,519
+Floyd,LAFAYETTE - 3,Voters,,Straight Ticket,R,120
+Floyd,LAFAYETTE - 3,Voters,,Straight Ticket,D,43
+Floyd,LAFAYETTE - 3,Voters,,Straight Ticket,L,5
+Floyd,LAFAYETTE - 3,President,,Donald J. Trump,R,332
+Floyd,LAFAYETTE - 3,President,,Hillary Clinton,D,149
+Floyd,LAFAYETTE - 3,President,,Gary Johnson,L,31
+Floyd,LAFAYETTE - 3,President,,Write In,,3
+Floyd,LAFAYETTE - 3,U.S. Senate,,Todd Young,R,324
+Floyd,LAFAYETTE - 3,U.S. Senate,,Evan Bayh,D,179
+Floyd,LAFAYETTE - 3,U.S. Senate,,Lucy Brenton,L,11
+Floyd,LAFAYETTE - 3,U.S. Senate,,Write In,,0
+Floyd,LAFAYETTE - 3,Governor,,Eric Holcomb,R,330
+Floyd,LAFAYETTE - 3,Governor,,John R. Gregg,D,163
+Floyd,LAFAYETTE - 3,Governor,,Rex Bell,L,13
+Floyd,LAFAYETTE - 3,Governor,,Write In,,0
+Floyd,LAFAYETTE - 3,Attorney General,,"Curtis T. Hill, Jr.",R,344
+Floyd,LAFAYETTE - 3,Attorney General,,Lorenzo Arredondo,D,141
+Floyd,LAFAYETTE - 3,Superintendent of Public Instruction,,Jennifer Mccormick,R,299
+Floyd,LAFAYETTE - 3,Superintendent of Public Instruction,,Glenda Ritz,D,191
+Floyd,LAFAYETTE - 3,U.S. House,9,Trey Hollingsworth,R,297
+Floyd,LAFAYETTE - 3,U.S. House,9,Shelli Yoder,D,182
+Floyd,LAFAYETTE - 3,U.S. House,9,Russell Brooksbank,L,21
+Floyd,LAFAYETTE - 3,U.S. House,9,Write In,,2
+Floyd,LAFAYETTE - 3,State House,72,Edward D. (Ed) Clere,R,352
+Floyd,LAFAYETTE - 3,State House,72,Steve Bonifer,D,155
+Floyd,LAFAYETTE - 4,Voters,,Registered,,1033
+Floyd,LAFAYETTE - 4,Voters,,Ballots Cast,,715
+Floyd,LAFAYETTE - 4,Voters,,Straight Ticket,R,177
+Floyd,LAFAYETTE - 4,Voters,,Straight Ticket,D,94
+Floyd,LAFAYETTE - 4,Voters,,Straight Ticket,L,6
+Floyd,LAFAYETTE - 4,President,,Donald J. Trump,R,440
+Floyd,LAFAYETTE - 4,President,,Hillary Clinton,D,208
+Floyd,LAFAYETTE - 4,President,,Gary Johnson,L,47
+Floyd,LAFAYETTE - 4,President,,Write In,,10
+Floyd,LAFAYETTE - 4,U.S. Senate,,Todd Young,R,428
+Floyd,LAFAYETTE - 4,U.S. Senate,,Evan Bayh,D,253
+Floyd,LAFAYETTE - 4,U.S. Senate,,Lucy Brenton,L,23
+Floyd,LAFAYETTE - 4,U.S. Senate,,Write In,,0
+Floyd,LAFAYETTE - 4,Governor,,Eric Holcomb,R,434
+Floyd,LAFAYETTE - 4,Governor,,John R. Gregg,D,227
+Floyd,LAFAYETTE - 4,Governor,,Rex Bell,L,23
+Floyd,LAFAYETTE - 4,Governor,,Write In,,0
+Floyd,LAFAYETTE - 4,Attorney General,,"Curtis T. Hill, Jr.",R,462
+Floyd,LAFAYETTE - 4,Attorney General,,Lorenzo Arredondo,D,202
+Floyd,LAFAYETTE - 4,Superintendent of Public Instruction,,Jennifer Mccormick,R,421
+Floyd,LAFAYETTE - 4,Superintendent of Public Instruction,,Glenda Ritz,D,251
+Floyd,LAFAYETTE - 4,U.S. House,9,Trey Hollingsworth,R,405
+Floyd,LAFAYETTE - 4,U.S. House,9,Shelli Yoder,D,253
+Floyd,LAFAYETTE - 4,U.S. House,9,Russell Brooksbank,L,39
+Floyd,LAFAYETTE - 4,U.S. House,9,Write In,,0
+Floyd,LAFAYETTE - 4,State House,72,Edward D. (Ed) Clere,R,474
+Floyd,LAFAYETTE - 4,State House,72,Steve Bonifer,D,219
+Floyd,LAFAYETTE - 5,Voters,,Registered,,1478
+Floyd,LAFAYETTE - 5,Voters,,Ballots Cast,,943
+Floyd,LAFAYETTE - 5,Voters,,Straight Ticket,R,231
+Floyd,LAFAYETTE - 5,Voters,,Straight Ticket,D,122
+Floyd,LAFAYETTE - 5,Voters,,Straight Ticket,L,5
+Floyd,LAFAYETTE - 5,President,,Donald J. Trump,R,558
+Floyd,LAFAYETTE - 5,President,,Hillary Clinton,D,328
+Floyd,LAFAYETTE - 5,President,,Gary Johnson,L,27
+Floyd,LAFAYETTE - 5,President,,Write In,,17
+Floyd,LAFAYETTE - 5,U.S. Senate,,Todd Young,R,561
+Floyd,LAFAYETTE - 5,U.S. Senate,,Evan Bayh,D,344
+Floyd,LAFAYETTE - 5,U.S. Senate,,Lucy Brenton,L,25
+Floyd,LAFAYETTE - 5,U.S. Senate,,Write In,,0
+Floyd,LAFAYETTE - 5,Governor,,Eric Holcomb,R,571
+Floyd,LAFAYETTE - 5,Governor,,John R. Gregg,D,341
+Floyd,LAFAYETTE - 5,Governor,,Rex Bell,L,11
+Floyd,LAFAYETTE - 5,Governor,,Write In,,0
+Floyd,LAFAYETTE - 5,Attorney General,,"Curtis T. Hill, Jr.",R,598
+Floyd,LAFAYETTE - 5,Attorney General,,Lorenzo Arredondo,D,290
+Floyd,LAFAYETTE - 5,Superintendent of Public Instruction,,Jennifer Mccormick,R,535
+Floyd,LAFAYETTE - 5,Superintendent of Public Instruction,,Glenda Ritz,D,365
+Floyd,LAFAYETTE - 5,U.S. House,9,Trey Hollingsworth,R,518
+Floyd,LAFAYETTE - 5,U.S. House,9,Shelli Yoder,D,371
+Floyd,LAFAYETTE - 5,U.S. House,9,Russell Brooksbank,L,33
+Floyd,LAFAYETTE - 5,U.S. House,9,Write In,,0
+Floyd,LAFAYETTE - 5,State House,72,Edward D. (Ed) Clere,R,583
+Floyd,LAFAYETTE - 5,State House,72,Steve Bonifer,D,328
+Floyd,LAFAYETTE - 6,Voters,,Registered,,854
+Floyd,LAFAYETTE - 6,Voters,,Ballots Cast,,613
+Floyd,LAFAYETTE - 6,Voters,,Straight Ticket,R,153
+Floyd,LAFAYETTE - 6,Voters,,Straight Ticket,D,71
+Floyd,LAFAYETTE - 6,Voters,,Straight Ticket,L,8
+Floyd,LAFAYETTE - 6,President,,Donald J. Trump,R,355
+Floyd,LAFAYETTE - 6,President,,Hillary Clinton,D,213
+Floyd,LAFAYETTE - 6,President,,Gary Johnson,L,28
+Floyd,LAFAYETTE - 6,President,,Write In,,6
+Floyd,LAFAYETTE - 6,U.S. Senate,,Todd Young,R,350
+Floyd,LAFAYETTE - 6,U.S. Senate,,Evan Bayh,D,236
+Floyd,LAFAYETTE - 6,U.S. Senate,,Lucy Brenton,L,18
+Floyd,LAFAYETTE - 6,U.S. Senate,,Write In,,1
+Floyd,LAFAYETTE - 6,Governor,,Eric Holcomb,R,368
+Floyd,LAFAYETTE - 6,Governor,,John R. Gregg,D,213
+Floyd,LAFAYETTE - 6,Governor,,Rex Bell,L,18
+Floyd,LAFAYETTE - 6,Governor,,Write In,,1
+Floyd,LAFAYETTE - 6,Attorney General,,"Curtis T. Hill, Jr.",R,390
+Floyd,LAFAYETTE - 6,Attorney General,,Lorenzo Arredondo,D,191
+Floyd,LAFAYETTE - 6,Superintendent of Public Instruction,,Jennifer Mccormick,R,371
+Floyd,LAFAYETTE - 6,Superintendent of Public Instruction,,Glenda Ritz,D,213
+Floyd,LAFAYETTE - 6,U.S. House,9,Trey Hollingsworth,R,332
+Floyd,LAFAYETTE - 6,U.S. House,9,Shelli Yoder,D,231
+Floyd,LAFAYETTE - 6,U.S. House,9,Russell Brooksbank,L,32
+Floyd,LAFAYETTE - 6,U.S. House,9,Write In,,1
+Floyd,LAFAYETTE - 6,State House,72,Edward D. (Ed) Clere,R,396
+Floyd,LAFAYETTE - 6,State House,72,Steve Bonifer,D,196
+Floyd,LAFAYETTE - 7,Voters,,Registered,,772
+Floyd,LAFAYETTE - 7,Voters,,Ballots Cast,,556
+Floyd,LAFAYETTE - 7,Voters,,Straight Ticket,R,118
+Floyd,LAFAYETTE - 7,Voters,,Straight Ticket,D,65
+Floyd,LAFAYETTE - 7,Voters,,Straight Ticket,L,1
+Floyd,LAFAYETTE - 7,President,,Donald J. Trump,R,363
+Floyd,LAFAYETTE - 7,President,,Hillary Clinton,D,157
+Floyd,LAFAYETTE - 7,President,,Gary Johnson,L,26
+Floyd,LAFAYETTE - 7,President,,Write In,,3
+Floyd,LAFAYETTE - 7,U.S. Senate,,Todd Young,R,337
+Floyd,LAFAYETTE - 7,U.S. Senate,,Evan Bayh,D,201
+Floyd,LAFAYETTE - 7,U.S. Senate,,Lucy Brenton,L,5
+Floyd,LAFAYETTE - 7,U.S. Senate,,Write In,,0
+Floyd,LAFAYETTE - 7,Governor,,Eric Holcomb,R,320
+Floyd,LAFAYETTE - 7,Governor,,John R. Gregg,D,197
+Floyd,LAFAYETTE - 7,Governor,,Rex Bell,L,6
+Floyd,LAFAYETTE - 7,Governor,,Write In,,1
+Floyd,LAFAYETTE - 7,Attorney General,,"Curtis T. Hill, Jr.",R,357
+Floyd,LAFAYETTE - 7,Attorney General,,Lorenzo Arredondo,D,151
+Floyd,LAFAYETTE - 7,Superintendent of Public Instruction,,Jennifer Mccormick,R,322
+Floyd,LAFAYETTE - 7,Superintendent of Public Instruction,,Glenda Ritz,D,189
+Floyd,LAFAYETTE - 7,U.S. House,9,Trey Hollingsworth,R,317
+Floyd,LAFAYETTE - 7,U.S. House,9,Shelli Yoder,D,199
+Floyd,LAFAYETTE - 7,U.S. House,9,Russell Brooksbank,L,18
+Floyd,LAFAYETTE - 7,U.S. House,9,Write In,,0
+Floyd,LAFAYETTE - 7,State House,72,Edward D. (Ed) Clere,R,356
+Floyd,LAFAYETTE - 7,State House,72,Steve Bonifer,D,178
+Floyd,NEW ALBANY - 01,Voters,,Registered,,1390
+Floyd,NEW ALBANY - 01,Voters,,Ballots Cast,,723
+Floyd,NEW ALBANY - 01,Voters,,Straight Ticket,R,145
+Floyd,NEW ALBANY - 01,Voters,,Straight Ticket,D,214
+Floyd,NEW ALBANY - 01,Voters,,Straight Ticket,L,6
+Floyd,NEW ALBANY - 01,President,,Donald J. Trump,R,336
+Floyd,NEW ALBANY - 01,President,,Hillary Clinton,D,332
+Floyd,NEW ALBANY - 01,President,,Gary Johnson,L,34
+Floyd,NEW ALBANY - 01,President,,Write In,,12
+Floyd,NEW ALBANY - 01,U.S. Senate,,Todd Young,R,302
+Floyd,NEW ALBANY - 01,U.S. Senate,,Evan Bayh,D,373
+Floyd,NEW ALBANY - 01,U.S. Senate,,Lucy Brenton,L,36
+Floyd,NEW ALBANY - 01,U.S. Senate,,Write In,,0
+Floyd,NEW ALBANY - 01,Governor,,Eric Holcomb,R,298
+Floyd,NEW ALBANY - 01,Governor,,John R. Gregg,D,366
+Floyd,NEW ALBANY - 01,Governor,,Rex Bell,L,27
+Floyd,NEW ALBANY - 01,Governor,,Write In,,0
+Floyd,NEW ALBANY - 01,Attorney General,,"Curtis T. Hill, Jr.",R,324
+Floyd,NEW ALBANY - 01,Attorney General,,Lorenzo Arredondo,D,350
+Floyd,NEW ALBANY - 01,Superintendent of Public Instruction,,Jennifer Mccormick,R,297
+Floyd,NEW ALBANY - 01,Superintendent of Public Instruction,,Glenda Ritz,D,372
+Floyd,NEW ALBANY - 01,U.S. House,9,Trey Hollingsworth,R,288
+Floyd,NEW ALBANY - 01,U.S. House,9,Shelli Yoder,D,378
+Floyd,NEW ALBANY - 01,U.S. House,9,Russell Brooksbank,L,40
+Floyd,NEW ALBANY - 01,U.S. House,9,Write In,,0
+Floyd,NEW ALBANY - 01,State House,72,Edward D. (Ed) Clere,R,300
+Floyd,NEW ALBANY - 01,State House,72,Steve Bonifer,D,393
+Floyd,NEW ALBANY - 03,Voters,,Registered,,1044
+Floyd,NEW ALBANY - 03,Voters,,Ballots Cast,,469
+Floyd,NEW ALBANY - 03,Voters,,Straight Ticket,R,76
+Floyd,NEW ALBANY - 03,Voters,,Straight Ticket,D,116
+Floyd,NEW ALBANY - 03,Voters,,Straight Ticket,L,11
+Floyd,NEW ALBANY - 03,President,,Donald J. Trump,R,176
+Floyd,NEW ALBANY - 03,President,,Hillary Clinton,D,234
+Floyd,NEW ALBANY - 03,President,,Gary Johnson,L,38
+Floyd,NEW ALBANY - 03,President,,Write In,,14
+Floyd,NEW ALBANY - 03,U.S. Senate,,Todd Young,R,163
+Floyd,NEW ALBANY - 03,U.S. Senate,,Evan Bayh,D,259
+Floyd,NEW ALBANY - 03,U.S. Senate,,Lucy Brenton,L,33
+Floyd,NEW ALBANY - 03,U.S. Senate,,Write In,,0
+Floyd,NEW ALBANY - 03,Governor,,Eric Holcomb,R,169
+Floyd,NEW ALBANY - 03,Governor,,John R. Gregg,D,252
+Floyd,NEW ALBANY - 03,Governor,,Rex Bell,L,28
+Floyd,NEW ALBANY - 03,Governor,,Write In,,0
+Floyd,NEW ALBANY - 03,Attorney General,,"Curtis T. Hill, Jr.",R,189
+Floyd,NEW ALBANY - 03,Attorney General,,Lorenzo Arredondo,D,242
+Floyd,NEW ALBANY - 03,Superintendent of Public Instruction,,Jennifer Mccormick,R,184
+Floyd,NEW ALBANY - 03,Superintendent of Public Instruction,,Glenda Ritz,D,244
+Floyd,NEW ALBANY - 03,U.S. House,9,Trey Hollingsworth,R,160
+Floyd,NEW ALBANY - 03,U.S. House,9,Shelli Yoder,D,265
+Floyd,NEW ALBANY - 03,U.S. House,9,Russell Brooksbank,L,27
+Floyd,NEW ALBANY - 03,U.S. House,9,Write In,,0
+Floyd,NEW ALBANY - 03,State House,72,Edward D. (Ed) Clere,R,192
+Floyd,NEW ALBANY - 03,State House,72,Steve Bonifer,D,254
+Floyd,NEW ALBANY - 05,Voters,,Registered,,1260
+Floyd,NEW ALBANY - 05,Voters,,Ballots Cast,,580
+Floyd,NEW ALBANY - 05,Voters,,Straight Ticket,R,87
+Floyd,NEW ALBANY - 05,Voters,,Straight Ticket,D,168
+Floyd,NEW ALBANY - 05,Voters,,Straight Ticket,L,7
+Floyd,NEW ALBANY - 05,President,,Donald J. Trump,R,193
+Floyd,NEW ALBANY - 05,President,,Hillary Clinton,D,319
+Floyd,NEW ALBANY - 05,President,,Gary Johnson,L,39
+Floyd,NEW ALBANY - 05,President,,Write In,,17
+Floyd,NEW ALBANY - 05,U.S. Senate,,Todd Young,R,204
+Floyd,NEW ALBANY - 05,U.S. Senate,,Evan Bayh,D,335
+Floyd,NEW ALBANY - 05,U.S. Senate,,Lucy Brenton,L,36
+Floyd,NEW ALBANY - 05,U.S. Senate,,Write In,,0
+Floyd,NEW ALBANY - 05,Governor,,Eric Holcomb,R,197
+Floyd,NEW ALBANY - 05,Governor,,John R. Gregg,D,347
+Floyd,NEW ALBANY - 05,Governor,,Rex Bell,L,23
+Floyd,NEW ALBANY - 05,Governor,,Write In,,0
+Floyd,NEW ALBANY - 05,Attorney General,,"Curtis T. Hill, Jr.",R,223
+Floyd,NEW ALBANY - 05,Attorney General,,Lorenzo Arredondo,D,321
+Floyd,NEW ALBANY - 05,Superintendent of Public Instruction,,Jennifer Mccormick,R,215
+Floyd,NEW ALBANY - 05,Superintendent of Public Instruction,,Glenda Ritz,D,341
+Floyd,NEW ALBANY - 05,U.S. House,9,Trey Hollingsworth,R,188
+Floyd,NEW ALBANY - 05,U.S. House,9,Shelli Yoder,D,342
+Floyd,NEW ALBANY - 05,U.S. House,9,Russell Brooksbank,L,41
+Floyd,NEW ALBANY - 05,U.S. House,9,Write In,,0
+Floyd,NEW ALBANY - 05,State House,72,Edward D. (Ed) Clere,R,228
+Floyd,NEW ALBANY - 05,State House,72,Steve Bonifer,D,337
+Floyd,NEW ALBANY - 07,Voters,,Registered,,928
+Floyd,NEW ALBANY - 07,Voters,,Ballots Cast,,397
+Floyd,NEW ALBANY - 07,Voters,,Straight Ticket,R,70
+Floyd,NEW ALBANY - 07,Voters,,Straight Ticket,D,119
+Floyd,NEW ALBANY - 07,Voters,,Straight Ticket,L,5
+Floyd,NEW ALBANY - 07,President,,Donald J. Trump,R,154
+Floyd,NEW ALBANY - 07,President,,Hillary Clinton,D,206
+Floyd,NEW ALBANY - 07,President,,Gary Johnson,L,29
+Floyd,NEW ALBANY - 07,President,,Write In,,7
+Floyd,NEW ALBANY - 07,U.S. Senate,,Todd Young,R,142
+Floyd,NEW ALBANY - 07,U.S. Senate,,Evan Bayh,D,218
+Floyd,NEW ALBANY - 07,U.S. Senate,,Lucy Brenton,L,31
+Floyd,NEW ALBANY - 07,U.S. Senate,,Write In,,0
+Floyd,NEW ALBANY - 07,Governor,,Eric Holcomb,R,133
+Floyd,NEW ALBANY - 07,Governor,,John R. Gregg,D,228
+Floyd,NEW ALBANY - 07,Governor,,Rex Bell,L,25
+Floyd,NEW ALBANY - 07,Governor,,Write In,,0
+Floyd,NEW ALBANY - 07,Attorney General,,"Curtis T. Hill, Jr.",R,164
+Floyd,NEW ALBANY - 07,Attorney General,,Lorenzo Arredondo,D,216
+Floyd,NEW ALBANY - 07,Superintendent of Public Instruction,,Jennifer Mccormick,R,158
+Floyd,NEW ALBANY - 07,Superintendent of Public Instruction,,Glenda Ritz,D,222
+Floyd,NEW ALBANY - 07,U.S. House,9,Trey Hollingsworth,R,130
+Floyd,NEW ALBANY - 07,U.S. House,9,Shelli Yoder,D,221
+Floyd,NEW ALBANY - 07,U.S. House,9,Russell Brooksbank,L,38
+Floyd,NEW ALBANY - 07,U.S. House,9,Write In,,0
+Floyd,NEW ALBANY - 07,State House,72,Edward D. (Ed) Clere,R,145
+Floyd,NEW ALBANY - 07,State House,72,Steve Bonifer,D,238
+Floyd,NEW ALBANY - 09,Voters,,Registered,,959
+Floyd,NEW ALBANY - 09,Voters,,Ballots Cast,,661
+Floyd,NEW ALBANY - 09,Voters,,Straight Ticket,R,136
+Floyd,NEW ALBANY - 09,Voters,,Straight Ticket,D,123
+Floyd,NEW ALBANY - 09,Voters,,Straight Ticket,L,3
+Floyd,NEW ALBANY - 09,President,,Donald J. Trump,R,315
+Floyd,NEW ALBANY - 09,President,,Hillary Clinton,D,292
+Floyd,NEW ALBANY - 09,President,,Gary Johnson,L,41
+Floyd,NEW ALBANY - 09,President,,Write In,,8
+Floyd,NEW ALBANY - 09,U.S. Senate,,Todd Young,R,314
+Floyd,NEW ALBANY - 09,U.S. Senate,,Evan Bayh,D,308
+Floyd,NEW ALBANY - 09,U.S. Senate,,Lucy Brenton,L,31
+Floyd,NEW ALBANY - 09,U.S. Senate,,Write In,,1
+Floyd,NEW ALBANY - 09,Governor,,Eric Holcomb,R,315
+Floyd,NEW ALBANY - 09,Governor,,John R. Gregg,D,303
+Floyd,NEW ALBANY - 09,Governor,,Rex Bell,L,25
+Floyd,NEW ALBANY - 09,Governor,,Write In,,0
+Floyd,NEW ALBANY - 09,Attorney General,,"Curtis T. Hill, Jr.",R,332
+Floyd,NEW ALBANY - 09,Attorney General,,Lorenzo Arredondo,D,292
+Floyd,NEW ALBANY - 09,Superintendent of Public Instruction,,Jennifer Mccormick,R,300
+Floyd,NEW ALBANY - 09,Superintendent of Public Instruction,,Glenda Ritz,D,331
+Floyd,NEW ALBANY - 09,U.S. House,9,Trey Hollingsworth,R,272
+Floyd,NEW ALBANY - 09,U.S. House,9,Shelli Yoder,D,331
+Floyd,NEW ALBANY - 09,U.S. House,9,Russell Brooksbank,L,41
+Floyd,NEW ALBANY - 09,U.S. House,9,Write In,,0
+Floyd,NEW ALBANY - 09,State House,72,Edward D. (Ed) Clere,R,319
+Floyd,NEW ALBANY - 09,State House,72,Steve Bonifer,D,327
+Floyd,NEW ALBANY - 10,Voters,,Registered,,1170
+Floyd,NEW ALBANY - 10,Voters,,Ballots Cast,,594
+Floyd,NEW ALBANY - 10,Voters,,Straight Ticket,R,121
+Floyd,NEW ALBANY - 10,Voters,,Straight Ticket,D,147
+Floyd,NEW ALBANY - 10,Voters,,Straight Ticket,L,9
+Floyd,NEW ALBANY - 10,President,,Donald J. Trump,R,268
+Floyd,NEW ALBANY - 10,President,,Hillary Clinton,D,261
+Floyd,NEW ALBANY - 10,President,,Gary Johnson,L,48
+Floyd,NEW ALBANY - 10,President,,Write In,,11
+Floyd,NEW ALBANY - 10,U.S. Senate,,Todd Young,R,265
+Floyd,NEW ALBANY - 10,U.S. Senate,,Evan Bayh,D,285
+Floyd,NEW ALBANY - 10,U.S. Senate,,Lucy Brenton,L,33
+Floyd,NEW ALBANY - 10,U.S. Senate,,Write In,,0
+Floyd,NEW ALBANY - 10,Governor,,Eric Holcomb,R,260
+Floyd,NEW ALBANY - 10,Governor,,John R. Gregg,D,287
+Floyd,NEW ALBANY - 10,Governor,,Rex Bell,L,29
+Floyd,NEW ALBANY - 10,Governor,,Write In,,0
+Floyd,NEW ALBANY - 10,Attorney General,,"Curtis T. Hill, Jr.",R,285
+Floyd,NEW ALBANY - 10,Attorney General,,Lorenzo Arredondo,D,278
+Floyd,NEW ALBANY - 10,Superintendent of Public Instruction,,Jennifer Mccormick,R,268
+Floyd,NEW ALBANY - 10,Superintendent of Public Instruction,,Glenda Ritz,D,296
+Floyd,NEW ALBANY - 10,U.S. House,9,Trey Hollingsworth,R,252
+Floyd,NEW ALBANY - 10,U.S. House,9,Shelli Yoder,D,280
+Floyd,NEW ALBANY - 10,U.S. House,9,Russell Brooksbank,L,49
+Floyd,NEW ALBANY - 10,U.S. House,9,Write In,,0
+Floyd,NEW ALBANY - 10,State House,72,Edward D. (Ed) Clere,R,276
+Floyd,NEW ALBANY - 10,State House,72,Steve Bonifer,D,296
+Floyd,NEW ALBANY - 11,Voters,,Registered,,1395
+Floyd,NEW ALBANY - 11,Voters,,Ballots Cast,,710
+Floyd,NEW ALBANY - 11,Voters,,Straight Ticket,R,106
+Floyd,NEW ALBANY - 11,Voters,,Straight Ticket,D,198
+Floyd,NEW ALBANY - 11,Voters,,Straight Ticket,L,17
+Floyd,NEW ALBANY - 11,President,,Donald J. Trump,R,241
+Floyd,NEW ALBANY - 11,President,,Hillary Clinton,D,391
+Floyd,NEW ALBANY - 11,President,,Gary Johnson,L,49
+Floyd,NEW ALBANY - 11,President,,Write In,,20
+Floyd,NEW ALBANY - 11,U.S. Senate,,Todd Young,R,241
+Floyd,NEW ALBANY - 11,U.S. Senate,,Evan Bayh,D,411
+Floyd,NEW ALBANY - 11,U.S. Senate,,Lucy Brenton,L,44
+Floyd,NEW ALBANY - 11,U.S. Senate,,Write In,,0
+Floyd,NEW ALBANY - 11,Governor,,Eric Holcomb,R,252
+Floyd,NEW ALBANY - 11,Governor,,John R. Gregg,D,405
+Floyd,NEW ALBANY - 11,Governor,,Rex Bell,L,36
+Floyd,NEW ALBANY - 11,Governor,,Write In,,0
+Floyd,NEW ALBANY - 11,Attorney General,,"Curtis T. Hill, Jr.",R,281
+Floyd,NEW ALBANY - 11,Attorney General,,Lorenzo Arredondo,D,395
+Floyd,NEW ALBANY - 11,Superintendent of Public Instruction,,Jennifer Mccormick,R,256
+Floyd,NEW ALBANY - 11,Superintendent of Public Instruction,,Glenda Ritz,D,421
+Floyd,NEW ALBANY - 11,U.S. House,9,Trey Hollingsworth,R,226
+Floyd,NEW ALBANY - 11,U.S. House,9,Shelli Yoder,D,424
+Floyd,NEW ALBANY - 11,U.S. House,9,Russell Brooksbank,L,44
+Floyd,NEW ALBANY - 11,U.S. House,9,Write In,,0
+Floyd,NEW ALBANY - 11,State House,72,Edward D. (Ed) Clere,R,276
+Floyd,NEW ALBANY - 11,State House,72,Steve Bonifer,D,418
+Floyd,NEW ALBANY - 13,Voters,,Registered,,638
+Floyd,NEW ALBANY - 13,Voters,,Ballots Cast,,374
+Floyd,NEW ALBANY - 13,Voters,,Straight Ticket,R,81
+Floyd,NEW ALBANY - 13,Voters,,Straight Ticket,D,66
+Floyd,NEW ALBANY - 13,Voters,,Straight Ticket,L,3
+Floyd,NEW ALBANY - 13,President,,Donald J. Trump,R,186
+Floyd,NEW ALBANY - 13,President,,Hillary Clinton,D,155
+Floyd,NEW ALBANY - 13,President,,Gary Johnson,L,21
+Floyd,NEW ALBANY - 13,President,,Write In,,6
+Floyd,NEW ALBANY - 13,U.S. Senate,,Todd Young,R,175
+Floyd,NEW ALBANY - 13,U.S. Senate,,Evan Bayh,D,169
+Floyd,NEW ALBANY - 13,U.S. Senate,,Lucy Brenton,L,17
+Floyd,NEW ALBANY - 13,U.S. Senate,,Write In,,0
+Floyd,NEW ALBANY - 13,Governor,,Eric Holcomb,R,167
+Floyd,NEW ALBANY - 13,Governor,,John R. Gregg,D,176
+Floyd,NEW ALBANY - 13,Governor,,Rex Bell,L,17
+Floyd,NEW ALBANY - 13,Governor,,Write In,,0
+Floyd,NEW ALBANY - 13,Attorney General,,"Curtis T. Hill, Jr.",R,198
+Floyd,NEW ALBANY - 13,Attorney General,,Lorenzo Arredondo,D,152
+Floyd,NEW ALBANY - 13,Superintendent of Public Instruction,,Jennifer Mccormick,R,189
+Floyd,NEW ALBANY - 13,Superintendent of Public Instruction,,Glenda Ritz,D,162
+Floyd,NEW ALBANY - 13,U.S. House,9,Trey Hollingsworth,R,163
+Floyd,NEW ALBANY - 13,U.S. House,9,Shelli Yoder,D,175
+Floyd,NEW ALBANY - 13,U.S. House,9,Russell Brooksbank,L,22
+Floyd,NEW ALBANY - 13,U.S. House,9,Write In,,0
+Floyd,NEW ALBANY - 13,State House,72,Edward D. (Ed) Clere,R,187
+Floyd,NEW ALBANY - 13,State House,72,Steve Bonifer,D,176
+Floyd,NEW ALBANY - 14,Voters,,Registered,,1003
+Floyd,NEW ALBANY - 14,Voters,,Ballots Cast,,635
+Floyd,NEW ALBANY - 14,Voters,,Straight Ticket,R,118
+Floyd,NEW ALBANY - 14,Voters,,Straight Ticket,D,142
+Floyd,NEW ALBANY - 14,Voters,,Straight Ticket,L,7
+Floyd,NEW ALBANY - 14,President,,Donald J. Trump,R,271
+Floyd,NEW ALBANY - 14,President,,Hillary Clinton,D,312
+Floyd,NEW ALBANY - 14,President,,Gary Johnson,L,36
+Floyd,NEW ALBANY - 14,President,,Write In,,12
+Floyd,NEW ALBANY - 14,U.S. Senate,,Todd Young,R,272
+Floyd,NEW ALBANY - 14,U.S. Senate,,Evan Bayh,D,320
+Floyd,NEW ALBANY - 14,U.S. Senate,,Lucy Brenton,L,28
+Floyd,NEW ALBANY - 14,U.S. Senate,,Write In,,0
+Floyd,NEW ALBANY - 14,Governor,,Eric Holcomb,R,254
+Floyd,NEW ALBANY - 14,Governor,,John R. Gregg,D,337
+Floyd,NEW ALBANY - 14,Governor,,Rex Bell,L,22
+Floyd,NEW ALBANY - 14,Governor,,Write In,,0
+Floyd,NEW ALBANY - 14,Attorney General,,"Curtis T. Hill, Jr.",R,280
+Floyd,NEW ALBANY - 14,Attorney General,,Lorenzo Arredondo,D,311
+Floyd,NEW ALBANY - 14,Superintendent of Public Instruction,,Jennifer Mccormick,R,262
+Floyd,NEW ALBANY - 14,Superintendent of Public Instruction,,Glenda Ritz,D,335
+Floyd,NEW ALBANY - 14,U.S. House,9,Trey Hollingsworth,R,254
+Floyd,NEW ALBANY - 14,U.S. House,9,Shelli Yoder,D,329
+Floyd,NEW ALBANY - 14,U.S. House,9,Russell Brooksbank,L,31
+Floyd,NEW ALBANY - 14,U.S. House,9,Write In,,0
+Floyd,NEW ALBANY - 14,State House,72,Edward D. (Ed) Clere,R,286
+Floyd,NEW ALBANY - 14,State House,72,Steve Bonifer,D,329
+Floyd,NEW ALBANY - 16,Voters,,Registered,,790
+Floyd,NEW ALBANY - 16,Voters,,Ballots Cast,,533
+Floyd,NEW ALBANY - 16,Voters,,Straight Ticket,R,98
+Floyd,NEW ALBANY - 16,Voters,,Straight Ticket,D,129
+Floyd,NEW ALBANY - 16,Voters,,Straight Ticket,L,1
+Floyd,NEW ALBANY - 16,President,,Donald J. Trump,R,252
+Floyd,NEW ALBANY - 16,President,,Hillary Clinton,D,239
+Floyd,NEW ALBANY - 16,President,,Gary Johnson,L,26
+Floyd,NEW ALBANY - 16,President,,Write In,,10
+Floyd,NEW ALBANY - 16,U.S. Senate,,Todd Young,R,235
+Floyd,NEW ALBANY - 16,U.S. Senate,,Evan Bayh,D,270
+Floyd,NEW ALBANY - 16,U.S. Senate,,Lucy Brenton,L,16
+Floyd,NEW ALBANY - 16,U.S. Senate,,Write In,,0
+Floyd,NEW ALBANY - 16,Governor,,Eric Holcomb,R,253
+Floyd,NEW ALBANY - 16,Governor,,John R. Gregg,D,251
+Floyd,NEW ALBANY - 16,Governor,,Rex Bell,L,11
+Floyd,NEW ALBANY - 16,Governor,,Write In,,0
+Floyd,NEW ALBANY - 16,Attorney General,,"Curtis T. Hill, Jr.",R,254
+Floyd,NEW ALBANY - 16,Attorney General,,Lorenzo Arredondo,D,237
+Floyd,NEW ALBANY - 16,Superintendent of Public Instruction,,Jennifer Mccormick,R,238
+Floyd,NEW ALBANY - 16,Superintendent of Public Instruction,,Glenda Ritz,D,260
+Floyd,NEW ALBANY - 16,U.S. House,9,Trey Hollingsworth,R,231
+Floyd,NEW ALBANY - 16,U.S. House,9,Shelli Yoder,D,263
+Floyd,NEW ALBANY - 16,U.S. House,9,Russell Brooksbank,L,22
+Floyd,NEW ALBANY - 16,U.S. House,9,Write In,,0
+Floyd,NEW ALBANY - 16,State House,72,Edward D. (Ed) Clere,R,252
+Floyd,NEW ALBANY - 16,State House,72,Steve Bonifer,D,256
+Floyd,NEW ALBANY - 18,Voters,,Registered,,813
+Floyd,NEW ALBANY - 18,Voters,,Ballots Cast,,568
+Floyd,NEW ALBANY - 18,Voters,,Straight Ticket,R,80
+Floyd,NEW ALBANY - 18,Voters,,Straight Ticket,D,96
+Floyd,NEW ALBANY - 18,Voters,,Straight Ticket,L,4
+Floyd,NEW ALBANY - 18,President,,Donald J. Trump,R,251
+Floyd,NEW ALBANY - 18,President,,Hillary Clinton,D,265
+Floyd,NEW ALBANY - 18,President,,Gary Johnson,L,28
+Floyd,NEW ALBANY - 18,President,,Write In,,11
+Floyd,NEW ALBANY - 18,U.S. Senate,,Todd Young,R,245
+Floyd,NEW ALBANY - 18,U.S. Senate,,Evan Bayh,D,295
+Floyd,NEW ALBANY - 18,U.S. Senate,,Lucy Brenton,L,17
+Floyd,NEW ALBANY - 18,U.S. Senate,,Write In,,0
+Floyd,NEW ALBANY - 18,Governor,,Eric Holcomb,R,253
+Floyd,NEW ALBANY - 18,Governor,,John R. Gregg,D,282
+Floyd,NEW ALBANY - 18,Governor,,Rex Bell,L,14
+Floyd,NEW ALBANY - 18,Governor,,Write In,,0
+Floyd,NEW ALBANY - 18,Attorney General,,"Curtis T. Hill, Jr.",R,260
+Floyd,NEW ALBANY - 18,Attorney General,,Lorenzo Arredondo,D,267
+Floyd,NEW ALBANY - 18,Superintendent of Public Instruction,,Jennifer Mccormick,R,252
+Floyd,NEW ALBANY - 18,Superintendent of Public Instruction,,Glenda Ritz,D,277
+Floyd,NEW ALBANY - 18,U.S. House,9,Trey Hollingsworth,R,226
+Floyd,NEW ALBANY - 18,U.S. House,9,Shelli Yoder,D,303
+Floyd,NEW ALBANY - 18,U.S. House,9,Russell Brooksbank,L,27
+Floyd,NEW ALBANY - 18,U.S. House,9,Write In,,0
+Floyd,NEW ALBANY - 18,State House,72,Edward D. (Ed) Clere,R,295
+Floyd,NEW ALBANY - 18,State House,72,Steve Bonifer,D,255
+Floyd,NEW ALBANY - 19,Voters,,Registered,,886
+Floyd,NEW ALBANY - 19,Voters,,Ballots Cast,,532
+Floyd,NEW ALBANY - 19,Voters,,Straight Ticket,R,113
+Floyd,NEW ALBANY - 19,Voters,,Straight Ticket,D,117
+Floyd,NEW ALBANY - 19,Voters,,Straight Ticket,L,6
+Floyd,NEW ALBANY - 19,President,,Donald J. Trump,R,254
+Floyd,NEW ALBANY - 19,President,,Hillary Clinton,D,229
+Floyd,NEW ALBANY - 19,President,,Gary Johnson,L,33
+Floyd,NEW ALBANY - 19,President,,Write In,,10
+Floyd,NEW ALBANY - 19,U.S. Senate,,Todd Young,R,236
+Floyd,NEW ALBANY - 19,U.S. Senate,,Evan Bayh,D,251
+Floyd,NEW ALBANY - 19,U.S. Senate,,Lucy Brenton,L,30
+Floyd,NEW ALBANY - 19,U.S. Senate,,Write In,,2
+Floyd,NEW ALBANY - 19,Governor,,Eric Holcomb,R,231
+Floyd,NEW ALBANY - 19,Governor,,John R. Gregg,D,260
+Floyd,NEW ALBANY - 19,Governor,,Rex Bell,L,18
+Floyd,NEW ALBANY - 19,Governor,,Write In,,1
+Floyd,NEW ALBANY - 19,Attorney General,,"Curtis T. Hill, Jr.",R,264
+Floyd,NEW ALBANY - 19,Attorney General,,Lorenzo Arredondo,D,238
+Floyd,NEW ALBANY - 19,Superintendent of Public Instruction,,Jennifer Mccormick,R,244
+Floyd,NEW ALBANY - 19,Superintendent of Public Instruction,,Glenda Ritz,D,257
+Floyd,NEW ALBANY - 19,U.S. House,9,Trey Hollingsworth,R,234
+Floyd,NEW ALBANY - 19,U.S. House,9,Shelli Yoder,D,260
+Floyd,NEW ALBANY - 19,U.S. House,9,Russell Brooksbank,L,20
+Floyd,NEW ALBANY - 19,U.S. House,9,Write In,,1
+Floyd,NEW ALBANY - 19,State House,72,Edward D. (Ed) Clere,R,252
+Floyd,NEW ALBANY - 19,State House,72,Steve Bonifer,D,261
+Floyd,NEW ALBANY - 20,Voters,,Registered,,1119
+Floyd,NEW ALBANY - 20,Voters,,Ballots Cast,,728
+Floyd,NEW ALBANY - 20,Voters,,Straight Ticket,R,169
+Floyd,NEW ALBANY - 20,Voters,,Straight Ticket,D,130
+Floyd,NEW ALBANY - 20,Voters,,Straight Ticket,L,6
+Floyd,NEW ALBANY - 20,President,,Donald J. Trump,R,408
+Floyd,NEW ALBANY - 20,President,,Hillary Clinton,D,276
+Floyd,NEW ALBANY - 20,President,,Gary Johnson,L,33
+Floyd,NEW ALBANY - 20,President,,Write In,,1
+Floyd,NEW ALBANY - 20,U.S. Senate,,Todd Young,R,374
+Floyd,NEW ALBANY - 20,U.S. Senate,,Evan Bayh,D,317
+Floyd,NEW ALBANY - 20,U.S. Senate,,Lucy Brenton,L,21
+Floyd,NEW ALBANY - 20,U.S. Senate,,Write In,,0
+Floyd,NEW ALBANY - 20,Governor,,Eric Holcomb,R,389
+Floyd,NEW ALBANY - 20,Governor,,John R. Gregg,D,285
+Floyd,NEW ALBANY - 20,Governor,,Rex Bell,L,19
+Floyd,NEW ALBANY - 20,Governor,,Write In,,0
+Floyd,NEW ALBANY - 20,Attorney General,,"Curtis T. Hill, Jr.",R,416
+Floyd,NEW ALBANY - 20,Attorney General,,Lorenzo Arredondo,D,252
+Floyd,NEW ALBANY - 20,Superintendent of Public Instruction,,Jennifer Mccormick,R,386
+Floyd,NEW ALBANY - 20,Superintendent of Public Instruction,,Glenda Ritz,D,296
+Floyd,NEW ALBANY - 20,U.S. House,9,Trey Hollingsworth,R,352
+Floyd,NEW ALBANY - 20,U.S. House,9,Shelli Yoder,D,325
+Floyd,NEW ALBANY - 20,U.S. House,9,Russell Brooksbank,L,29
+Floyd,NEW ALBANY - 20,U.S. House,9,Write In,,0
+Floyd,NEW ALBANY - 20,State House,72,Edward D. (Ed) Clere,R,388
+Floyd,NEW ALBANY - 20,State House,72,Steve Bonifer,D,311
+Floyd,NEW ALBANY - 21,Voters,,Registered,,1151
+Floyd,NEW ALBANY - 21,Voters,,Ballots Cast,,441
+Floyd,NEW ALBANY - 21,Voters,,Straight Ticket,R,86
+Floyd,NEW ALBANY - 21,Voters,,Straight Ticket,D,196
+Floyd,NEW ALBANY - 21,Voters,,Straight Ticket,L,6
+Floyd,NEW ALBANY - 21,President,,Donald J. Trump,R,142
+Floyd,NEW ALBANY - 21,President,,Hillary Clinton,D,265
+Floyd,NEW ALBANY - 21,President,,Gary Johnson,L,20
+Floyd,NEW ALBANY - 21,President,,Write In,,13
+Floyd,NEW ALBANY - 21,U.S. Senate,,Todd Young,R,142
+Floyd,NEW ALBANY - 21,U.S. Senate,,Evan Bayh,D,277
+Floyd,NEW ALBANY - 21,U.S. Senate,,Lucy Brenton,L,16
+Floyd,NEW ALBANY - 21,U.S. Senate,,Write In,,1
+Floyd,NEW ALBANY - 21,Governor,,Eric Holcomb,R,144
+Floyd,NEW ALBANY - 21,Governor,,John R. Gregg,D,265
+Floyd,NEW ALBANY - 21,Governor,,Rex Bell,L,17
+Floyd,NEW ALBANY - 21,Governor,,Write In,,0
+Floyd,NEW ALBANY - 21,Attorney General,,"Curtis T. Hill, Jr.",R,157
+Floyd,NEW ALBANY - 21,Attorney General,,Lorenzo Arredondo,D,263
+Floyd,NEW ALBANY - 21,Superintendent of Public Instruction,,Jennifer Mccormick,R,155
+Floyd,NEW ALBANY - 21,Superintendent of Public Instruction,,Glenda Ritz,D,266
+Floyd,NEW ALBANY - 21,U.S. House,9,Trey Hollingsworth,R,140
+Floyd,NEW ALBANY - 21,U.S. House,9,Shelli Yoder,D,265
+Floyd,NEW ALBANY - 21,U.S. House,9,Russell Brooksbank,L,20
+Floyd,NEW ALBANY - 21,U.S. House,9,Write In,,1
+Floyd,NEW ALBANY - 21,State House,72,Edward D. (Ed) Clere,R,152
+Floyd,NEW ALBANY - 21,State House,72,Steve Bonifer,D,276
+Floyd,NEW ALBANY - 22,Voters,,Registered,,1095
+Floyd,NEW ALBANY - 22,Voters,,Ballots Cast,,562
+Floyd,NEW ALBANY - 22,Voters,,Straight Ticket,R,116
+Floyd,NEW ALBANY - 22,Voters,,Straight Ticket,D,131
+Floyd,NEW ALBANY - 22,Voters,,Straight Ticket,L,9
+Floyd,NEW ALBANY - 22,President,,Donald J. Trump,R,268
+Floyd,NEW ALBANY - 22,President,,Hillary Clinton,D,249
+Floyd,NEW ALBANY - 22,President,,Gary Johnson,L,27
+Floyd,NEW ALBANY - 22,President,,Write In,,11
+Floyd,NEW ALBANY - 22,U.S. Senate,,Todd Young,R,250
+Floyd,NEW ALBANY - 22,U.S. Senate,,Evan Bayh,D,269
+Floyd,NEW ALBANY - 22,U.S. Senate,,Lucy Brenton,L,27
+Floyd,NEW ALBANY - 22,U.S. Senate,,Write In,,1
+Floyd,NEW ALBANY - 22,Governor,,Eric Holcomb,R,253
+Floyd,NEW ALBANY - 22,Governor,,John R. Gregg,D,261
+Floyd,NEW ALBANY - 22,Governor,,Rex Bell,L,23
+Floyd,NEW ALBANY - 22,Governor,,Write In,,0
+Floyd,NEW ALBANY - 22,Attorney General,,"Curtis T. Hill, Jr.",R,270
+Floyd,NEW ALBANY - 22,Attorney General,,Lorenzo Arredondo,D,248
+Floyd,NEW ALBANY - 22,Superintendent of Public Instruction,,Jennifer Mccormick,R,261
+Floyd,NEW ALBANY - 22,Superintendent of Public Instruction,,Glenda Ritz,D,258
+Floyd,NEW ALBANY - 22,U.S. House,9,Trey Hollingsworth,R,241
+Floyd,NEW ALBANY - 22,U.S. House,9,Shelli Yoder,D,267
+Floyd,NEW ALBANY - 22,U.S. House,9,Russell Brooksbank,L,32
+Floyd,NEW ALBANY - 22,U.S. House,9,Write In,,0
+Floyd,NEW ALBANY - 22,State House,72,Edward D. (Ed) Clere,R,265
+Floyd,NEW ALBANY - 22,State House,72,Steve Bonifer,D,273
+Floyd,NEW ALBANY - 23,Voters,,Registered,,1228
+Floyd,NEW ALBANY - 23,Voters,,Ballots Cast,,601
+Floyd,NEW ALBANY - 23,Voters,,Straight Ticket,R,91
+Floyd,NEW ALBANY - 23,Voters,,Straight Ticket,D,208
+Floyd,NEW ALBANY - 23,Voters,,Straight Ticket,L,9
+Floyd,NEW ALBANY - 23,President,,Donald J. Trump,R,237
+Floyd,NEW ALBANY - 23,President,,Hillary Clinton,D,322
+Floyd,NEW ALBANY - 23,President,,Gary Johnson,L,24
+Floyd,NEW ALBANY - 23,President,,Write In,,13
+Floyd,NEW ALBANY - 23,U.S. Senate,,Todd Young,R,215
+Floyd,NEW ALBANY - 23,U.S. Senate,,Evan Bayh,D,347
+Floyd,NEW ALBANY - 23,U.S. Senate,,Lucy Brenton,L,29
+Floyd,NEW ALBANY - 23,U.S. Senate,,Write In,,0
+Floyd,NEW ALBANY - 23,Governor,,Eric Holcomb,R,220
+Floyd,NEW ALBANY - 23,Governor,,John R. Gregg,D,338
+Floyd,NEW ALBANY - 23,Governor,,Rex Bell,L,23
+Floyd,NEW ALBANY - 23,Governor,,Write In,,0
+Floyd,NEW ALBANY - 23,Attorney General,,"Curtis T. Hill, Jr.",R,235
+Floyd,NEW ALBANY - 23,Attorney General,,Lorenzo Arredondo,D,327
+Floyd,NEW ALBANY - 23,Superintendent of Public Instruction,,Jennifer Mccormick,R,234
+Floyd,NEW ALBANY - 23,Superintendent of Public Instruction,,Glenda Ritz,D,333
+Floyd,NEW ALBANY - 23,U.S. House,9,Trey Hollingsworth,R,204
+Floyd,NEW ALBANY - 23,U.S. House,9,Shelli Yoder,D,347
+Floyd,NEW ALBANY - 23,U.S. House,9,Russell Brooksbank,L,36
+Floyd,NEW ALBANY - 23,U.S. House,9,Write In,,0
+Floyd,NEW ALBANY - 23,State House,72,Edward D. (Ed) Clere,R,229
+Floyd,NEW ALBANY - 23,State House,72,Steve Bonifer,D,349
+Floyd,NEW ALBANY - 24,Voters,,Registered,,824
+Floyd,NEW ALBANY - 24,Voters,,Ballots Cast,,383
+Floyd,NEW ALBANY - 24,Voters,,Straight Ticket,R,86
+Floyd,NEW ALBANY - 24,Voters,,Straight Ticket,D,103
+Floyd,NEW ALBANY - 24,Voters,,Straight Ticket,L,9
+Floyd,NEW ALBANY - 24,President,,Donald J. Trump,R,172
+Floyd,NEW ALBANY - 24,President,,Hillary Clinton,D,168
+Floyd,NEW ALBANY - 24,President,,Gary Johnson,L,33
+Floyd,NEW ALBANY - 24,President,,Write In,,8
+Floyd,NEW ALBANY - 24,U.S. Senate,,Todd Young,R,151
+Floyd,NEW ALBANY - 24,U.S. Senate,,Evan Bayh,D,202
+Floyd,NEW ALBANY - 24,U.S. Senate,,Lucy Brenton,L,24
+Floyd,NEW ALBANY - 24,U.S. Senate,,Write In,,0
+Floyd,NEW ALBANY - 24,Governor,,Eric Holcomb,R,155
+Floyd,NEW ALBANY - 24,Governor,,John R. Gregg,D,204
+Floyd,NEW ALBANY - 24,Governor,,Rex Bell,L,15
+Floyd,NEW ALBANY - 24,Governor,,Write In,,0
+Floyd,NEW ALBANY - 24,Attorney General,,"Curtis T. Hill, Jr.",R,175
+Floyd,NEW ALBANY - 24,Attorney General,,Lorenzo Arredondo,D,194
+Floyd,NEW ALBANY - 24,Superintendent of Public Instruction,,Jennifer Mccormick,R,169
+Floyd,NEW ALBANY - 24,Superintendent of Public Instruction,,Glenda Ritz,D,200
+Floyd,NEW ALBANY - 24,U.S. House,9,Trey Hollingsworth,R,140
+Floyd,NEW ALBANY - 24,U.S. House,9,Shelli Yoder,D,203
+Floyd,NEW ALBANY - 24,U.S. House,9,Russell Brooksbank,L,31
+Floyd,NEW ALBANY - 24,U.S. House,9,Write In,,0
+Floyd,NEW ALBANY - 24,State House,72,Edward D. (Ed) Clere,R,151
+Floyd,NEW ALBANY - 24,State House,72,Steve Bonifer,D,220
+Floyd,NEW ALBANY - 25,Voters,,Registered,,549
+Floyd,NEW ALBANY - 25,Voters,,Ballots Cast,,256
+Floyd,NEW ALBANY - 25,Voters,,Straight Ticket,R,74
+Floyd,NEW ALBANY - 25,Voters,,Straight Ticket,D,52
+Floyd,NEW ALBANY - 25,Voters,,Straight Ticket,L,1
+Floyd,NEW ALBANY - 25,President,,Donald J. Trump,R,141
+Floyd,NEW ALBANY - 25,President,,Hillary Clinton,D,95
+Floyd,NEW ALBANY - 25,President,,Gary Johnson,L,15
+Floyd,NEW ALBANY - 25,President,,Write In,,3
+Floyd,NEW ALBANY - 25,U.S. Senate,,Todd Young,R,115
+Floyd,NEW ALBANY - 25,U.S. Senate,,Evan Bayh,D,124
+Floyd,NEW ALBANY - 25,U.S. Senate,,Lucy Brenton,L,9
+Floyd,NEW ALBANY - 25,U.S. Senate,,Write In,,0
+Floyd,NEW ALBANY - 25,Governor,,Eric Holcomb,R,115
+Floyd,NEW ALBANY - 25,Governor,,John R. Gregg,D,118
+Floyd,NEW ALBANY - 25,Governor,,Rex Bell,L,11
+Floyd,NEW ALBANY - 25,Governor,,Write In,,0
+Floyd,NEW ALBANY - 25,Attorney General,,"Curtis T. Hill, Jr.",R,139
+Floyd,NEW ALBANY - 25,Attorney General,,Lorenzo Arredondo,D,103
+Floyd,NEW ALBANY - 25,Superintendent of Public Instruction,,Jennifer Mccormick,R,130
+Floyd,NEW ALBANY - 25,Superintendent of Public Instruction,,Glenda Ritz,D,116
+Floyd,NEW ALBANY - 25,U.S. House,9,Trey Hollingsworth,R,122
+Floyd,NEW ALBANY - 25,U.S. House,9,Shelli Yoder,D,107
+Floyd,NEW ALBANY - 25,U.S. House,9,Russell Brooksbank,L,16
+Floyd,NEW ALBANY - 25,U.S. House,9,Write In,,0
+Floyd,NEW ALBANY - 25,State House,72,Edward D. (Ed) Clere,R,125
+Floyd,NEW ALBANY - 25,State House,72,Steve Bonifer,D,124
+Floyd,NEW ALBANY - 26,Voters,,Registered,,1168
+Floyd,NEW ALBANY - 26,Voters,,Ballots Cast,,648
+Floyd,NEW ALBANY - 26,Voters,,Straight Ticket,R,167
+Floyd,NEW ALBANY - 26,Voters,,Straight Ticket,D,120
+Floyd,NEW ALBANY - 26,Voters,,Straight Ticket,L,6
+Floyd,NEW ALBANY - 26,President,,Donald J. Trump,R,328
+Floyd,NEW ALBANY - 26,President,,Hillary Clinton,D,256
+Floyd,NEW ALBANY - 26,President,,Gary Johnson,L,47
+Floyd,NEW ALBANY - 26,President,,Write In,,10
+Floyd,NEW ALBANY - 26,U.S. Senate,,Todd Young,R,312
+Floyd,NEW ALBANY - 26,U.S. Senate,,Evan Bayh,D,296
+Floyd,NEW ALBANY - 26,U.S. Senate,,Lucy Brenton,L,30
+Floyd,NEW ALBANY - 26,U.S. Senate,,Write In,,0
+Floyd,NEW ALBANY - 26,Governor,,Eric Holcomb,R,306
+Floyd,NEW ALBANY - 26,Governor,,John R. Gregg,D,289
+Floyd,NEW ALBANY - 26,Governor,,Rex Bell,L,27
+Floyd,NEW ALBANY - 26,Governor,,Write In,,0
+Floyd,NEW ALBANY - 26,Attorney General,,"Curtis T. Hill, Jr.",R,349
+Floyd,NEW ALBANY - 26,Attorney General,,Lorenzo Arredondo,D,257
+Floyd,NEW ALBANY - 26,Superintendent of Public Instruction,,Jennifer Mccormick,R,324
+Floyd,NEW ALBANY - 26,Superintendent of Public Instruction,,Glenda Ritz,D,279
+Floyd,NEW ALBANY - 26,U.S. House,9,Trey Hollingsworth,R,298
+Floyd,NEW ALBANY - 26,U.S. House,9,Shelli Yoder,D,288
+Floyd,NEW ALBANY - 26,U.S. House,9,Russell Brooksbank,L,37
+Floyd,NEW ALBANY - 26,U.S. House,9,Write In,,0
+Floyd,NEW ALBANY - 26,State House,72,Edward D. (Ed) Clere,R,326
+Floyd,NEW ALBANY - 26,State House,72,Steve Bonifer,D,294
+Floyd,NEW ALBANY - 27,Voters,,Registered,,1041
+Floyd,NEW ALBANY - 27,Voters,,Ballots Cast,,568
+Floyd,NEW ALBANY - 27,Voters,,Straight Ticket,R,94
+Floyd,NEW ALBANY - 27,Voters,,Straight Ticket,D,145
+Floyd,NEW ALBANY - 27,Voters,,Straight Ticket,L,8
+Floyd,NEW ALBANY - 27,President,,Donald J. Trump,R,247
+Floyd,NEW ALBANY - 27,President,,Hillary Clinton,D,275
+Floyd,NEW ALBANY - 27,President,,Gary Johnson,L,28
+Floyd,NEW ALBANY - 27,President,,Write In,,13
+Floyd,NEW ALBANY - 27,U.S. Senate,,Todd Young,R,241
+Floyd,NEW ALBANY - 27,U.S. Senate,,Evan Bayh,D,291
+Floyd,NEW ALBANY - 27,U.S. Senate,,Lucy Brenton,L,26
+Floyd,NEW ALBANY - 27,U.S. Senate,,Write In,,0
+Floyd,NEW ALBANY - 27,Governor,,Eric Holcomb,R,244
+Floyd,NEW ALBANY - 27,Governor,,John R. Gregg,D,285
+Floyd,NEW ALBANY - 27,Governor,,Rex Bell,L,17
+Floyd,NEW ALBANY - 27,Governor,,Write In,,0
+Floyd,NEW ALBANY - 27,Attorney General,,"Curtis T. Hill, Jr.",R,253
+Floyd,NEW ALBANY - 27,Attorney General,,Lorenzo Arredondo,D,275
+Floyd,NEW ALBANY - 27,Superintendent of Public Instruction,,Jennifer Mccormick,R,243
+Floyd,NEW ALBANY - 27,Superintendent of Public Instruction,,Glenda Ritz,D,294
+Floyd,NEW ALBANY - 27,U.S. House,9,Trey Hollingsworth,R,215
+Floyd,NEW ALBANY - 27,U.S. House,9,Shelli Yoder,D,310
+Floyd,NEW ALBANY - 27,U.S. House,9,Russell Brooksbank,L,27
+Floyd,NEW ALBANY - 27,U.S. House,9,Write In,,0
+Floyd,NEW ALBANY - 27,State House,72,Edward D. (Ed) Clere,R,244
+Floyd,NEW ALBANY - 27,State House,72,Steve Bonifer,D,302
+Floyd,NEW ALBANY - 28,Voters,,Registered,,1026
+Floyd,NEW ALBANY - 28,Voters,,Ballots Cast,,664
+Floyd,NEW ALBANY - 28,Voters,,Straight Ticket,R,161
+Floyd,NEW ALBANY - 28,Voters,,Straight Ticket,D,109
+Floyd,NEW ALBANY - 28,Voters,,Straight Ticket,L,9
+Floyd,NEW ALBANY - 28,President,,Donald J. Trump,R,360
+Floyd,NEW ALBANY - 28,President,,Hillary Clinton,D,244
+Floyd,NEW ALBANY - 28,President,,Gary Johnson,L,30
+Floyd,NEW ALBANY - 28,President,,Write In,,22
+Floyd,NEW ALBANY - 28,U.S. Senate,,Todd Young,R,347
+Floyd,NEW ALBANY - 28,U.S. Senate,,Evan Bayh,D,285
+Floyd,NEW ALBANY - 28,U.S. Senate,,Lucy Brenton,L,15
+Floyd,NEW ALBANY - 28,U.S. Senate,,Write In,,0
+Floyd,NEW ALBANY - 28,Governor,,Eric Holcomb,R,354
+Floyd,NEW ALBANY - 28,Governor,,John R. Gregg,D,268
+Floyd,NEW ALBANY - 28,Governor,,Rex Bell,L,17
+Floyd,NEW ALBANY - 28,Governor,,Write In,,0
+Floyd,NEW ALBANY - 28,Attorney General,,"Curtis T. Hill, Jr.",R,372
+Floyd,NEW ALBANY - 28,Attorney General,,Lorenzo Arredondo,D,242
+Floyd,NEW ALBANY - 28,Superintendent of Public Instruction,,Jennifer Mccormick,R,344
+Floyd,NEW ALBANY - 28,Superintendent of Public Instruction,,Glenda Ritz,D,270
+Floyd,NEW ALBANY - 28,U.S. House,9,Trey Hollingsworth,R,317
+Floyd,NEW ALBANY - 28,U.S. House,9,Shelli Yoder,D,294
+Floyd,NEW ALBANY - 28,U.S. House,9,Russell Brooksbank,L,23
+Floyd,NEW ALBANY - 28,U.S. House,9,Write In,,0
+Floyd,NEW ALBANY - 28,State House,72,Edward D. (Ed) Clere,R,362
+Floyd,NEW ALBANY - 28,State House,72,Steve Bonifer,D,276
+Floyd,NEW ALBANY - 29,Voters,,Registered,,1333
+Floyd,NEW ALBANY - 29,Voters,,Ballots Cast,,602
+Floyd,NEW ALBANY - 29,Voters,,Straight Ticket,R,143
+Floyd,NEW ALBANY - 29,Voters,,Straight Ticket,D,121
+Floyd,NEW ALBANY - 29,Voters,,Straight Ticket,L,5
+Floyd,NEW ALBANY - 29,President,,Donald J. Trump,R,301
+Floyd,NEW ALBANY - 29,President,,Hillary Clinton,D,245
+Floyd,NEW ALBANY - 29,President,,Gary Johnson,L,31
+Floyd,NEW ALBANY - 29,President,,Write In,,9
+Floyd,NEW ALBANY - 29,U.S. Senate,,Todd Young,R,287
+Floyd,NEW ALBANY - 29,U.S. Senate,,Evan Bayh,D,272
+Floyd,NEW ALBANY - 29,U.S. Senate,,Lucy Brenton,L,26
+Floyd,NEW ALBANY - 29,U.S. Senate,,Write In,,2
+Floyd,NEW ALBANY - 29,Governor,,Eric Holcomb,R,294
+Floyd,NEW ALBANY - 29,Governor,,John R. Gregg,D,271
+Floyd,NEW ALBANY - 29,Governor,,Rex Bell,L,17
+Floyd,NEW ALBANY - 29,Governor,,Write In,,0
+Floyd,NEW ALBANY - 29,Attorney General,,"Curtis T. Hill, Jr.",R,314
+Floyd,NEW ALBANY - 29,Attorney General,,Lorenzo Arredondo,D,250
+Floyd,NEW ALBANY - 29,Superintendent of Public Instruction,,Jennifer Mccormick,R,297
+Floyd,NEW ALBANY - 29,Superintendent of Public Instruction,,Glenda Ritz,D,272
+Floyd,NEW ALBANY - 29,U.S. House,9,Trey Hollingsworth,R,283
+Floyd,NEW ALBANY - 29,U.S. House,9,Shelli Yoder,D,275
+Floyd,NEW ALBANY - 29,U.S. House,9,Russell Brooksbank,L,26
+Floyd,NEW ALBANY - 29,U.S. House,9,Write In,,0
+Floyd,NEW ALBANY - 29,State House,72,Edward D. (Ed) Clere,R,301
+Floyd,NEW ALBANY - 29,State House,72,Steve Bonifer,D,284
+Floyd,NEW ALBANY - 30,Voters,,Registered,,748
+Floyd,NEW ALBANY - 30,Voters,,Ballots Cast,,523
+Floyd,NEW ALBANY - 30,Voters,,Straight Ticket,R,136
+Floyd,NEW ALBANY - 30,Voters,,Straight Ticket,D,88
+Floyd,NEW ALBANY - 30,Voters,,Straight Ticket,L,4
+Floyd,NEW ALBANY - 30,President,,Donald J. Trump,R,300
+Floyd,NEW ALBANY - 30,President,,Hillary Clinton,D,188
+Floyd,NEW ALBANY - 30,President,,Gary Johnson,L,18
+Floyd,NEW ALBANY - 30,President,,Write In,,10
+Floyd,NEW ALBANY - 30,U.S. Senate,,Todd Young,R,285
+Floyd,NEW ALBANY - 30,U.S. Senate,,Evan Bayh,D,211
+Floyd,NEW ALBANY - 30,U.S. Senate,,Lucy Brenton,L,16
+Floyd,NEW ALBANY - 30,U.S. Senate,,Write In,,0
+Floyd,NEW ALBANY - 30,Governor,,Eric Holcomb,R,297
+Floyd,NEW ALBANY - 30,Governor,,John R. Gregg,D,198
+Floyd,NEW ALBANY - 30,Governor,,Rex Bell,L,10
+Floyd,NEW ALBANY - 30,Governor,,Write In,,0
+Floyd,NEW ALBANY - 30,Attorney General,,"Curtis T. Hill, Jr.",R,310
+Floyd,NEW ALBANY - 30,Attorney General,,Lorenzo Arredondo,D,173
+Floyd,NEW ALBANY - 30,Superintendent of Public Instruction,,Jennifer Mccormick,R,287
+Floyd,NEW ALBANY - 30,Superintendent of Public Instruction,,Glenda Ritz,D,195
+Floyd,NEW ALBANY - 30,U.S. House,9,Trey Hollingsworth,R,281
+Floyd,NEW ALBANY - 30,U.S. House,9,Shelli Yoder,D,212
+Floyd,NEW ALBANY - 30,U.S. House,9,Russell Brooksbank,L,17
+Floyd,NEW ALBANY - 30,U.S. House,9,Write In,,0
+Floyd,NEW ALBANY - 30,State House,72,Edward D. (Ed) Clere,R,315
+Floyd,NEW ALBANY - 30,State House,72,Steve Bonifer,D,186
+Floyd,NEW ALBANY - 31,Voters,,Registered,,997
+Floyd,NEW ALBANY - 31,Voters,,Ballots Cast,,718
+Floyd,NEW ALBANY - 31,Voters,,Straight Ticket,R,184
+Floyd,NEW ALBANY - 31,Voters,,Straight Ticket,D,100
+Floyd,NEW ALBANY - 31,Voters,,Straight Ticket,L,0
+Floyd,NEW ALBANY - 31,President,,Donald J. Trump,R,451
+Floyd,NEW ALBANY - 31,President,,Hillary Clinton,D,222
+Floyd,NEW ALBANY - 31,President,,Gary Johnson,L,36
+Floyd,NEW ALBANY - 31,President,,Write In,,3
+Floyd,NEW ALBANY - 31,U.S. Senate,,Todd Young,R,460
+Floyd,NEW ALBANY - 31,U.S. Senate,,Evan Bayh,D,237
+Floyd,NEW ALBANY - 31,U.S. Senate,,Lucy Brenton,L,11
+Floyd,NEW ALBANY - 31,U.S. Senate,,Write In,,0
+Floyd,NEW ALBANY - 31,Governor,,Eric Holcomb,R,465
+Floyd,NEW ALBANY - 31,Governor,,John R. Gregg,D,220
+Floyd,NEW ALBANY - 31,Governor,,Rex Bell,L,10
+Floyd,NEW ALBANY - 31,Governor,,Write In,,0
+Floyd,NEW ALBANY - 31,Attorney General,,"Curtis T. Hill, Jr.",R,475
+Floyd,NEW ALBANY - 31,Attorney General,,Lorenzo Arredondo,D,195
+Floyd,NEW ALBANY - 31,Superintendent of Public Instruction,,Jennifer Mccormick,R,433
+Floyd,NEW ALBANY - 31,Superintendent of Public Instruction,,Glenda Ritz,D,242
+Floyd,NEW ALBANY - 31,U.S. House,9,Trey Hollingsworth,R,436
+Floyd,NEW ALBANY - 31,U.S. House,9,Shelli Yoder,D,241
+Floyd,NEW ALBANY - 31,U.S. House,9,Russell Brooksbank,L,23
+Floyd,NEW ALBANY - 31,U.S. House,9,Write In,,0
+Floyd,NEW ALBANY - 31,State House,72,Edward D. (Ed) Clere,R,473
+Floyd,NEW ALBANY - 31,State House,72,Steve Bonifer,D,221
+Floyd,NEW ALBANY - 32,Voters,,Registered,,1052
+Floyd,NEW ALBANY - 32,Voters,,Ballots Cast,,644
+Floyd,NEW ALBANY - 32,Voters,,Straight Ticket,R,166
+Floyd,NEW ALBANY - 32,Voters,,Straight Ticket,D,109
+Floyd,NEW ALBANY - 32,Voters,,Straight Ticket,L,5
+Floyd,NEW ALBANY - 32,President,,Donald J. Trump,R,360
+Floyd,NEW ALBANY - 32,President,,Hillary Clinton,D,231
+Floyd,NEW ALBANY - 32,President,,Gary Johnson,L,38
+Floyd,NEW ALBANY - 32,President,,Write In,,9
+Floyd,NEW ALBANY - 32,U.S. Senate,,Todd Young,R,369
+Floyd,NEW ALBANY - 32,U.S. Senate,,Evan Bayh,D,243
+Floyd,NEW ALBANY - 32,U.S. Senate,,Lucy Brenton,L,20
+Floyd,NEW ALBANY - 32,U.S. Senate,,Write In,,1
+Floyd,NEW ALBANY - 32,Governor,,Eric Holcomb,R,375
+Floyd,NEW ALBANY - 32,Governor,,John R. Gregg,D,231
+Floyd,NEW ALBANY - 32,Governor,,Rex Bell,L,13
+Floyd,NEW ALBANY - 32,Governor,,Write In,,1
+Floyd,NEW ALBANY - 32,Attorney General,,"Curtis T. Hill, Jr.",R,393
+Floyd,NEW ALBANY - 32,Attorney General,,Lorenzo Arredondo,D,200
+Floyd,NEW ALBANY - 32,Superintendent of Public Instruction,,Jennifer Mccormick,R,379
+Floyd,NEW ALBANY - 32,Superintendent of Public Instruction,,Glenda Ritz,D,226
+Floyd,NEW ALBANY - 32,U.S. House,9,Trey Hollingsworth,R,362
+Floyd,NEW ALBANY - 32,U.S. House,9,Shelli Yoder,D,240
+Floyd,NEW ALBANY - 32,U.S. House,9,Russell Brooksbank,L,27
+Floyd,NEW ALBANY - 32,U.S. House,9,Write In,,0
+Floyd,NEW ALBANY - 32,State House,72,Edward D. (Ed) Clere,R,381
+Floyd,NEW ALBANY - 32,State House,72,Steve Bonifer,D,238
+Floyd,NEW ALBANY - 33,Voters,,Registered,,854
+Floyd,NEW ALBANY - 33,Voters,,Ballots Cast,,526
+Floyd,NEW ALBANY - 33,Voters,,Straight Ticket,R,146
+Floyd,NEW ALBANY - 33,Voters,,Straight Ticket,D,85
+Floyd,NEW ALBANY - 33,Voters,,Straight Ticket,L,3
+Floyd,NEW ALBANY - 33,President,,Donald J. Trump,R,335
+Floyd,NEW ALBANY - 33,President,,Hillary Clinton,D,160
+Floyd,NEW ALBANY - 33,President,,Gary Johnson,L,20
+Floyd,NEW ALBANY - 33,President,,Write In,,4
+Floyd,NEW ALBANY - 33,U.S. Senate,,Todd Young,R,308
+Floyd,NEW ALBANY - 33,U.S. Senate,,Evan Bayh,D,194
+Floyd,NEW ALBANY - 33,U.S. Senate,,Lucy Brenton,L,16
+Floyd,NEW ALBANY - 33,U.S. Senate,,Write In,,1
+Floyd,NEW ALBANY - 33,Governor,,Eric Holcomb,R,314
+Floyd,NEW ALBANY - 33,Governor,,John R. Gregg,D,182
+Floyd,NEW ALBANY - 33,Governor,,Rex Bell,L,12
+Floyd,NEW ALBANY - 33,Governor,,Write In,,0
+Floyd,NEW ALBANY - 33,Attorney General,,"Curtis T. Hill, Jr.",R,335
+Floyd,NEW ALBANY - 33,Attorney General,,Lorenzo Arredondo,D,164
+Floyd,NEW ALBANY - 33,Superintendent of Public Instruction,,Jennifer Mccormick,R,307
+Floyd,NEW ALBANY - 33,Superintendent of Public Instruction,,Glenda Ritz,D,191
+Floyd,NEW ALBANY - 33,U.S. House,9,Trey Hollingsworth,R,301
+Floyd,NEW ALBANY - 33,U.S. House,9,Shelli Yoder,D,191
+Floyd,NEW ALBANY - 33,U.S. House,9,Russell Brooksbank,L,18
+Floyd,NEW ALBANY - 33,U.S. House,9,Write In,,1
+Floyd,NEW ALBANY - 33,State House,72,Edward D. (Ed) Clere,R,310
+Floyd,NEW ALBANY - 33,State House,72,Steve Bonifer,D,205
+Floyd,NEW ALBANY - 34,Voters,,Registered,,972
+Floyd,NEW ALBANY - 34,Voters,,Ballots Cast,,667
+Floyd,NEW ALBANY - 34,Voters,,Straight Ticket,R,171
+Floyd,NEW ALBANY - 34,Voters,,Straight Ticket,D,71
+Floyd,NEW ALBANY - 34,Voters,,Straight Ticket,L,4
+Floyd,NEW ALBANY - 34,President,,Donald J. Trump,R,393
+Floyd,NEW ALBANY - 34,President,,Hillary Clinton,D,233
+Floyd,NEW ALBANY - 34,President,,Gary Johnson,L,29
+Floyd,NEW ALBANY - 34,President,,Write In,,6
+Floyd,NEW ALBANY - 34,U.S. Senate,,Todd Young,R,409
+Floyd,NEW ALBANY - 34,U.S. Senate,,Evan Bayh,D,237
+Floyd,NEW ALBANY - 34,U.S. Senate,,Lucy Brenton,L,16
+Floyd,NEW ALBANY - 34,U.S. Senate,,Write In,,0
+Floyd,NEW ALBANY - 34,Governor,,Eric Holcomb,R,412
+Floyd,NEW ALBANY - 34,Governor,,John R. Gregg,D,235
+Floyd,NEW ALBANY - 34,Governor,,Rex Bell,L,11
+Floyd,NEW ALBANY - 34,Governor,,Write In,,0
+Floyd,NEW ALBANY - 34,Attorney General,,"Curtis T. Hill, Jr.",R,433
+Floyd,NEW ALBANY - 34,Attorney General,,Lorenzo Arredondo,D,197
+Floyd,NEW ALBANY - 34,Superintendent of Public Instruction,,Jennifer Mccormick,R,402
+Floyd,NEW ALBANY - 34,Superintendent of Public Instruction,,Glenda Ritz,D,237
+Floyd,NEW ALBANY - 34,U.S. House,9,Trey Hollingsworth,R,368
+Floyd,NEW ALBANY - 34,U.S. House,9,Shelli Yoder,D,260
+Floyd,NEW ALBANY - 34,U.S. House,9,Russell Brooksbank,L,29
+Floyd,NEW ALBANY - 34,U.S. House,9,Write In,,0
+Floyd,NEW ALBANY - 34,State House,72,Edward D. (Ed) Clere,R,418
+Floyd,NEW ALBANY - 34,State House,72,Steve Bonifer,D,242
+Floyd,NEW ALBANY - 35,Voters,,Registered,,1326
+Floyd,NEW ALBANY - 35,Voters,,Ballots Cast,,776
+Floyd,NEW ALBANY - 35,Voters,,Straight Ticket,R,200
+Floyd,NEW ALBANY - 35,Voters,,Straight Ticket,D,167
+Floyd,NEW ALBANY - 35,Voters,,Straight Ticket,L,7
+Floyd,NEW ALBANY - 35,President,,Donald J. Trump,R,427
+Floyd,NEW ALBANY - 35,President,,Hillary Clinton,D,288
+Floyd,NEW ALBANY - 35,President,,Gary Johnson,L,40
+Floyd,NEW ALBANY - 35,President,,Write In,,16
+Floyd,NEW ALBANY - 35,U.S. Senate,,Todd Young,R,417
+Floyd,NEW ALBANY - 35,U.S. Senate,,Evan Bayh,D,314
+Floyd,NEW ALBANY - 35,U.S. Senate,,Lucy Brenton,L,29
+Floyd,NEW ALBANY - 35,U.S. Senate,,Write In,,2
+Floyd,NEW ALBANY - 35,Governor,,Eric Holcomb,R,412
+Floyd,NEW ALBANY - 35,Governor,,John R. Gregg,D,326
+Floyd,NEW ALBANY - 35,Governor,,Rex Bell,L,21
+Floyd,NEW ALBANY - 35,Governor,,Write In,,0
+Floyd,NEW ALBANY - 35,Attorney General,,"Curtis T. Hill, Jr.",R,435
+Floyd,NEW ALBANY - 35,Attorney General,,Lorenzo Arredondo,D,292
+Floyd,NEW ALBANY - 35,Superintendent of Public Instruction,,Jennifer Mccormick,R,417
+Floyd,NEW ALBANY - 35,Superintendent of Public Instruction,,Glenda Ritz,D,330
+Floyd,NEW ALBANY - 35,U.S. House,9,Trey Hollingsworth,R,394
+Floyd,NEW ALBANY - 35,U.S. House,9,Shelli Yoder,D,329
+Floyd,NEW ALBANY - 35,U.S. House,9,Russell Brooksbank,L,37
+Floyd,NEW ALBANY - 35,U.S. House,9,Write In,,2
+Floyd,NEW ALBANY - 35,State House,72,Edward D. (Ed) Clere,R,426
+Floyd,NEW ALBANY - 35,State House,72,Steve Bonifer,D,335
+Floyd,NEW ALBANY - 36,Voters,,Registered,,1096
+Floyd,NEW ALBANY - 36,Voters,,Ballots Cast,,616
+Floyd,NEW ALBANY - 36,Voters,,Straight Ticket,R,152
+Floyd,NEW ALBANY - 36,Voters,,Straight Ticket,D,132
+Floyd,NEW ALBANY - 36,Voters,,Straight Ticket,L,8
+Floyd,NEW ALBANY - 36,President,,Donald J. Trump,R,330
+Floyd,NEW ALBANY - 36,President,,Hillary Clinton,D,237
+Floyd,NEW ALBANY - 36,President,,Gary Johnson,L,30
+Floyd,NEW ALBANY - 36,President,,Write In,,11
+Floyd,NEW ALBANY - 36,U.S. Senate,,Todd Young,R,331
+Floyd,NEW ALBANY - 36,U.S. Senate,,Evan Bayh,D,247
+Floyd,NEW ALBANY - 36,U.S. Senate,,Lucy Brenton,L,25
+Floyd,NEW ALBANY - 36,U.S. Senate,,Write In,,0
+Floyd,NEW ALBANY - 36,Governor,,Eric Holcomb,R,325
+Floyd,NEW ALBANY - 36,Governor,,John R. Gregg,D,253
+Floyd,NEW ALBANY - 36,Governor,,Rex Bell,L,17
+Floyd,NEW ALBANY - 36,Governor,,Write In,,0
+Floyd,NEW ALBANY - 36,Attorney General,,"Curtis T. Hill, Jr.",R,349
+Floyd,NEW ALBANY - 36,Attorney General,,Lorenzo Arredondo,D,228
+Floyd,NEW ALBANY - 36,Superintendent of Public Instruction,,Jennifer Mccormick,R,318
+Floyd,NEW ALBANY - 36,Superintendent of Public Instruction,,Glenda Ritz,D,258
+Floyd,NEW ALBANY - 36,U.S. House,9,Trey Hollingsworth,R,306
+Floyd,NEW ALBANY - 36,U.S. House,9,Shelli Yoder,D,263
+Floyd,NEW ALBANY - 36,U.S. House,9,Russell Brooksbank,L,24
+Floyd,NEW ALBANY - 36,U.S. House,9,Write In,,1
+Floyd,NEW ALBANY - 36,State House,72,Edward D. (Ed) Clere,R,315
+Floyd,NEW ALBANY - 36,State House,72,Steve Bonifer,D,281
+Floyd,NEW ALBANY - 37,Voters,,Registered,,1108
+Floyd,NEW ALBANY - 37,Voters,,Ballots Cast,,735
+Floyd,NEW ALBANY - 37,Voters,,Straight Ticket,R,161
+Floyd,NEW ALBANY - 37,Voters,,Straight Ticket,D,136
+Floyd,NEW ALBANY - 37,Voters,,Straight Ticket,L,4
+Floyd,NEW ALBANY - 37,President,,Donald J. Trump,R,405
+Floyd,NEW ALBANY - 37,President,,Hillary Clinton,D,282
+Floyd,NEW ALBANY - 37,President,,Gary Johnson,L,33
+Floyd,NEW ALBANY - 37,President,,Write In,,8
+Floyd,NEW ALBANY - 37,U.S. Senate,,Todd Young,R,402
+Floyd,NEW ALBANY - 37,U.S. Senate,,Evan Bayh,D,295
+Floyd,NEW ALBANY - 37,U.S. Senate,,Lucy Brenton,L,19
+Floyd,NEW ALBANY - 37,U.S. Senate,,Write In,,1
+Floyd,NEW ALBANY - 37,Governor,,Eric Holcomb,R,392
+Floyd,NEW ALBANY - 37,Governor,,John R. Gregg,D,293
+Floyd,NEW ALBANY - 37,Governor,,Rex Bell,L,20
+Floyd,NEW ALBANY - 37,Governor,,Write In,,1
+Floyd,NEW ALBANY - 37,Attorney General,,"Curtis T. Hill, Jr.",R,412
+Floyd,NEW ALBANY - 37,Attorney General,,Lorenzo Arredondo,D,259
+Floyd,NEW ALBANY - 37,Superintendent of Public Instruction,,Jennifer Mccormick,R,371
+Floyd,NEW ALBANY - 37,Superintendent of Public Instruction,,Glenda Ritz,D,306
+Floyd,NEW ALBANY - 37,U.S. House,9,Trey Hollingsworth,R,363
+Floyd,NEW ALBANY - 37,U.S. House,9,Shelli Yoder,D,313
+Floyd,NEW ALBANY - 37,U.S. House,9,Russell Brooksbank,L,24
+Floyd,NEW ALBANY - 37,U.S. House,9,Write In,,4
+Floyd,NEW ALBANY - 37,State House,72,Edward D. (Ed) Clere,R,392
+Floyd,NEW ALBANY - 37,State House,72,Steve Bonifer,D,311
+Floyd,NEW ALBANY - 38,Voters,,Registered,,1131
+Floyd,NEW ALBANY - 38,Voters,,Ballots Cast,,746
+Floyd,NEW ALBANY - 38,Voters,,Straight Ticket,R,202
+Floyd,NEW ALBANY - 38,Voters,,Straight Ticket,D,90
+Floyd,NEW ALBANY - 38,Voters,,Straight Ticket,L,3
+Floyd,NEW ALBANY - 38,President,,Donald J. Trump,R,475
+Floyd,NEW ALBANY - 38,President,,Hillary Clinton,D,228
+Floyd,NEW ALBANY - 38,President,,Gary Johnson,L,24
+Floyd,NEW ALBANY - 38,President,,Write In,,10
+Floyd,NEW ALBANY - 38,U.S. Senate,,Todd Young,R,467
+Floyd,NEW ALBANY - 38,U.S. Senate,,Evan Bayh,D,249
+Floyd,NEW ALBANY - 38,U.S. Senate,,Lucy Brenton,L,19
+Floyd,NEW ALBANY - 38,U.S. Senate,,Write In,,0
+Floyd,NEW ALBANY - 38,Governor,,Eric Holcomb,R,478
+Floyd,NEW ALBANY - 38,Governor,,John R. Gregg,D,228
+Floyd,NEW ALBANY - 38,Governor,,Rex Bell,L,7
+Floyd,NEW ALBANY - 38,Governor,,Write In,,0
+Floyd,NEW ALBANY - 38,Attorney General,,"Curtis T. Hill, Jr.",R,497
+Floyd,NEW ALBANY - 38,Attorney General,,Lorenzo Arredondo,D,199
+Floyd,NEW ALBANY - 38,Superintendent of Public Instruction,,Jennifer Mccormick,R,456
+Floyd,NEW ALBANY - 38,Superintendent of Public Instruction,,Glenda Ritz,D,238
+Floyd,NEW ALBANY - 38,U.S. House,9,Trey Hollingsworth,R,438
+Floyd,NEW ALBANY - 38,U.S. House,9,Shelli Yoder,D,263
+Floyd,NEW ALBANY - 38,U.S. House,9,Russell Brooksbank,L,24
+Floyd,NEW ALBANY - 38,U.S. House,9,Write In,,1
+Floyd,NEW ALBANY - 38,State House,72,Edward D. (Ed) Clere,R,463
+Floyd,NEW ALBANY - 38,State House,72,Steve Bonifer,D,268
+Floyd,NEW ALBANY - 39,Voters,,Registered,,994
+Floyd,NEW ALBANY - 39,Voters,,Ballots Cast,,708
+Floyd,NEW ALBANY - 39,Voters,,Straight Ticket,R,204
+Floyd,NEW ALBANY - 39,Voters,,Straight Ticket,D,85
+Floyd,NEW ALBANY - 39,Voters,,Straight Ticket,L,2
+Floyd,NEW ALBANY - 39,President,,Donald J. Trump,R,463
+Floyd,NEW ALBANY - 39,President,,Hillary Clinton,D,209
+Floyd,NEW ALBANY - 39,President,,Gary Johnson,L,23
+Floyd,NEW ALBANY - 39,President,,Write In,,8
+Floyd,NEW ALBANY - 39,U.S. Senate,,Todd Young,R,471
+Floyd,NEW ALBANY - 39,U.S. Senate,,Evan Bayh,D,214
+Floyd,NEW ALBANY - 39,U.S. Senate,,Lucy Brenton,L,11
+Floyd,NEW ALBANY - 39,U.S. Senate,,Write In,,0
+Floyd,NEW ALBANY - 39,Governor,,Eric Holcomb,R,472
+Floyd,NEW ALBANY - 39,Governor,,John R. Gregg,D,205
+Floyd,NEW ALBANY - 39,Governor,,Rex Bell,L,7
+Floyd,NEW ALBANY - 39,Governor,,Write In,,0
+Floyd,NEW ALBANY - 39,Attorney General,,"Curtis T. Hill, Jr.",R,490
+Floyd,NEW ALBANY - 39,Attorney General,,Lorenzo Arredondo,D,176
+Floyd,NEW ALBANY - 39,Superintendent of Public Instruction,,Jennifer Mccormick,R,465
+Floyd,NEW ALBANY - 39,Superintendent of Public Instruction,,Glenda Ritz,D,213
+Floyd,NEW ALBANY - 39,U.S. House,9,Trey Hollingsworth,R,427
+Floyd,NEW ALBANY - 39,U.S. House,9,Shelli Yoder,D,243
+Floyd,NEW ALBANY - 39,U.S. House,9,Russell Brooksbank,L,17
+Floyd,NEW ALBANY - 39,U.S. House,9,Write In,,0
+Floyd,NEW ALBANY - 39,State House,72,Edward D. (Ed) Clere,R,478
+Floyd,NEW ALBANY - 39,State House,72,Steve Bonifer,D,208
+Floyd,NEW ALBANY - 40,Voters,,Registered,,945
+Floyd,NEW ALBANY - 40,Voters,,Ballots Cast,,593
+Floyd,NEW ALBANY - 40,Voters,,Straight Ticket,R,118
+Floyd,NEW ALBANY - 40,Voters,,Straight Ticket,D,137
+Floyd,NEW ALBANY - 40,Voters,,Straight Ticket,L,6
+Floyd,NEW ALBANY - 40,President,,Donald J. Trump,R,292
+Floyd,NEW ALBANY - 40,President,,Hillary Clinton,D,249
+Floyd,NEW ALBANY - 40,President,,Gary Johnson,L,27
+Floyd,NEW ALBANY - 40,President,,Write In,,14
+Floyd,NEW ALBANY - 40,U.S. Senate,,Todd Young,R,272
+Floyd,NEW ALBANY - 40,U.S. Senate,,Evan Bayh,D,287
+Floyd,NEW ALBANY - 40,U.S. Senate,,Lucy Brenton,L,22
+Floyd,NEW ALBANY - 40,U.S. Senate,,Write In,,0
+Floyd,NEW ALBANY - 40,Governor,,Eric Holcomb,R,270
+Floyd,NEW ALBANY - 40,Governor,,John R. Gregg,D,289
+Floyd,NEW ALBANY - 40,Governor,,Rex Bell,L,14
+Floyd,NEW ALBANY - 40,Governor,,Write In,,1
+Floyd,NEW ALBANY - 40,Attorney General,,"Curtis T. Hill, Jr.",R,300
+Floyd,NEW ALBANY - 40,Attorney General,,Lorenzo Arredondo,D,255
+Floyd,NEW ALBANY - 40,Superintendent of Public Instruction,,Jennifer Mccormick,R,267
+Floyd,NEW ALBANY - 40,Superintendent of Public Instruction,,Glenda Ritz,D,298
+Floyd,NEW ALBANY - 40,U.S. House,9,Trey Hollingsworth,R,251
+Floyd,NEW ALBANY - 40,U.S. House,9,Shelli Yoder,D,292
+Floyd,NEW ALBANY - 40,U.S. House,9,Russell Brooksbank,L,25
+Floyd,NEW ALBANY - 40,U.S. House,9,Write In,,0
+Floyd,NEW ALBANY - 40,State House,72,Edward D. (Ed) Clere,R,282
+Floyd,NEW ALBANY - 40,State House,72,Steve Bonifer,D,293
+Floyd,NEW ALBANY - 41,Voters,,Registered,,1335
+Floyd,NEW ALBANY - 41,Voters,,Ballots Cast,,758
+Floyd,NEW ALBANY - 41,Voters,,Straight Ticket,R,209
+Floyd,NEW ALBANY - 41,Voters,,Straight Ticket,D,152
+Floyd,NEW ALBANY - 41,Voters,,Straight Ticket,L,6
+Floyd,NEW ALBANY - 41,President,,Donald J. Trump,R,391
+Floyd,NEW ALBANY - 41,President,,Hillary Clinton,D,323
+Floyd,NEW ALBANY - 41,President,,Gary Johnson,L,21
+Floyd,NEW ALBANY - 41,President,,Write In,,15
+Floyd,NEW ALBANY - 41,U.S. Senate,,Todd Young,R,373
+Floyd,NEW ALBANY - 41,U.S. Senate,,Evan Bayh,D,342
+Floyd,NEW ALBANY - 41,U.S. Senate,,Lucy Brenton,L,26
+Floyd,NEW ALBANY - 41,U.S. Senate,,Write In,,0
+Floyd,NEW ALBANY - 41,Governor,,Eric Holcomb,R,389
+Floyd,NEW ALBANY - 41,Governor,,John R. Gregg,D,331
+Floyd,NEW ALBANY - 41,Governor,,Rex Bell,L,16
+Floyd,NEW ALBANY - 41,Governor,,Write In,,0
+Floyd,NEW ALBANY - 41,Attorney General,,"Curtis T. Hill, Jr.",R,425
+Floyd,NEW ALBANY - 41,Attorney General,,Lorenzo Arredondo,D,290
+Floyd,NEW ALBANY - 41,Superintendent of Public Instruction,,Jennifer Mccormick,R,398
+Floyd,NEW ALBANY - 41,Superintendent of Public Instruction,,Glenda Ritz,D,322
+Floyd,NEW ALBANY - 41,U.S. House,9,Trey Hollingsworth,R,375
+Floyd,NEW ALBANY - 41,U.S. House,9,Shelli Yoder,D,329
+Floyd,NEW ALBANY - 41,U.S. House,9,Russell Brooksbank,L,33
+Floyd,NEW ALBANY - 41,U.S. House,9,Write In,,0
+Floyd,NEW ALBANY - 41,State House,72,Edward D. (Ed) Clere,R,402
+Floyd,NEW ALBANY - 41,State House,72,Steve Bonifer,D,328
+Floyd,NEW ALBANY - 42,Voters,,Registered,,913
+Floyd,NEW ALBANY - 42,Voters,,Ballots Cast,,593
+Floyd,NEW ALBANY - 42,Voters,,Straight Ticket,R,135
+Floyd,NEW ALBANY - 42,Voters,,Straight Ticket,D,99
+Floyd,NEW ALBANY - 42,Voters,,Straight Ticket,L,3
+Floyd,NEW ALBANY - 42,President,,Donald J. Trump,R,317
+Floyd,NEW ALBANY - 42,President,,Hillary Clinton,D,242
+Floyd,NEW ALBANY - 42,President,,Gary Johnson,L,21
+Floyd,NEW ALBANY - 42,President,,Write In,,9
+Floyd,NEW ALBANY - 42,U.S. Senate,,Todd Young,R,299
+Floyd,NEW ALBANY - 42,U.S. Senate,,Evan Bayh,D,258
+Floyd,NEW ALBANY - 42,U.S. Senate,,Lucy Brenton,L,21
+Floyd,NEW ALBANY - 42,U.S. Senate,,Write In,,0
+Floyd,NEW ALBANY - 42,Governor,,Eric Holcomb,R,300
+Floyd,NEW ALBANY - 42,Governor,,John R. Gregg,D,254
+Floyd,NEW ALBANY - 42,Governor,,Rex Bell,L,16
+Floyd,NEW ALBANY - 42,Governor,,Write In,,1
+Floyd,NEW ALBANY - 42,Attorney General,,"Curtis T. Hill, Jr.",R,331
+Floyd,NEW ALBANY - 42,Attorney General,,Lorenzo Arredondo,D,221
+Floyd,NEW ALBANY - 42,Superintendent of Public Instruction,,Jennifer Mccormick,R,327
+Floyd,NEW ALBANY - 42,Superintendent of Public Instruction,,Glenda Ritz,D,234
+Floyd,NEW ALBANY - 42,U.S. House,9,Trey Hollingsworth,R,276
+Floyd,NEW ALBANY - 42,U.S. House,9,Shelli Yoder,D,274
+Floyd,NEW ALBANY - 42,U.S. House,9,Russell Brooksbank,L,19
+Floyd,NEW ALBANY - 42,U.S. House,9,Write In,,1
+Floyd,NEW ALBANY - 42,State House,72,Edward D. (Ed) Clere,R,306
+Floyd,NEW ALBANY - 42,State House,72,Steve Bonifer,D,271
+Floyd,NEW ALBANY - 43,Voters,,Registered,,558
+Floyd,NEW ALBANY - 43,Voters,,Ballots Cast,,387
+Floyd,NEW ALBANY - 43,Voters,,Straight Ticket,R,56
+Floyd,NEW ALBANY - 43,Voters,,Straight Ticket,D,78
+Floyd,NEW ALBANY - 43,Voters,,Straight Ticket,L,4
+Floyd,NEW ALBANY - 43,President,,Donald J. Trump,R,188
+Floyd,NEW ALBANY - 43,President,,Hillary Clinton,D,168
+Floyd,NEW ALBANY - 43,President,,Gary Johnson,L,20
+Floyd,NEW ALBANY - 43,President,,Write In,,5
+Floyd,NEW ALBANY - 43,U.S. Senate,,Todd Young,R,184
+Floyd,NEW ALBANY - 43,U.S. Senate,,Evan Bayh,D,188
+Floyd,NEW ALBANY - 43,U.S. Senate,,Lucy Brenton,L,10
+Floyd,NEW ALBANY - 43,U.S. Senate,,Write In,,0
+Floyd,NEW ALBANY - 43,Governor,,Eric Holcomb,R,188
+Floyd,NEW ALBANY - 43,Governor,,John R. Gregg,D,183
+Floyd,NEW ALBANY - 43,Governor,,Rex Bell,L,8
+Floyd,NEW ALBANY - 43,Governor,,Write In,,0
+Floyd,NEW ALBANY - 43,Attorney General,,"Curtis T. Hill, Jr.",R,198
+Floyd,NEW ALBANY - 43,Attorney General,,Lorenzo Arredondo,D,167
+Floyd,NEW ALBANY - 43,Superintendent of Public Instruction,,Jennifer Mccormick,R,178
+Floyd,NEW ALBANY - 43,Superintendent of Public Instruction,,Glenda Ritz,D,189
+Floyd,NEW ALBANY - 43,U.S. House,9,Trey Hollingsworth,R,161
+Floyd,NEW ALBANY - 43,U.S. House,9,Shelli Yoder,D,198
+Floyd,NEW ALBANY - 43,U.S. House,9,Russell Brooksbank,L,15
+Floyd,NEW ALBANY - 43,U.S. House,9,Write In,,0
+Floyd,NEW ALBANY - 43,State House,72,Edward D. (Ed) Clere,R,186
+Floyd,NEW ALBANY - 43,State House,72,Steve Bonifer,D,193
+Floyd,NEW ALBANY - 44,Voters,,Registered,,1095
+Floyd,NEW ALBANY - 44,Voters,,Ballots Cast,,751
+Floyd,NEW ALBANY - 44,Voters,,Straight Ticket,R,147
+Floyd,NEW ALBANY - 44,Voters,,Straight Ticket,D,128
+Floyd,NEW ALBANY - 44,Voters,,Straight Ticket,L,4
+Floyd,NEW ALBANY - 44,President,,Donald J. Trump,R,397
+Floyd,NEW ALBANY - 44,President,,Hillary Clinton,D,299
+Floyd,NEW ALBANY - 44,President,,Gary Johnson,L,34
+Floyd,NEW ALBANY - 44,President,,Write In,,11
+Floyd,NEW ALBANY - 44,U.S. Senate,,Todd Young,R,401
+Floyd,NEW ALBANY - 44,U.S. Senate,,Evan Bayh,D,315
+Floyd,NEW ALBANY - 44,U.S. Senate,,Lucy Brenton,L,18
+Floyd,NEW ALBANY - 44,U.S. Senate,,Write In,,0
+Floyd,NEW ALBANY - 44,Governor,,Eric Holcomb,R,397
+Floyd,NEW ALBANY - 44,Governor,,John R. Gregg,D,313
+Floyd,NEW ALBANY - 44,Governor,,Rex Bell,L,17
+Floyd,NEW ALBANY - 44,Governor,,Write In,,0
+Floyd,NEW ALBANY - 44,Attorney General,,"Curtis T. Hill, Jr.",R,420
+Floyd,NEW ALBANY - 44,Attorney General,,Lorenzo Arredondo,D,273
+Floyd,NEW ALBANY - 44,Superintendent of Public Instruction,,Jennifer Mccormick,R,400
+Floyd,NEW ALBANY - 44,Superintendent of Public Instruction,,Glenda Ritz,D,314
+Floyd,NEW ALBANY - 44,U.S. House,9,Trey Hollingsworth,R,364
+Floyd,NEW ALBANY - 44,U.S. House,9,Shelli Yoder,D,331
+Floyd,NEW ALBANY - 44,U.S. House,9,Russell Brooksbank,L,28
+Floyd,NEW ALBANY - 44,U.S. House,9,Write In,,0
+Floyd,NEW ALBANY - 44,State House,72,Edward D. (Ed) Clere,R,391
+Floyd,NEW ALBANY - 44,State House,72,Steve Bonifer,D,338
+Floyd,NEW ALBANY - 45,Voters,,Registered,,500
+Floyd,NEW ALBANY - 45,Voters,,Ballots Cast,,342
+Floyd,NEW ALBANY - 45,Voters,,Straight Ticket,R,88
+Floyd,NEW ALBANY - 45,Voters,,Straight Ticket,D,47
+Floyd,NEW ALBANY - 45,Voters,,Straight Ticket,L,3
+Floyd,NEW ALBANY - 45,President,,Donald J. Trump,R,195
+Floyd,NEW ALBANY - 45,President,,Hillary Clinton,D,124
+Floyd,NEW ALBANY - 45,President,,Gary Johnson,L,15
+Floyd,NEW ALBANY - 45,President,,Write In,,4
+Floyd,NEW ALBANY - 45,U.S. Senate,,Todd Young,R,182
+Floyd,NEW ALBANY - 45,U.S. Senate,,Evan Bayh,D,143
+Floyd,NEW ALBANY - 45,U.S. Senate,,Lucy Brenton,L,12
+Floyd,NEW ALBANY - 45,U.S. Senate,,Write In,,0
+Floyd,NEW ALBANY - 45,Governor,,Eric Holcomb,R,184
+Floyd,NEW ALBANY - 45,Governor,,John R. Gregg,D,140
+Floyd,NEW ALBANY - 45,Governor,,Rex Bell,L,8
+Floyd,NEW ALBANY - 45,Governor,,Write In,,0
+Floyd,NEW ALBANY - 45,Attorney General,,"Curtis T. Hill, Jr.",R,199
+Floyd,NEW ALBANY - 45,Attorney General,,Lorenzo Arredondo,D,125
+Floyd,NEW ALBANY - 45,Superintendent of Public Instruction,,Jennifer Mccormick,R,182
+Floyd,NEW ALBANY - 45,Superintendent of Public Instruction,,Glenda Ritz,D,143
+Floyd,NEW ALBANY - 45,U.S. House,9,Trey Hollingsworth,R,171
+Floyd,NEW ALBANY - 45,U.S. House,9,Shelli Yoder,D,144
+Floyd,NEW ALBANY - 45,U.S. House,9,Russell Brooksbank,L,21
+Floyd,NEW ALBANY - 45,U.S. House,9,Write In,,0
+Floyd,NEW ALBANY - 45,State House,72,Edward D. (Ed) Clere,R,188
+Floyd,NEW ALBANY - 45,State House,72,Steve Bonifer,D,143
+Floyd,NEW ALBANY - 46,Voters,,Registered,,433
+Floyd,NEW ALBANY - 46,Voters,,Ballots Cast,,342
+Floyd,NEW ALBANY - 46,Voters,,Straight Ticket,R,79
+Floyd,NEW ALBANY - 46,Voters,,Straight Ticket,D,36
+Floyd,NEW ALBANY - 46,Voters,,Straight Ticket,L,1
+Floyd,NEW ALBANY - 46,President,,Donald J. Trump,R,223
+Floyd,NEW ALBANY - 46,President,,Hillary Clinton,D,104
+Floyd,NEW ALBANY - 46,President,,Gary Johnson,L,7
+Floyd,NEW ALBANY - 46,President,,Write In,,3
+Floyd,NEW ALBANY - 46,U.S. Senate,,Todd Young,R,213
+Floyd,NEW ALBANY - 46,U.S. Senate,,Evan Bayh,D,112
+Floyd,NEW ALBANY - 46,U.S. Senate,,Lucy Brenton,L,10
+Floyd,NEW ALBANY - 46,U.S. Senate,,Write In,,0
+Floyd,NEW ALBANY - 46,Governor,,Eric Holcomb,R,224
+Floyd,NEW ALBANY - 46,Governor,,John R. Gregg,D,103
+Floyd,NEW ALBANY - 46,Governor,,Rex Bell,L,4
+Floyd,NEW ALBANY - 46,Governor,,Write In,,0
+Floyd,NEW ALBANY - 46,Attorney General,,"Curtis T. Hill, Jr.",R,229
+Floyd,NEW ALBANY - 46,Attorney General,,Lorenzo Arredondo,D,89
+Floyd,NEW ALBANY - 46,Superintendent of Public Instruction,,Jennifer Mccormick,R,212
+Floyd,NEW ALBANY - 46,Superintendent of Public Instruction,,Glenda Ritz,D,112
+Floyd,NEW ALBANY - 46,U.S. House,9,Trey Hollingsworth,R,214
+Floyd,NEW ALBANY - 46,U.S. House,9,Shelli Yoder,D,119
+Floyd,NEW ALBANY - 46,U.S. House,9,Russell Brooksbank,L,3
+Floyd,NEW ALBANY - 46,U.S. House,9,Write In,,0
+Floyd,NEW ALBANY - 46,State House,72,Edward D. (Ed) Clere,R,232
+Floyd,NEW ALBANY - 46,State House,72,Steve Bonifer,D,104
+Floyd,Total,Governor,,Eric Holcomb,R,20783
+Floyd,Total,Governor,,John R. Gregg,D,15176
+Floyd,Total,Governor,,Rex Bell,L,1042
+Floyd,Total,Governor,,Write In,,0
+Floyd,Total,President,,Donald J. Trump,R,21432
+Floyd,Total,President,,Gary Johnson,L,1861
+Floyd,Total,President,,Hillary Clinton,D,13945
+Floyd,Total,President,,Write In,,197
+Floyd,Total,U.S. Senate,,Evan Bayh,D,15504
+Floyd,Total,U.S. Senate,,Lucy Brenton,L,1349
+Floyd,Total,U.S. Senate,,Todd Young,R,20735
+Floyd,Total,U.S. Senate,,Write In,,0
+Floyd,Total,Attorney General,,"Curtis T. Hill, Jr.",R,22182
+Floyd,Total,Attorney General,,Lorenzo Arredondo,D,13558
+Floyd,Total,Superintendent of Public Instruction,,Glenda Ritz,D,15519
+Floyd,Total,Superintendent of Public Instruction,,Jennifer Mccormick,R,20550
+Floyd,Total,U.S. House,9,Russell Brooksbank,L,1737
+Floyd,Total,U.S. House,9,Shelli Yoder,D,16004
+Floyd,Total,U.S. House,9,Trey Hollingsworth,R,19411
+Floyd,Total,State House,70,Heidi Cade Sellers,D,1796
+Floyd,Total,State House,70,Karen Engleman,R,3496
+Floyd,Total,State House,72,Edward D. (Ed) Clere,R,18092
+Floyd,Total,State House,72,Steve Bonifer,D,13511
+Floyd,Total,Voters,,Ballots Cast,,38266
+Floyd,Total,Voters,,Registered,,61175


### PR DESCRIPTION
Totals are as specified in the summaries at the start of FLOYD-1.pdf, specifically using the AMENDED section where necessary.

Note that simple summation over the all the precincts leads to total vote counts that are different by a few votes (usually less than 10) than the summaries.