### PR TITLE
Add 2016 general election precinct-level results for Carroll county. 

### DIFF
--- a/2016/20161108__in__general__carroll__precinct.csv
+++ b/2016/20161108__in__general__carroll__precinct.csv
@@ -1,1 +1,589 @@
-county,precinct,office,district,candidate,party,voteCarroll,Adams,President,,Donald Trump,REP,186Carroll,Burlington,President,,Donald Trump,REP,671Carroll,Carrollton,President,,Donald Trump,REP,247Carroll,Clay,President,,Donald Trump,REP,320Carroll,Deer  Creek  1,President,,Donald Trump,REP,555Carroll,Deer  Creek  3,President,,Donald Trump,REP,366Carroll,Deer  Creek  5,President,,Donald Trump,REP,344Carroll,Democrat,President,,Donald Trump,REP,326Carroll,Jackson,President,,Donald Trump,REP,408Carroll,Jefferson 1,President,,Donald Trump,REP,432Carroll,Jefferson 2,President,,Donald Trump,REP,315Carroll,Liberty,President,,Donald Trump,REP,162Carroll,Madison,President,,Donald Trump,REP,145Carroll,Monroe 1,President,,Donald Trump,REP,349Carroll,Monroe 2,President,,Donald Trump,REP,463Carroll,Rock  Creek,President,,Donald Trump,REP,120Carroll,Tippecanoe  1,President,,Donald Trump,REP,350Carroll,Tippecanoe  2,President,,Donald Trump,REP,309Carroll,Washington,President,,Donald Trump,REP,205Carroll,Total,President,,Donald Trump,REP,6273Carroll,Adams,President,,Hillary Clinton,DEM,47Carroll,Burlington,President,,Hillary Clinton,DEM,140Carroll,Carrollton,President,,Hillary Clinton,DEM,42Carroll,Clay,President,,Hillary Clinton,DEM,98Carroll,Deer  Creek  1,President,,Hillary Clinton,DEM,164Carroll,Deer  Creek  3,President,,Hillary Clinton,DEM,138Carroll,Deer  Creek  5,President,,Hillary Clinton,DEM,170Carroll,Democrat,President,,Hillary Clinton,DEM,87Carroll,Jackson,President,,Hillary Clinton,DEM,112Carroll,Jefferson 1,President,,Hillary Clinton,DEM,130Carroll,Jefferson 2,President,,Hillary Clinton,DEM,96Carroll,Liberty,President,,Hillary Clinton,DEM,39Carroll,Madison,President,,Hillary Clinton,DEM,44Carroll,Monroe 1,President,,Hillary Clinton,DEM,92Carroll,Monroe 2,President,,Hillary Clinton,DEM,131Carroll,Rock  Creek,President,,Hillary Clinton,DEM,39Carroll,Tippecanoe  1,President,,Hillary Clinton,DEM,135Carroll,Tippecanoe  2,President,,Hillary Clinton,DEM,139Carroll,Washington,President,,Hillary Clinton,DEM,49Carroll,Total,President,,Hillary Clinton,DEM,1892Carroll,Adams,President,,Gary Johnson,LBT,10Carroll,Burlington,President,,Gary Johnson,LBT,45Carroll,Carrollton,President,,Gary Johnson,LBT,14Carroll,Clay,President,,Gary Johnson,LBT,25Carroll,Deer  Creek  1,President,,Gary Johnson,LBT,38Carroll,Deer  Creek  3,President,,Gary Johnson,LBT,22Carroll,Deer  Creek  5,President,,Gary Johnson,LBT,30Carroll,Democrat,President,,Gary Johnson,LBT,17Carroll,Jackson,President,,Gary Johnson,LBT,28Carroll,Jefferson 1,President,,Gary Johnson,LBT,33Carroll,Jefferson 2,President,,Gary Johnson,LBT,27Carroll,Liberty,President,,Gary Johnson,LBT,6Carroll,Madison,President,,Gary Johnson,LBT,13Carroll,Monroe 1,President,,Gary Johnson,LBT,21Carroll,Monroe 2,President,,Gary Johnson,LBT,30Carroll,Rock  Creek,President,,Gary Johnson,LBT,12Carroll,Tippecanoe  1,President,,Gary Johnson,LBT,29Carroll,Tippecanoe  2,President,,Gary Johnson,LBT,28Carroll,Washington,President,,Gary Johnson,LBT,17Carroll,Total,President,,Gary Johnson,LBT,445Carroll,Adams,President,,Write-ins,,1Carroll,Burlington,President,,Write-ins,,12Carroll,Carrollton,President,,Write-ins,,1Carroll,Clay,President,,Write-ins,,9Carroll,Deer  Creek  1,President,,Write-ins,,7Carroll,Deer  Creek  3,President,,Write-ins,,8Carroll,Deer  Creek  5,President,,Write-ins,,5Carroll,Democrat,President,,Write-ins,,7Carroll,Jackson,President,,Write-ins,,8Carroll,Jefferson 1,President,,Write-ins,,2Carroll,Jefferson 2,President,,Write-ins,,5Carroll,Liberty,President,,Write-ins,,2Carroll,Madison,President,,Write-ins,,0Carroll,Monroe 1,President,,Write-ins,,5Carroll,Monroe 2,President,,Write-ins,,10Carroll,Rock  Creek,President,,Write-ins,,1Carroll,Tippecanoe  1,President,,Write-ins,,4Carroll,Tippecanoe  2,President,,Write-ins,,3Carroll,Washington,President,,Write-ins,,1Carroll,Total,President,,Write-ins,,91Carroll,Adams,U.S. Senate,,Todd Young,REP,167Carroll,Burlington,U.S. Senate,,Todd Young,REP,599Carroll,Carrollton,U.S. Senate,,Todd Young,REP,210Carroll,Clay,U.S. Senate,,Todd Young,REP,279Carroll,Deer  Creek  1,U.S. Senate,,Todd Young,REP,482Carroll,Deer  Creek  3,U.S. Senate,,Todd Young,REP,310Carroll,Deer  Creek  5,U.S. Senate,,Todd Young,REP,301Carroll,Democrat,U.S. Senate,,Todd Young,REP,286Carroll,Jackson,U.S. Senate,,Todd Young,REP,359Carroll,Jefferson 1,U.S. Senate,,Todd Young,REP,389Carroll,Jefferson 2,U.S. Senate,,Todd Young,REP,285Carroll,Liberty,U.S. Senate,,Todd Young,REP,139Carroll,Madison,U.S. Senate,,Todd Young,REP,126Carroll,Monroe 1,U.S. Senate,,Todd Young,REP,300Carroll,Monroe 2,U.S. Senate,,Todd Young,REP,406Carroll,Rock  Creek,U.S. Senate,,Todd Young,REP,94Carroll,Tippecanoe  1,U.S. Senate,,Todd Young,REP,313Carroll,Tippecanoe  2,U.S. Senate,,Todd Young,REP,283Carroll,Washington,U.S. Senate,,Todd Young,REP,184Carroll,Total,U.S. Senate,,Todd Young,REP,5512Carroll,Adams,U.S. Senate,,Evan Bayh,DEM,61Carroll,Burlington,U.S. Senate,,Evan Bayh,DEM,203Carroll,Carrollton,U.S. Senate,,Evan Bayh,DEM,65Carroll,Clay,U.S. Senate,,Evan Bayh,DEM,137Carroll,Deer  Creek  1,U.S. Senate,,Evan Bayh,DEM,219Carroll,Deer  Creek  3,U.S. Senate,,Evan Bayh,DEM,174Carroll,Deer  Creek  5,U.S. Senate,,Evan Bayh,DEM,203Carroll,Democrat,U.S. Senate,,Evan Bayh,DEM,117Carroll,Jackson,U.S. Senate,,Evan Bayh,DEM,153Carroll,Jefferson 1,U.S. Senate,,Evan Bayh,DEM,168Carroll,Jefferson 2,U.S. Senate,,Evan Bayh,DEM,129Carroll,Liberty,U.S. Senate,,Evan Bayh,DEM,60Carroll,Madison,U.S. Senate,,Evan Bayh,DEM,58Carroll,Monroe 1,U.S. Senate,,Evan Bayh,DEM,135Carroll,Monroe 2,U.S. Senate,,Evan Bayh,DEM,188Carroll,Rock  Creek,U.S. Senate,,Evan Bayh,DEM,57Carroll,Tippecanoe  1,U.S. Senate,,Evan Bayh,DEM,165Carroll,Tippecanoe  2,U.S. Senate,,Evan Bayh,DEM,159Carroll,Washington,U.S. Senate,,Evan Bayh,DEM,71Carroll,Total,U.S. Senate,,Evan Bayh,DEM,2522Carroll,Adams,U.S. Senate,,Lucy Brenton,LBT,15Carroll,Burlington,U.S. Senate,,Lucy Brenton,LBT,65Carroll,Carrollton,U.S. Senate,,Lucy Brenton,LBT,28Carroll,Clay,U.S. Senate,,Lucy Brenton,LBT,34Carroll,Deer  Creek  1,U.S. Senate,,Lucy Brenton,LBT,61Carroll,Deer  Creek  3,U.S. Senate,,Lucy Brenton,LBT,41Carroll,Deer  Creek  5,U.S. Senate,,Lucy Brenton,LBT,41Carroll,Democrat,U.S. Senate,,Lucy Brenton,LBT,28Carroll,Jackson,U.S. Senate,,Lucy Brenton,LBT,44Carroll,Jefferson 1,U.S. Senate,,Lucy Brenton,LBT,40Carroll,Jefferson 2,U.S. Senate,,Lucy Brenton,LBT,28Carroll,Liberty,U.S. Senate,,Lucy Brenton,LBT,12Carroll,Madison,U.S. Senate,,Lucy Brenton,LBT,15Carroll,Monroe 1,U.S. Senate,,Lucy Brenton,LBT,35Carroll,Monroe 2,U.S. Senate,,Lucy Brenton,LBT,40Carroll,Rock  Creek,U.S. Senate,,Lucy Brenton,LBT,20Carroll,Tippecanoe  1,U.S. Senate,,Lucy Brenton,LBT,43Carroll,Tippecanoe  2,U.S. Senate,,Lucy Brenton,LBT,36Carroll,Washington,U.S. Senate,,Lucy Brenton,LBT,22Carroll,Total,U.S. Senate,,Lucy Brenton,LBT,648Carroll,Adams,U.S. Senate,,Write-ins,,0Carroll,Burlington,U.S. Senate,,Write-ins,,0Carroll,Carrollton,U.S. Senate,,Write-ins,,0Carroll,Clay,U.S. Senate,,Write-ins,,0Carroll,Deer  Creek  1,U.S. Senate,,Write-ins,,0Carroll,Deer  Creek  3,U.S. Senate,,Write-ins,,0Carroll,Deer  Creek  5,U.S. Senate,,Write-ins,,0Carroll,Democrat,U.S. Senate,,Write-ins,,1Carroll,Jackson,U.S. Senate,,Write-ins,,0Carroll,Jefferson 1,U.S. Senate,,Write-ins,,0Carroll,Jefferson 2,U.S. Senate,,Write-ins,,0Carroll,Liberty,U.S. Senate,,Write-ins,,0Carroll,Madison,U.S. Senate,,Write-ins,,0Carroll,Monroe 1,U.S. Senate,,Write-ins,,0Carroll,Monroe 2,U.S. Senate,,Write-ins,,1Carroll,Rock  Creek,U.S. Senate,,Write-ins,,0Carroll,Tippecanoe  1,U.S. Senate,,Write-ins,,0Carroll,Tippecanoe  2,U.S. Senate,,Write-ins,,0Carroll,Washington,U.S. Senate,,Write-ins,,0Carroll,Total,U.S. Senate,,Write-ins,,2Carroll,Adams,Governor,,Eric Holcomb,REP,158Carroll,Burlington,Governor,,Eric Holcomb,REP,589Carroll,Carrollton,Governor,,Eric Holcomb,REP,205Carroll,Clay,Governor,,Eric Holcomb,REP,279Carroll,Deer  Creek  1,Governor,,Eric Holcomb,REP,484Carroll,Deer  Creek  3,Governor,,Eric Holcomb,REP,305Carroll,Deer  Creek  5,Governor,,Eric Holcomb,REP,288Carroll,Democrat,Governor,,Eric Holcomb,REP,276Carroll,Jackson,Governor,,Eric Holcomb,REP,339Carroll,Jefferson 1,Governor,,Eric Holcomb,REP,379Carroll,Jefferson 2,Governor,,Eric Holcomb,REP,280Carroll,Liberty,Governor,,Eric Holcomb,REP,141Carroll,Madison,Governor,,Eric Holcomb,REP,125Carroll,Monroe 1,Governor,,Eric Holcomb,REP,292Carroll,Monroe 2,Governor,,Eric Holcomb,REP,394Carroll,Rock  Creek,Governor,,Eric Holcomb,REP,98Carroll,Tippecanoe  1,Governor,,Eric Holcomb,REP,300Carroll,Tippecanoe  2,Governor,,Eric Holcomb,REP,274Carroll,Washington,Governor,,Eric Holcomb,REP,175Carroll,Total,Governor,,Eric Holcomb,REP,5381Carroll,Adams,Governor,,John Gregg,DEM,76Carroll,Burlington,Governor,,John Gregg,DEM,249Carroll,Carrollton,Governor,,John Gregg,DEM,82Carroll,Clay,Governor,,John Gregg,DEM,152Carroll,Deer  Creek  1,Governor,,John Gregg,DEM,252Carroll,Deer  Creek  3,Governor,,John Gregg,DEM,197Carroll,Deer  Creek  5,Governor,,John Gregg,DEM,220Carroll,Democrat,Governor,,John Gregg,DEM,140Carroll,Jackson,Governor,,John Gregg,DEM,189Carroll,Jefferson 1,Governor,,John Gregg,DEM,190Carroll,Jefferson 2,Governor,,John Gregg,DEM,151Carroll,Liberty,Governor,,John Gregg,DEM,65Carroll,Madison,Governor,,John Gregg,DEM,68Carroll,Monroe 1,Governor,,John Gregg,DEM,158Carroll,Monroe 2,Governor,,John Gregg,DEM,212Carroll,Rock  Creek,Governor,,John Gregg,DEM,62Carroll,Tippecanoe  1,Governor,,John Gregg,DEM,194Carroll,Tippecanoe  2,Governor,,John Gregg,DEM,177Carroll,Washington,Governor,,John Gregg,DEM,89Carroll,Total,Governor,,John Gregg,DEM,2923Carroll,Adams,Governor,,Rex Bell,LBT,7Carroll,Burlington,Governor,,Rex Bell,LBT,29Carroll,Carrollton,Governor,,Rex Bell,LBT,15Carroll,Clay,Governor,,Rex Bell,LBT,20Carroll,Deer  Creek  1,Governor,,Rex Bell,LBT,24Carroll,Deer  Creek  3,Governor,,Rex Bell,LBT,22Carroll,Deer  Creek  5,Governor,,Rex Bell,LBT,29Carroll,Democrat,Governor,,Rex Bell,LBT,17Carroll,Jackson,Governor,,Rex Bell,LBT,26Carroll,Jefferson 1,Governor,,Rex Bell,LBT,26Carroll,Jefferson 2,Governor,,Rex Bell,LBT,12Carroll,Liberty,Governor,,Rex Bell,LBT,5Carroll,Madison,Governor,,Rex Bell,LBT,5Carroll,Monroe 1,Governor,,Rex Bell,LBT,20Carroll,Monroe 2,Governor,,Rex Bell,LBT,28Carroll,Rock  Creek,Governor,,Rex Bell,LBT,10Carroll,Tippecanoe  1,Governor,,Rex Bell,LBT,24Carroll,Tippecanoe  2,Governor,,Rex Bell,LBT,24Carroll,Washington,Governor,,Rex Bell,LBT,10Carroll,Total,Governor,,Rex Bell,LBT,353Carroll,Adams,Governor,,Write-ins,,0Carroll,Burlington,Governor,,Write-ins,,0Carroll,Carrollton,Governor,,Write-ins,,0Carroll,Clay,Governor,,Write-ins,,0Carroll,Deer  Creek  1,Governor,,Write-ins,,0Carroll,Deer  Creek  3,Governor,,Write-ins,,0Carroll,Deer  Creek  5,Governor,,Write-ins,,0Carroll,Democrat,Governor,,Write-ins,,0Carroll,Jackson,Governor,,Write-ins,,1Carroll,Jefferson 1,Governor,,Write-ins,,0Carroll,Jefferson 2,Governor,,Write-ins,,1Carroll,Liberty,Governor,,Write-ins,,0Carroll,Madison,Governor,,Write-ins,,0Carroll,Monroe 1,Governor,,Write-ins,,0Carroll,Monroe 2,Governor,,Write-ins,,0Carroll,Rock  Creek,Governor,,Write-ins,,0Carroll,Tippecanoe  1,Governor,,Write-ins,,0Carroll,Tippecanoe  2,Governor,,Write-ins,,0Carroll,Washington,Governor,,Write-ins,,0Carroll,Total,Governor,,Write-ins,,2Carroll,Adams,Attorney General,,Curtis Hill,REP,184Carroll,Burlington,Attorney General,,Curtis Hill,REP,697Carroll,Carrollton,Attorney General,,Curtis Hill,REP,256Carroll,Clay,Attorney General,,Curtis Hill,REP,338Carroll,Deer  Creek  1,Attorney General,,Curtis Hill,REP,566Carroll,Deer  Creek  3,Attorney General,,Curtis Hill,REP,375Carroll,Deer  Creek  5,Attorney General,,Curtis Hill,REP,357Carroll,Democrat,Attorney General,,Curtis Hill,REP,325Carroll,Jackson,Attorney General,,Curtis Hill,REP,426Carroll,Jefferson 1,Attorney General,,Curtis Hill,REP,444Carroll,Jefferson 2,Attorney General,,Curtis Hill,REP,330Carroll,Liberty,Attorney General,,Curtis Hill,REP,169Carroll,Madison,Attorney General,,Curtis Hill,REP,156Carroll,Monroe 1,Attorney General,,Curtis Hill,REP,347Carroll,Monroe 2,Attorney General,,Curtis Hill,REP,490Carroll,Rock  Creek,Attorney General,,Curtis Hill,REP,124Carroll,Tippecanoe  1,Attorney General,,Curtis Hill,REP,362Carroll,Tippecanoe  2,Attorney General,,Curtis Hill,REP,328Carroll,Washington,Attorney General,,Curtis Hill,REP,219Carroll,Total,Attorney General,,Curtis Hill,REP,6493Carroll,Adams,Attorney General,,Lorenzo Arredondo,DEM,51Carroll,Burlington,Attorney General,,Lorenzo Arredondo,DEM,155Carroll,Carrollton,Attorney General,,Lorenzo Arredondo,DEM,42Carroll,Clay,Attorney General,,Lorenzo Arredondo,DEM,105Carroll,Deer  Creek  1,Attorney General,,Lorenzo Arredondo,DEM,170Carroll,Deer  Creek  3,Attorney General,,Lorenzo Arredondo,DEM,130Carroll,Deer  Creek  5,Attorney General,,Lorenzo Arredondo,DEM,162Carroll,Democrat,Attorney General,,Lorenzo Arredondo,DEM,93Carroll,Jackson,Attorney General,,Lorenzo Arredondo,DEM,112Carroll,Jefferson 1,Attorney General,,Lorenzo Arredondo,DEM,137Carroll,Jefferson 2,Attorney General,,Lorenzo Arredondo,DEM,97Carroll,Liberty,Attorney General,,Lorenzo Arredondo,DEM,39Carroll,Madison,Attorney General,,Lorenzo Arredondo,DEM,38Carroll,Monroe 1,Attorney General,,Lorenzo Arredondo,DEM,104Carroll,Monroe 2,Attorney General,,Lorenzo Arredondo,DEM,125Carroll,Rock  Creek,Attorney General,,Lorenzo Arredondo,DEM,42Carroll,Tippecanoe  1,Attorney General,,Lorenzo Arredondo,DEM,141Carroll,Tippecanoe  2,Attorney General,,Lorenzo Arredondo,DEM,140Carroll,Washington,Attorney General,,Lorenzo Arredondo,DEM,50Carroll,Total,Attorney General,,Lorenzo Arredondo,DEM,1933Carroll,Adams,Public Instruction,,Jennifer McCormick,REP,149Carroll,Burlington,Public Instruction,,Jennifer McCormick,REP,581Carroll,Carrollton,Public Instruction,,Jennifer McCormick,REP,191Carroll,Clay,Public Instruction,,Jennifer McCormick,REP,275Carroll,Deer  Creek  1,Public Instruction,,Jennifer McCormick,REP,486Carroll,Deer  Creek  3,Public Instruction,,Jennifer McCormick,REP,301Carroll,Deer  Creek  5,Public Instruction,,Jennifer McCormick,REP,317Carroll,Democrat,Public Instruction,,Jennifer McCormick,REP,261Carroll,Jackson,Public Instruction,,Jennifer McCormick,REP,310Carroll,Jefferson 1,Public Instruction,,Jennifer McCormick,REP,374Carroll,Jefferson 2,Public Instruction,,Jennifer McCormick,REP,277Carroll,Liberty,Public Instruction,,Jennifer McCormick,REP,134Carroll,Madison,Public Instruction,,Jennifer McCormick,REP,125Carroll,Monroe 1,Public Instruction,,Jennifer McCormick,REP,285Carroll,Monroe 2,Public Instruction,,Jennifer McCormick,REP,408Carroll,Rock  Creek,Public Instruction,,Jennifer McCormick,REP,90Carroll,Tippecanoe  1,Public Instruction,,Jennifer McCormick,REP,315Carroll,Tippecanoe  2,Public Instruction,,Jennifer McCormick,REP,264Carroll,Washington,Public Instruction,,Jennifer McCormick,REP,174Carroll,Total,Public Instruction,,Jennifer McCormick,REP,5317Carroll,Adams,Public Instruction,,Glenda Ritz,DEM,92Carroll,Burlington,Public Instruction,,Glenda Ritz,DEM,276Carroll,Carrollton,Public Instruction,,Glenda Ritz,DEM,105Carroll,Clay,Public Instruction,,Glenda Ritz,DEM,176Carroll,Deer  Creek  1,Public Instruction,,Glenda Ritz,DEM,265Carroll,Deer  Creek  3,Public Instruction,,Glenda Ritz,DEM,212Carroll,Deer  Creek  5,Public Instruction,,Glenda Ritz,DEM,212Carroll,Democrat,Public Instruction,,Glenda Ritz,DEM,164Carroll,Jackson,Public Instruction,,Glenda Ritz,DEM,237Carroll,Jefferson 1,Public Instruction,,Glenda Ritz,DEM,213Carroll,Jefferson 2,Public Instruction,,Glenda Ritz,DEM,158Carroll,Liberty,Public Instruction,,Glenda Ritz,DEM,76Carroll,Madison,Public Instruction,,Glenda Ritz,DEM,73Carroll,Monroe 1,Public Instruction,,Glenda Ritz,DEM,176Carroll,Monroe 2,Public Instruction,,Glenda Ritz,DEM,219Carroll,Rock  Creek,Public Instruction,,Glenda Ritz,DEM,78Carroll,Tippecanoe  1,Public Instruction,,Glenda Ritz,DEM,197Carroll,Tippecanoe  2,Public Instruction,,Glenda Ritz,DEM,211Carroll,Washington,Public Instruction,,Glenda Ritz,DEM,98Carroll,Total,Public Instruction,,Glenda Ritz,DEM,3238Carroll,Adams,U.S. House,4,Todd Rokita,R,304Carroll,Burlington,U.S. House,4,Todd Rokita,R,255Carroll,Carrollton,U.S. House,4,Todd Rokita,R,14Carroll,Clay,U.S. House,4,Todd Rokita,R,346Carroll,Deer  Creek  1,U.S. House,4,Todd Rokita,R,425Carroll,Deer  Creek  3,U.S. House,4,Todd Rokita,R,373Carroll,Deer  Creek  5,U.S. House,4,Todd Rokita,R,300Carroll,Democrat,U.S. House,4,Todd Rokita,R,294Carroll,Jackson,U.S. House,4,Todd Rokita,R,461Carroll,Jefferson 1,U.S. House,4,Todd Rokita,R,144Carroll,Jefferson 2,U.S. House,4,Todd Rokita,R,94Carroll,Liberty,U.S. House,4,Todd Rokita,R,154Carroll,Madison,U.S. House,4,Todd Rokita,R,149Carroll,Monroe 1,U.S. House,4,Todd Rokita,R,340Carroll,Monroe 2,U.S. House,4,Todd Rokita,R,460Carroll,Rock  Creek,U.S. House,4,Todd Rokita,R,106Carroll,Tippecanoe  1,U.S. House,4,Todd Rokita,R,344Carroll,Tippecanoe  2,U.S. House,4,Todd Rokita,R,303Carroll,Washington,U.S. House,4,Todd Rokita,R,205Carroll,Total,U.S. House,4,Todd Rokita,R,6113Carroll,Adams,U.S. House,4,John Dale,DEM,160Carroll,Burlington,U.S. House,4,John Dale,DEM,105Carroll,Carrollton,U.S. House,4,John Dale,DEM,16Carroll,Clay,U.S. House,4,John Dale,DEM,112Carroll,Deer  Creek  1,U.S. House,4,John Dale,DEM,188Carroll,Deer  Creek  3,U.S. House,4,John Dale,DEM,158Carroll,Deer  Creek  5,U.S. House,4,John Dale,DEM,129Carroll,Democrat,U.S. House,4,John Dale,DEM,127Carroll,Jackson,U.S. House,4,John Dale,DEM,181Carroll,Jefferson 1,U.S. House,4,John Dale,DEM,44Carroll,Jefferson 2,U.S. House,4,John Dale,DEM,18Carroll,Liberty,U.S. House,4,John Dale,DEM,48Carroll,Madison,U.S. House,4,John Dale,DEM,41Carroll,Monroe 1,U.S. House,4,John Dale,DEM,102Carroll,Monroe 2,U.S. House,4,John Dale,DEM,129Carroll,Rock  Creek,U.S. House,4,John Dale,DEM,53Carroll,Tippecanoe  1,U.S. House,4,John Dale,DEM,142Carroll,Tippecanoe  2,U.S. House,4,John Dale,DEM,145Carroll,Washington,U.S. House,4,John Dale,DEM,56Carroll,Total,U.S. House,4,John Dale,DEM,2027Carroll,Adams,U.S. House,4,Steven Mayoras,LBT,41Carroll,Burlington,U.S. House,4,Steven Mayoras,LBT,18Carroll,Carrollton,U.S. House,4,Steven Mayoras,LBT,1Carroll,Clay,U.S. House,4,Steven Mayoras,LBT,26Carroll,Deer  Creek  1,U.S. House,4,Steven Mayoras,LBT,32Carroll,Deer  Creek  3,U.S. House,4,Steven Mayoras,LBT,46Carroll,Deer  Creek  5,U.S. House,4,Steven Mayoras,LBT,38Carroll,Democrat,U.S. House,4,Steven Mayoras,LBT,28Carroll,Jackson,U.S. House,4,Steven Mayoras,LBT,31Carroll,Jefferson 1,U.S. House,4,Steven Mayoras,LBT,12Carroll,Jefferson 2,U.S. House,4,Steven Mayoras,LBT,4Carroll,Liberty,U.S. House,4,Steven Mayoras,LBT,6Carroll,Madison,U.S. House,4,Steven Mayoras,LBT,8Carroll,Monroe 1,U.S. House,4,Steven Mayoras,LBT,23Carroll,Monroe 2,U.S. House,4,Steven Mayoras,LBT,33Carroll,Rock  Creek,U.S. House,4,Steven Mayoras,LBT,12Carroll,Tippecanoe  1,U.S. House,4,Steven Mayoras,LBT,27Carroll,Tippecanoe  2,U.S. House,4,Steven Mayoras,LBT,26Carroll,Washington,U.S. House,4,Steven Mayoras,LBT,12Carroll,Total,U.S. House,4,Steven Mayoras,LBT,452Carroll,Adams,U.S. House,4,Write-ins,,0Carroll,Burlington,U.S. House,4,Write-ins,,0Carroll,Carrollton,U.S. House,4,Write-ins,,1Carroll,Clay,U.S. House,4,Write-ins,,1Carroll,Deer  Creek  1,U.S. House,4,Write-ins,,0Carroll,Deer  Creek  3,U.S. House,4,Write-ins,,0Carroll,Deer  Creek  5,U.S. House,4,Write-ins,,0Carroll,Democrat,U.S. House,4,Write-ins,,0Carroll,Jackson,U.S. House,4,Write-ins,,0Carroll,Jefferson 1,U.S. House,4,Write-ins,,0Carroll,Jefferson 2,U.S. House,4,Write-ins,,0Carroll,Liberty,U.S. House,4,Write-ins,,0Carroll,Madison,U.S. House,4,Write-ins,,0Carroll,Monroe 1,U.S. House,4,Write-ins,,0Carroll,Monroe 2,U.S. House,4,Write-ins,,0Carroll,Rock  Creek,U.S. House,4,Write-ins,,0Carroll,Tippecanoe  1,U.S. House,4,Write-ins,,0Carroll,Tippecanoe  2,U.S. House,4,Write-ins,,0Carroll,Washington,U.S. House,4,Write-ins,,0Carroll,Total,U.S. House,4,Write-ins,,2Carroll,Adams,State Senate,18,Randall Head,REP,189Carroll,Burlington,State Senate,7,Brandt Hershman,REP,687Carroll,Carrollton,State Senate,18,Randall Head,REP,244Carroll,Clay,State Senate,7,Brandt Hershman,REP,338Carroll,Deer  Creek  1,State Senate,7,Brandt Hershman,REP,587Carroll,Deer  Creek  3,State Senate,7,Brandt Hershman,REP,386Carroll,Deer  Creek  5,State Senate,7,Brandt Hershman,REP,366Carroll,Democrat,State Senate,7,Brandt Hershman,REP,318Carroll,Jackson,State Senate,18,Randall Head,REP,415Carroll,Jefferson 1,State Senate,7,Brandt Hershman,REP,447Carroll,Jefferson 2,State Senate,7,Brandt Hershman,REP,333Carroll,Liberty,State Senate,18,Randall Head,REP,169Carroll,Madison,State Senate,7,Brandt Hershman,REP,158Carroll,Monroe 1,State Senate,18,Randall Head,REP,362Carroll,Monroe 2,State Senate,18,Randall Head,REP,500Carroll,Rock  Creek,State Senate,18,Randall Head,REP,120Carroll,Tippecanoe  1,State Senate,7,Brandt Hershman,REP,374Carroll,Tippecanoe  2,State Senate,7,Brandt Hershman,REP,333Carroll,Washington,State Senate,18,Randall Head,REP,220Carroll,Total,State Senate,7,Brandt Hershman,REP,4327Carroll,Total,State Senate,18,Randall Head,REP,2219Carroll,Burlington,State Senate,7,Justin Notoras,DEM,171Carroll,Clay,State Senate,7,Justin Notoras,DEM,107Carroll,Deer  Creek  1,State Senate,7,Justin Notoras,DEM,164Carroll,Deer  Creek  3,State Senate,7,Justin Notoras,DEM,129Carroll,Deer  Creek  5,State Senate,7,Justin Notoras,DEM,164Carroll,Democrat,State Senate,7,Justin Notoras,DEM,106Carroll,Jefferson 1,State Senate,7,Justin Notoras,DEM,145Carroll,Jefferson 2,State Senate,7,Justin Notoras,DEM,97Carroll,Madison,State Senate,7,Justin Notoras,DEM,37Carroll,Tippecanoe  1,State Senate,7,Justin Notoras,DEM,136Carroll,Tippecanoe  2,State Senate,7,Justin Notoras,DEM,141Carroll,Total,State Senate,7,Justin Notoras,DEM,1397Carroll,Adams,State House,25,Donald Lehe,REP,184Carroll,Burlington,State Senate,38,Heath Van Natter,REP,598Carroll,Carrollton,State Senate,38,Heath Van Natter,REP,186Carroll,Clay,State Senate,25,Donald Lehe,REP,321Carroll,Deer  Creek  1,State Senate,25,Donald Lehe,REP,560Carroll,Deer  Creek  3,State Senate,25,Donald Lehe,REP,362Carroll,Deer  Creek  5,State Senate,25,Donald Lehe,REP,350Carroll,Democrat,State Senate,38,Heath Van Natter,REP,263Carroll,Jackson,State Senate,38,Heath Van Natter,REP,338Carroll,Jefferson 1,State Senate,25,Donald Lehe,REP,423Carroll,Jefferson 2,State Senate,25,Donald Lehe,REP,326Carroll,Liberty,State Senate,25,Donald Lehe,REP,155Carroll,Madison,State Senate,25,Donald Lehe,REP,159Carroll,Monroe 1,State Senate,38,Heath Van Natter,REP,237Carroll,Monroe 2,State Senate,38,Heath Van Natter,REP,325Carroll,Rock  Creek,State Senate,25,Donald Lehe,REP,108Carroll,Tippecanoe  1,State Senate,25,Donald Lehe,REP,345Carroll,Tippecanoe  2,State Senate,25,Donald Lehe,REP,314Carroll,Washington,State Senate,38,Heath Van Natter,REP,177Carroll,Total,State Senate,25,Donald Lehe,REP,3607Carroll,Total,State Senate,38,Heath Van Natter,REP,2124Carroll,Adams,State House,25,Maurice Fuller,DEM,47Carroll,Clay,State Senate,25,Maurice Fuller,DEM,98Carroll,Deer  Creek  1,State Senate,25,Maurice Fuller,DEM,148Carroll,Deer  Creek  3,State Senate,25,Maurice Fuller,DEM,118Carroll,Deer  Creek  5,State Senate,25,Maurice Fuller,DEM,137Carroll,Jefferson 1,State Senate,25,Maurice Fuller,DEM,125Carroll,Jefferson 2,State Senate,25,Maurice Fuller,DEM,92Carroll,Liberty,State Senate,25,Maurice Fuller,DEM,34Carroll,Madison,State Senate,25,Maurice Fuller,DEM,33Carroll,Rock  Creek,State Senate,25,Maurice Fuller,DEM,40Carroll,Tippecanoe  1,State Senate,25,Maurice Fuller,DEM,134Carroll,Tippecanoe  2,State Senate,25,Maurice Fuller,DEM,117Carroll,Total,State Senate,25,Maurice Fuller,DEM,1120Carroll,Adams,State House,25,Franklyn Voorhies,LBT,7Carroll,Burlington,State Senate,38,Jason Burns,IND,239Carroll,Carrollton,State Senate,38,Jason Burns,IND,107Carroll,Clay,State Senate,25,Franklyn Voorhies,LBT,28Carroll,Deer  Creek  1,State Senate,25,Franklyn Voorhies,LBT,45Carroll,Deer  Creek  3,State Senate,25,Franklyn Voorhies,LBT,29Carroll,Deer  Creek  5,State Senate,25,Franklyn Voorhies,LBT,44Carroll,Democrat,State Senate,38,Jason Burns,IND,154Carroll,Jackson,State Senate,38,Jason Burns,IND,171Carroll,Jefferson 1,State Senate,25,Franklyn Voorhies,LBT,40Carroll,Jefferson 2,State Senate,25,Franklyn Voorhies,LBT,17Carroll,Liberty,State Senate,25,Franklyn Voorhies,LBT,13Carroll,Madison,State Senate,25,Franklyn Voorhies,LBT,7Carroll,Monroe 1,State Senate,38,Jason Burns,IND,210Carroll,Monroe 2,State Senate,38,Jason Burns,IND,280Carroll,Rock  Creek,State Senate,25,Franklyn Voorhies,LBT,20Carroll,Tippecanoe  1,State Senate,25,Franklyn Voorhies,LBT,36Carroll,Tippecanoe  2,State Senate,25,Franklyn Voorhies,LBT,38Carroll,Washington,State Senate,38,Jason Burns,IND,73Carroll,Total,State Senate,25,Franklyn Voorhies,LBT,324Carroll,Total,State Senate,38,Jason Burns,IND,1234
+county,precinct,office,district,candidate,party,votes
+Carroll,Adams,Voters,,Registered,,373
+Carroll,Adams,Voters,,Ballots Cast,,250
+Carroll,Adams,Voters,,Straight Ticket,D,31
+Carroll,Adams,Voters,,Straight Ticket,L,1
+Carroll,Adams,Voters,,Straight Ticket,R,101
+Carroll,Adams,President,,Donald J. Trump,R,186
+Carroll,Adams,President,,Hillary Clinton,D,47
+Carroll,Adams,President,,Gary Johnson,L,10
+Carroll,Adams,President,,Write-In,,1
+Carroll,Adams,U.S. Senate,,Todd Young,R,167
+Carroll,Adams,U.S. Senate,,Evan Bayh,D,61
+Carroll,Adams,U.S. Senate,,Lucy Brenton,L,15
+Carroll,Adams,U.S. Senate,,Write-In,,0
+Carroll,Adams,Governor,,Eric Holcomb,R,158
+Carroll,Adams,Governor,,John R. Gregg,D,76
+Carroll,Adams,Governor,,Rex Bell,L,7
+Carroll,Adams,Governor,,Write-in,,0
+Carroll,Adams,Attorney General,,"Curtis T. Hill, Jr.",R,184
+Carroll,Adams,Attorney General,,Lorenzo Arredondo,D,51
+Carroll,Adams,Superintendent of Public Instruction,,Jennifer McCormick,R,149
+Carroll,Adams,Superintendent of Public Instruction,,Glenda Ritz,D,92
+Carroll,Adams,U.S. House,4,Todd Rokita,R,181
+Carroll,Adams,U.S. House,4,John Dale,D,48
+Carroll,Adams,U.S. House,4,Steven M. Mayoras,L,12
+Carroll,Adams,U.S. House,4,Write-in,,0
+Carroll,Adams,State Senate,18,Randall Head,R,189
+Carroll,Adams,State House,25,Donald J. Lehe,R,184
+Carroll,Adams,State House,25,Maurice O. Fuller,D,47
+Carroll,Adams,State House,25,Franklyn Voorhies,L,7
+Carroll,Burlington,Voters,,Registered,,1286
+Carroll,Burlington,Voters,,Ballots Cast,,886
+Carroll,Burlington,Voters,,Straight Ticket,D,71
+Carroll,Burlington,Voters,,Straight Ticket,L,13
+Carroll,Burlington,Voters,,Straight Ticket,R,331
+Carroll,Burlington,President,,Donald J. Trump,R,671
+Carroll,Burlington,President,,Hillary Clinton,D,140
+Carroll,Burlington,President,,Gary Johnson,L,45
+Carroll,Burlington,President,,Write-In,,12
+Carroll,Burlington,U.S. Senate,,Todd Young,R,599
+Carroll,Burlington,U.S. Senate,,Evan Bayh,D,203
+Carroll,Burlington,U.S. Senate,,Lucy Brenton,L,65
+Carroll,Burlington,U.S. Senate,,Write-In,,0
+Carroll,Burlington,Governor,,Eric Holcomb,R,589
+Carroll,Burlington,Governor,,John R. Gregg,D,249
+Carroll,Burlington,Governor,,Rex Bell,L,29
+Carroll,Burlington,Governor,,Write-in,,0
+Carroll,Burlington,Attorney General,,"Curtis T. Hill, Jr.",R,697
+Carroll,Burlington,Attorney General,,Lorenzo Arredondo,D,155
+Carroll,Burlington,Superintendent of Public Instruction,,Jennifer McCormick,R,581
+Carroll,Burlington,Superintendent of Public Instruction,,Glenda Ritz,D,276
+Carroll,Burlington,U.S. House,4,Todd Rokita,R,655
+Carroll,Burlington,U.S. House,4,John Dale,D,170
+Carroll,Burlington,U.S. House,4,Steven M. Mayoras,L,39
+Carroll,Burlington,U.S. House,4,Write-in,,0
+Carroll,Burlington,State Senate,7,Brandt Hershman,R,687
+Carroll,Burlington,State Senate,7,Justin Notoras,D,171
+Carroll,Burlington,State House,38,Heath VanNatter,R,598
+Carroll,Burlington,State House,38,Jason Scott Burns,I,239
+Carroll,Carrollton,Voters,,Registered,,441
+Carroll,Carrollton,Voters,,Ballots Cast,,309
+Carroll,Carrollton,Voters,,Straight Ticket,D,17
+Carroll,Carrollton,Voters,,Straight Ticket,L,3
+Carroll,Carrollton,Voters,,Straight Ticket,R,111
+Carroll,Carrollton,President,,Donald J. Trump,R,247
+Carroll,Carrollton,President,,Hillary Clinton,D,42
+Carroll,Carrollton,President,,Gary Johnson,L,14
+Carroll,Carrollton,President,,Write-In,,1
+Carroll,Carrollton,U.S. Senate,,Todd Young,R,210
+Carroll,Carrollton,U.S. Senate,,Evan Bayh,D,65
+Carroll,Carrollton,U.S. Senate,,Lucy Brenton,L,28
+Carroll,Carrollton,U.S. Senate,,Write-In,,0
+Carroll,Carrollton,Governor,,Eric Holcomb,R,205
+Carroll,Carrollton,Governor,,John R. Gregg,D,82
+Carroll,Carrollton,Governor,,Rex Bell,L,15
+Carroll,Carrollton,Governor,,Write-in,,0
+Carroll,Carrollton,Attorney General,,"Curtis T. Hill, Jr.",R,256
+Carroll,Carrollton,Attorney General,,Lorenzo Arredondo,D,42
+Carroll,Carrollton,Superintendent of Public Instruction,,Jennifer McCormick,R,191
+Carroll,Carrollton,Superintendent of Public Instruction,,Glenda Ritz,D,105
+Carroll,Carrollton,U.S. House,4,Todd Rokita,R,232
+Carroll,Carrollton,U.S. House,4,John Dale,D,50
+Carroll,Carrollton,U.S. House,4,Steven M. Mayoras,L,15
+Carroll,Carrollton,U.S. House,4,Write-in,,1
+Carroll,Carrollton,State Senate,18,Randall Head,R,244
+Carroll,Carrollton,State House,38,Heath VanNatter,R,186
+Carroll,Carrollton,State House,38,Jason Scott Burns,I,107
+Carroll,Clay,Voters,,Registered,,721
+Carroll,Clay,Voters,,Ballots Cast,,463
+Carroll,Clay,Voters,,Straight Ticket,D,37
+Carroll,Clay,Voters,,Straight Ticket,L,5
+Carroll,Clay,Voters,,Straight Ticket,R,156
+Carroll,Clay,President,,Donald J. Trump,R,320
+Carroll,Clay,President,,Hillary Clinton,D,98
+Carroll,Clay,President,,Gary Johnson,L,25
+Carroll,Clay,President,,Write-In,,9
+Carroll,Clay,U.S. Senate,,Todd Young,R,279
+Carroll,Clay,U.S. Senate,,Evan Bayh,D,137
+Carroll,Clay,U.S. Senate,,Lucy Brenton,L,34
+Carroll,Clay,U.S. Senate,,Write-In,,0
+Carroll,Clay,Governor,,Eric Holcomb,R,279
+Carroll,Clay,Governor,,John R. Gregg,D,152
+Carroll,Clay,Governor,,Rex Bell,L,20
+Carroll,Clay,Governor,,Write-in,,0
+Carroll,Clay,Attorney General,,"Curtis T. Hill, Jr.",R,338
+Carroll,Clay,Attorney General,,Lorenzo Arredondo,D,105
+Carroll,Clay,Superintendent of Public Instruction,,Jennifer McCormick,R,275
+Carroll,Clay,Superintendent of Public Instruction,,Glenda Ritz,D,176
+Carroll,Clay,U.S. House,4,Todd Rokita,R,318
+Carroll,Clay,U.S. House,4,John Dale,D,107
+Carroll,Clay,U.S. House,4,Steven M. Mayoras,L,25
+Carroll,Clay,U.S. House,4,Write-in,,1
+Carroll,Clay,State Senate,7,Brandt Hershman,R,338
+Carroll,Clay,State Senate,7,Justin Notoras,D,107
+Carroll,Clay,State House,25,Donald J. Lehe,R,321
+Carroll,Clay,State House,25,Maurice O. Fuller,D,98
+Carroll,Clay,State House,25,Franklyn Voorhies,L,28
+Carroll,Deer Creek 1,Voters,,Registered,,1193
+Carroll,Deer Creek 1,Voters,,Ballots Cast,,776
+Carroll,Deer Creek 1,Voters,,Straight Ticket,D,58
+Carroll,Deer Creek 1,Voters,,Straight Ticket,L,13
+Carroll,Deer Creek 1,Voters,,Straight Ticket,R,262
+Carroll,Deer Creek 1,President,,Donald J. Trump,R,555
+Carroll,Deer Creek 1,President,,Hillary Clinton,D,164
+Carroll,Deer Creek 1,President,,Gary Johnson,L,38
+Carroll,Deer Creek 1,President,,Write-In,,7
+Carroll,Deer Creek 1,U.S. Senate,,Todd Young,R,482
+Carroll,Deer Creek 1,U.S. Senate,,Evan Bayh,D,219
+Carroll,Deer Creek 1,U.S. Senate,,Lucy Brenton,L,61
+Carroll,Deer Creek 1,U.S. Senate,,Write-In,,0
+Carroll,Deer Creek 1,Governor,,Eric Holcomb,R,484
+Carroll,Deer Creek 1,Governor,,John R. Gregg,D,252
+Carroll,Deer Creek 1,Governor,,Rex Bell,L,24
+Carroll,Deer Creek 1,Governor,,Write-in,,0
+Carroll,Deer Creek 1,Attorney General,,"Curtis T. Hill, Jr.",R,566
+Carroll,Deer Creek 1,Attorney General,,Lorenzo Arredondo,D,170
+Carroll,Deer Creek 1,Superintendent of Public Instruction,,Jennifer McCormick,R,486
+Carroll,Deer Creek 1,Superintendent of Public Instruction,,Glenda Ritz,D,265
+Carroll,Deer Creek 1,U.S. House,4,Todd Rokita,R,548
+Carroll,Deer Creek 1,U.S. House,4,John Dale,D,165
+Carroll,Deer Creek 1,U.S. House,4,Steven M. Mayoras,L,39
+Carroll,Deer Creek 1,U.S. House,4,Write-in,,0
+Carroll,Deer Creek 1,State Senate,7,Brandt Hershman,R,587
+Carroll,Deer Creek 1,State Senate,7,Justin Notoras,D,164
+Carroll,Deer Creek 1,State House,25,Donald J. Lehe,R,560
+Carroll,Deer Creek 1,State House,25,Maurice O. Fuller,D,145
+Carroll,Deer Creek 1,State House,25,Franklyn Voorhies,L,45
+Carroll,Deer Creek 3,Voters,,Registered,,930
+Carroll,Deer Creek 3,Voters,,Ballots Cast,,547
+Carroll,Deer Creek 3,Voters,,Straight Ticket,D,65
+Carroll,Deer Creek 3,Voters,,Straight Ticket,L,4
+Carroll,Deer Creek 3,Voters,,Straight Ticket,R,175
+Carroll,Deer Creek 3,President,,Donald J. Trump,R,366
+Carroll,Deer Creek 3,President,,Hillary Clinton,D,138
+Carroll,Deer Creek 3,President,,Gary Johnson,L,22
+Carroll,Deer Creek 3,President,,Write-In,,8
+Carroll,Deer Creek 3,U.S. Senate,,Todd Young,R,310
+Carroll,Deer Creek 3,U.S. Senate,,Evan Bayh,D,174
+Carroll,Deer Creek 3,U.S. Senate,,Lucy Brenton,L,41
+Carroll,Deer Creek 3,U.S. Senate,,Write-In,,0
+Carroll,Deer Creek 3,Governor,,Eric Holcomb,R,305
+Carroll,Deer Creek 3,Governor,,John R. Gregg,D,197
+Carroll,Deer Creek 3,Governor,,Rex Bell,L,22
+Carroll,Deer Creek 3,Governor,,Write-in,,0
+Carroll,Deer Creek 3,Attorney General,,"Curtis T. Hill, Jr.",R,375
+Carroll,Deer Creek 3,Attorney General,,Lorenzo Arredondo,D,130
+Carroll,Deer Creek 3,Superintendent of Public Instruction,,Jennifer McCormick,R,301
+Carroll,Deer Creek 3,Superintendent of Public Instruction,,Glenda Ritz,D,212
+Carroll,Deer Creek 3,U.S. House,4,Todd Rokita,R,350
+Carroll,Deer Creek 3,U.S. House,4,John Dale,D,134
+Carroll,Deer Creek 3,U.S. House,4,Steven M. Mayoras,L,32
+Carroll,Deer Creek 3,U.S. House,4,Write-in,,0
+Carroll,Deer Creek 3,State Senate,7,Brandt Hershman,R,386
+Carroll,Deer Creek 3,State Senate,7,Justin Notoras,D,129
+Carroll,Deer Creek 3,State House,25,Donald J. Lehe,R,362
+Carroll,Deer Creek 3,State House,25,Maurice O. Fuller,D,118
+Carroll,Deer Creek 3,State House,25,Franklyn Voorhies,L,29
+Carroll,Deer Creek 5,Voters,,Registered,,1137
+Carroll,Deer Creek 5,Voters,,Ballots Cast,,563
+Carroll,Deer Creek 5,Voters,,Straight Ticket,D,88
+Carroll,Deer Creek 5,Voters,,Straight Ticket,L,12
+Carroll,Deer Creek 5,Voters,,Straight Ticket,R,179
+Carroll,Deer Creek 5,President,,Donald J. Trump,R,344
+Carroll,Deer Creek 5,President,,Hillary Clinton,D,170
+Carroll,Deer Creek 5,President,,Gary Johnson,L,30
+Carroll,Deer Creek 5,President,,Write-In,,5
+Carroll,Deer Creek 5,U.S. Senate,,Todd Young,R,301
+Carroll,Deer Creek 5,U.S. Senate,,Evan Bayh,D,203
+Carroll,Deer Creek 5,U.S. Senate,,Lucy Brenton,L,41
+Carroll,Deer Creek 5,U.S. Senate,,Write-In,,0
+Carroll,Deer Creek 5,Governor,,Eric Holcomb,R,288
+Carroll,Deer Creek 5,Governor,,John R. Gregg,D,220
+Carroll,Deer Creek 5,Governor,,Rex Bell,L,29
+Carroll,Deer Creek 5,Governor,,Write-in,,0
+Carroll,Deer Creek 5,Attorney General,,"Curtis T. Hill, Jr.",R,357
+Carroll,Deer Creek 5,Attorney General,,Lorenzo Arredondo,D,162
+Carroll,Deer Creek 5,Superintendent of Public Instruction,,Jennifer McCormick,R,317
+Carroll,Deer Creek 5,Superintendent of Public Instruction,,Glenda Ritz,D,212
+Carroll,Deer Creek 5,U.S. House,4,Todd Rokita,R,323
+Carroll,Deer Creek 5,U.S. House,4,John Dale,D,177
+Carroll,Deer Creek 5,U.S. House,4,Steven M. Mayoras,L,40
+Carroll,Deer Creek 5,U.S. House,4,Write-in,,0
+Carroll,Deer Creek 5,State Senate,7,Brandt Hershman,R,366
+Carroll,Deer Creek 5,State Senate,7,Justin Notoras,D,164
+Carroll,Deer Creek 5,State House,25,Donald J. Lehe,R,350
+Carroll,Deer Creek 5,State House,25,Maurice O. Fuller,D,137
+Carroll,Deer Creek 5,State House,25,Franklyn Voorhies,L,44
+Carroll,Democrat,Voters,,Registered,,648
+Carroll,Democrat,Voters,,Ballots Cast,,445
+Carroll,Democrat,Voters,,Straight Ticket,D,38
+Carroll,Democrat,Voters,,Straight Ticket,L,4
+Carroll,Democrat,Voters,,Straight Ticket,R,123
+Carroll,Democrat,President,,Donald J. Trump,R,326
+Carroll,Democrat,President,,Hillary Clinton,D,87
+Carroll,Democrat,President,,Gary Johnson,L,17
+Carroll,Democrat,President,,Write-In,,7
+Carroll,Democrat,U.S. Senate,,Todd Young,R,286
+Carroll,Democrat,U.S. Senate,,Evan Bayh,D,117
+Carroll,Democrat,U.S. Senate,,Lucy Brenton,L,28
+Carroll,Democrat,U.S. Senate,,Write-In,,1
+Carroll,Democrat,Governor,,Eric Holcomb,R,276
+Carroll,Democrat,Governor,,John R. Gregg,D,140
+Carroll,Democrat,Governor,,Rex Bell,L,17
+Carroll,Democrat,Governor,,Write-in,,0
+Carroll,Democrat,Attorney General,,"Curtis T. Hill, Jr.",R,325
+Carroll,Democrat,Attorney General,,Lorenzo Arredondo,D,93
+Carroll,Democrat,Superintendent of Public Instruction,,Jennifer McCormick,R,261
+Carroll,Democrat,Superintendent of Public Instruction,,Glenda Ritz,D,164
+Carroll,Democrat,U.S. House,4,Todd Rokita,R,314
+Carroll,Democrat,U.S. House,4,John Dale,D,102
+Carroll,Democrat,U.S. House,4,Steven M. Mayoras,L,14
+Carroll,Democrat,U.S. House,4,Write-in,,0
+Carroll,Democrat,State Senate,7,Brandt Hershman,R,318
+Carroll,Democrat,State Senate,7,Justin Notoras,D,106
+Carroll,Democrat,State House,38,Heath VanNatter,R,263
+Carroll,Democrat,State House,38,Jason Scott Burns,I,154
+Carroll,Jackson,Voters,,Registered,,829
+Carroll,Jackson,Voters,,Ballots Cast,,568
+Carroll,Jackson,Voters,,Straight Ticket,D,47
+Carroll,Jackson,Voters,,Straight Ticket,L,3
+Carroll,Jackson,Voters,,Straight Ticket,R,174
+Carroll,Jackson,President,,Donald J. Trump,R,408
+Carroll,Jackson,President,,Hillary Clinton,D,112
+Carroll,Jackson,President,,Gary Johnson,L,28
+Carroll,Jackson,President,,Write-In,,8
+Carroll,Jackson,U.S. Senate,,Todd Young,R,359
+Carroll,Jackson,U.S. Senate,,Evan Bayh,D,153
+Carroll,Jackson,U.S. Senate,,Lucy Brenton,L,44
+Carroll,Jackson,U.S. Senate,,Write-In,,0
+Carroll,Jackson,Governor,,Eric Holcomb,R,339
+Carroll,Jackson,Governor,,John R. Gregg,D,189
+Carroll,Jackson,Governor,,Rex Bell,L,26
+Carroll,Jackson,Governor,,Write-in,,1
+Carroll,Jackson,Attorney General,,"Curtis T. Hill, Jr.",R,426
+Carroll,Jackson,Attorney General,,Lorenzo Arredondo,D,112
+Carroll,Jackson,Superintendent of Public Instruction,,Jennifer McCormick,R,310
+Carroll,Jackson,Superintendent of Public Instruction,,Glenda Ritz,D,237
+Carroll,Jackson,U.S. House,4,Todd Rokita,R,398
+Carroll,Jackson,U.S. House,4,John Dale,D,120
+Carroll,Jackson,U.S. House,4,Steven M. Mayoras,L,31
+Carroll,Jackson,U.S. House,4,Write-in,,0
+Carroll,Jackson,State Senate,18,Randall Head,R,415
+Carroll,Jackson,State House,38,Heath VanNatter,R,338
+Carroll,Jackson,State House,38,Jason Scott Burns,I,171
+Carroll,Jefferson 1,Voters,,Registered,,1003
+Carroll,Jefferson 1,Voters,,Ballots Cast,,611
+Carroll,Jefferson 1,Voters,,Straight Ticket,D,69
+Carroll,Jefferson 1,Voters,,Straight Ticket,L,11
+Carroll,Jefferson 1,Voters,,Straight Ticket,R,222
+Carroll,Jefferson 1,President,,Donald J. Trump,R,432
+Carroll,Jefferson 1,President,,Hillary Clinton,D,130
+Carroll,Jefferson 1,President,,Gary Johnson,L,33
+Carroll,Jefferson 1,President,,Write-In,,2
+Carroll,Jefferson 1,U.S. Senate,,Todd Young,R,389
+Carroll,Jefferson 1,U.S. Senate,,Evan Bayh,D,168
+Carroll,Jefferson 1,U.S. Senate,,Lucy Brenton,L,40
+Carroll,Jefferson 1,U.S. Senate,,Write-In,,0
+Carroll,Jefferson 1,Governor,,Eric Holcomb,R,379
+Carroll,Jefferson 1,Governor,,John R. Gregg,D,190
+Carroll,Jefferson 1,Governor,,Rex Bell,L,26
+Carroll,Jefferson 1,Governor,,Write-in,,0
+Carroll,Jefferson 1,Attorney General,,"Curtis T. Hill, Jr.",R,444
+Carroll,Jefferson 1,Attorney General,,Lorenzo Arredondo,D,137
+Carroll,Jefferson 1,Superintendent of Public Instruction,,Jennifer McCormick,R,374
+Carroll,Jefferson 1,Superintendent of Public Instruction,,Glenda Ritz,D,213
+Carroll,Jefferson 1,U.S. House,4,Todd Rokita,R,420
+Carroll,Jefferson 1,U.S. House,4,John Dale,D,136
+Carroll,Jefferson 1,U.S. House,4,Steven M. Mayoras,L,38
+Carroll,Jefferson 1,U.S. House,4,Write-in,,0
+Carroll,Jefferson 1,State Senate,7,Brandt Hershman,R,447
+Carroll,Jefferson 1,State Senate,7,Justin Notoras,D,145
+Carroll,Jefferson 1,State House,25,Donald J. Lehe,R,423
+Carroll,Jefferson 1,State House,25,Maurice O. Fuller,D,125
+Carroll,Jefferson 1,State House,25,Franklyn Voorhies,L,40
+Carroll,Jefferson 2,Voters,,Registered,,698
+Carroll,Jefferson 2,Voters,,Ballots Cast,,448
+Carroll,Jefferson 2,Voters,,Straight Ticket,D,40
+Carroll,Jefferson 2,Voters,,Straight Ticket,L,10
+Carroll,Jefferson 2,Voters,,Straight Ticket,R,165
+Carroll,Jefferson 2,President,,Donald J. Trump,R,315
+Carroll,Jefferson 2,President,,Hillary Clinton,D,96
+Carroll,Jefferson 2,President,,Gary Johnson,L,27
+Carroll,Jefferson 2,President,,Write-In,,5
+Carroll,Jefferson 2,U.S. Senate,,Todd Young,R,285
+Carroll,Jefferson 2,U.S. Senate,,Evan Bayh,D,129
+Carroll,Jefferson 2,U.S. Senate,,Lucy Brenton,L,28
+Carroll,Jefferson 2,U.S. Senate,,Write-In,,0
+Carroll,Jefferson 2,Governor,,Eric Holcomb,R,280
+Carroll,Jefferson 2,Governor,,John R. Gregg,D,151
+Carroll,Jefferson 2,Governor,,Rex Bell,L,12
+Carroll,Jefferson 2,Governor,,Write-in,,1
+Carroll,Jefferson 2,Attorney General,,"Curtis T. Hill, Jr.",R,330
+Carroll,Jefferson 2,Attorney General,,Lorenzo Arredondo,D,97
+Carroll,Jefferson 2,Superintendent of Public Instruction,,Jennifer McCormick,R,277
+Carroll,Jefferson 2,Superintendent of Public Instruction,,Glenda Ritz,D,158
+Carroll,Jefferson 2,U.S. House,4,Todd Rokita,R,313
+Carroll,Jefferson 2,U.S. House,4,John Dale,D,102
+Carroll,Jefferson 2,U.S. House,4,Steven M. Mayoras,L,20
+Carroll,Jefferson 2,U.S. House,4,Write-in,,0
+Carroll,Jefferson 2,State Senate,7,Brandt Hershman,R,333
+Carroll,Jefferson 2,State Senate,7,Justin Notoras,D,97
+Carroll,Jefferson 2,State House,25,Donald J. Lehe,R,326
+Carroll,Jefferson 2,State House,25,Maurice O. Fuller,D,92
+Carroll,Jefferson 2,State House,25,Franklyn Voorhies,L,17
+Carroll,Liberty,Voters,,Registered,,345
+Carroll,Liberty,Voters,,Ballots Cast,,213
+Carroll,Liberty,Voters,,Straight Ticket,D,20
+Carroll,Liberty,Voters,,Straight Ticket,L,1
+Carroll,Liberty,Voters,,Straight Ticket,R,78
+Carroll,Liberty,President,,Donald J. Trump,R,162
+Carroll,Liberty,President,,Hillary Clinton,D,39
+Carroll,Liberty,President,,Gary Johnson,L,6
+Carroll,Liberty,President,,Write-In,,2
+Carroll,Liberty,U.S. Senate,,Todd Young,R,139
+Carroll,Liberty,U.S. Senate,,Evan Bayh,D,60
+Carroll,Liberty,U.S. Senate,,Lucy Brenton,L,12
+Carroll,Liberty,U.S. Senate,,Write-In,,0
+Carroll,Liberty,Governor,,Eric Holcomb,R,141
+Carroll,Liberty,Governor,,John R. Gregg,D,65
+Carroll,Liberty,Governor,,Rex Bell,L,5
+Carroll,Liberty,Governor,,Write-in,,0
+Carroll,Liberty,Attorney General,,"Curtis T. Hill, Jr.",R,169
+Carroll,Liberty,Attorney General,,Lorenzo Arredondo,D,39
+Carroll,Liberty,Superintendent of Public Instruction,,Jennifer McCormick,R,134
+Carroll,Liberty,Superintendent of Public Instruction,,Glenda Ritz,D,76
+Carroll,Liberty,U.S. House,4,Todd Rokita,R,154
+Carroll,Liberty,U.S. House,4,John Dale,D,48
+Carroll,Liberty,U.S. House,4,Steven M. Mayoras,L,6
+Carroll,Liberty,U.S. House,4,Write-in,,0
+Carroll,Liberty,State Senate,18,Randall Head,R,169
+Carroll,Liberty,State House,25,Donald J. Lehe,R,155
+Carroll,Liberty,State House,25,Maurice O. Fuller,D,34
+Carroll,Liberty,State House,25,Franklyn Voorhies,L,13
+Carroll,Madison,Voters,,Registered,,330
+Carroll,Madison,Voters,,Ballots Cast,,207
+Carroll,Madison,Voters,,Straight Ticket,D,13
+Carroll,Madison,Voters,,Straight Ticket,L,3
+Carroll,Madison,Voters,,Straight Ticket,R,63
+Carroll,Madison,President,,Donald J. Trump,R,145
+Carroll,Madison,President,,Hillary Clinton,D,44
+Carroll,Madison,President,,Gary Johnson,L,13
+Carroll,Madison,President,,Write-In,,0
+Carroll,Madison,U.S. Senate,,Todd Young,R,126
+Carroll,Madison,U.S. Senate,,Evan Bayh,D,58
+Carroll,Madison,U.S. Senate,,Lucy Brenton,L,15
+Carroll,Madison,U.S. Senate,,Write-In,,0
+Carroll,Madison,Governor,,Eric Holcomb,R,125
+Carroll,Madison,Governor,,John R. Gregg,D,68
+Carroll,Madison,Governor,,Rex Bell,L,5
+Carroll,Madison,Governor,,Write-in,,0
+Carroll,Madison,Attorney General,,"Curtis T. Hill, Jr.",R,156
+Carroll,Madison,Attorney General,,Lorenzo Arredondo,D,38
+Carroll,Madison,Superintendent of Public Instruction,,Jennifer McCormick,R,125
+Carroll,Madison,Superintendent of Public Instruction,,Glenda Ritz,D,73
+Carroll,Madison,U.S. House,4,Todd Rokita,R,149
+Carroll,Madison,U.S. House,4,John Dale,D,41
+Carroll,Madison,U.S. House,4,Steven M. Mayoras,L,8
+Carroll,Madison,U.S. House,4,Write-in,,0
+Carroll,Madison,State Senate,7,Brandt Hershman,R,158
+Carroll,Madison,State Senate,7,Justin Notoras,D,37
+Carroll,Madison,State House,25,Donald J. Lehe,R,159
+Carroll,Madison,State House,25,Maurice O. Fuller,D,33
+Carroll,Madison,State House,25,Franklyn Voorhies,L,7
+Carroll,Monroe 1,Voters,,Registered,,804
+Carroll,Monroe 1,Voters,,Ballots Cast,,477
+Carroll,Monroe 1,Voters,,Straight Ticket,D,45
+Carroll,Monroe 1,Voters,,Straight Ticket,L,4
+Carroll,Monroe 1,Voters,,Straight Ticket,R,146
+Carroll,Monroe 1,President,,Donald J. Trump,R,349
+Carroll,Monroe 1,President,,Hillary Clinton,D,92
+Carroll,Monroe 1,President,,Gary Johnson,L,21
+Carroll,Monroe 1,President,,Write-In,,5
+Carroll,Monroe 1,U.S. Senate,,Todd Young,R,300
+Carroll,Monroe 1,U.S. Senate,,Evan Bayh,D,135
+Carroll,Monroe 1,U.S. Senate,,Lucy Brenton,L,35
+Carroll,Monroe 1,U.S. Senate,,Write-In,,0
+Carroll,Monroe 1,Governor,,Eric Holcomb,R,292
+Carroll,Monroe 1,Governor,,John R. Gregg,D,158
+Carroll,Monroe 1,Governor,,Rex Bell,L,20
+Carroll,Monroe 1,Governor,,Write-in,,0
+Carroll,Monroe 1,Attorney General,,"Curtis T. Hill, Jr.",R,347
+Carroll,Monroe 1,Attorney General,,Lorenzo Arredondo,D,104
+Carroll,Monroe 1,Superintendent of Public Instruction,,Jennifer McCormick,R,285
+Carroll,Monroe 1,Superintendent of Public Instruction,,Glenda Ritz,D,176
+Carroll,Monroe 1,U.S. House,4,Todd Rokita,R,340
+Carroll,Monroe 1,U.S. House,4,John Dale,D,102
+Carroll,Monroe 1,U.S. House,4,Steven M. Mayoras,L,23
+Carroll,Monroe 1,U.S. House,4,Write-in,,0
+Carroll,Monroe 1,State Senate,18,Randall Head,R,362
+Carroll,Monroe 1,State House,38,Heath VanNatter,R,237
+Carroll,Monroe 1,State House,38,Jason Scott Burns,I,210
+Carroll,Monroe 2,Voters,,Registered,,1112
+Carroll,Monroe 2,Voters,,Ballots Cast,,660
+Carroll,Monroe 2,Voters,,Straight Ticket,D,67
+Carroll,Monroe 2,Voters,,Straight Ticket,L,12
+Carroll,Monroe 2,Voters,,Straight Ticket,R,215
+Carroll,Monroe 2,President,,Donald J. Trump,R,463
+Carroll,Monroe 2,President,,Hillary Clinton,D,131
+Carroll,Monroe 2,President,,Gary Johnson,L,30
+Carroll,Monroe 2,President,,Write-In,,10
+Carroll,Monroe 2,U.S. Senate,,Todd Young,R,406
+Carroll,Monroe 2,U.S. Senate,,Evan Bayh,D,188
+Carroll,Monroe 2,U.S. Senate,,Lucy Brenton,L,40
+Carroll,Monroe 2,U.S. Senate,,Write-In,,1
+Carroll,Monroe 2,Governor,,Eric Holcomb,R,394
+Carroll,Monroe 2,Governor,,John R. Gregg,D,212
+Carroll,Monroe 2,Governor,,Rex Bell,L,28
+Carroll,Monroe 2,Governor,,Write-in,,0
+Carroll,Monroe 2,Attorney General,,"Curtis T. Hill, Jr.",R,490
+Carroll,Monroe 2,Attorney General,,Lorenzo Arredondo,D,125
+Carroll,Monroe 2,Superintendent of Public Instruction,,Jennifer McCormick,R,408
+Carroll,Monroe 2,Superintendent of Public Instruction,,Glenda Ritz,D,219
+Carroll,Monroe 2,U.S. House,4,Todd Rokita,R,460
+Carroll,Monroe 2,U.S. House,4,John Dale,D,129
+Carroll,Monroe 2,U.S. House,4,Steven M. Mayoras,L,33
+Carroll,Monroe 2,U.S. House,4,Write-in,,0
+Carroll,Monroe 2,State Senate,18,Randall Head,R,500
+Carroll,Monroe 2,State House,38,Heath VanNatter,R,325
+Carroll,Monroe 2,State House,38,Jason Scott Burns,I,280
+Carroll,Rock Creek,Voters,,Registered,,293
+Carroll,Rock Creek,Voters,,Ballots Cast,,177
+Carroll,Rock Creek,Voters,,Straight Ticket,D,23
+Carroll,Rock Creek,Voters,,Straight Ticket,L,7
+Carroll,Rock Creek,Voters,,Straight Ticket,R,56
+Carroll,Rock Creek,President,,Donald J. Trump,R,120
+Carroll,Rock Creek,President,,Hillary Clinton,D,39
+Carroll,Rock Creek,President,,Gary Johnson,L,12
+Carroll,Rock Creek,President,,Write-In,,1
+Carroll,Rock Creek,U.S. Senate,,Todd Young,R,94
+Carroll,Rock Creek,U.S. Senate,,Evan Bayh,D,57
+Carroll,Rock Creek,U.S. Senate,,Lucy Brenton,L,20
+Carroll,Rock Creek,U.S. Senate,,Write-In,,0
+Carroll,Rock Creek,Governor,,Eric Holcomb,R,98
+Carroll,Rock Creek,Governor,,John R. Gregg,D,62
+Carroll,Rock Creek,Governor,,Rex Bell,L,10
+Carroll,Rock Creek,Governor,,Write-in,,0
+Carroll,Rock Creek,Attorney General,,"Curtis T. Hill, Jr.",R,124
+Carroll,Rock Creek,Attorney General,,Lorenzo Arredondo,D,42
+Carroll,Rock Creek,Superintendent of Public Instruction,,Jennifer McCormick,R,90
+Carroll,Rock Creek,Superintendent of Public Instruction,,Glenda Ritz,D,78
+Carroll,Rock Creek,U.S. House,4,Todd Rokita,R,106
+Carroll,Rock Creek,U.S. House,4,John Dale,D,53
+Carroll,Rock Creek,U.S. House,4,Steven M. Mayoras,L,12
+Carroll,Rock Creek,U.S. House,4,Write-in,,0
+Carroll,Rock Creek,State Senate,18,Randall Head,R,120
+Carroll,Rock Creek,State House,25,Donald J. Lehe,R,108
+Carroll,Rock Creek,State House,25,Maurice O. Fuller,D,40
+Carroll,Rock Creek,State House,25,Franklyn Voorhies,L,20
+Carroll,Tippecanoe 1,Voters,,Registered,,914
+Carroll,Tippecanoe 1,Voters,,Ballots Cast,,531
+Carroll,Tippecanoe 1,Voters,,Straight Ticket,D,69
+Carroll,Tippecanoe 1,Voters,,Straight Ticket,L,11
+Carroll,Tippecanoe 1,Voters,,Straight Ticket,R,188
+Carroll,Tippecanoe 1,President,,Donald J. Trump,R,350
+Carroll,Tippecanoe 1,President,,Hillary Clinton,D,135
+Carroll,Tippecanoe 1,President,,Gary Johnson,L,29
+Carroll,Tippecanoe 1,President,,Write-In,,4
+Carroll,Tippecanoe 1,U.S. Senate,,Todd Young,R,313
+Carroll,Tippecanoe 1,U.S. Senate,,Evan Bayh,D,165
+Carroll,Tippecanoe 1,U.S. Senate,,Lucy Brenton,L,43
+Carroll,Tippecanoe 1,U.S. Senate,,Write-In,,0
+Carroll,Tippecanoe 1,Governor,,Eric Holcomb,R,300
+Carroll,Tippecanoe 1,Governor,,John R. Gregg,D,194
+Carroll,Tippecanoe 1,Governor,,Rex Bell,L,24
+Carroll,Tippecanoe 1,Governor,,Write-in,,0
+Carroll,Tippecanoe 1,Attorney General,,"Curtis T. Hill, Jr.",R,362
+Carroll,Tippecanoe 1,Attorney General,,Lorenzo Arredondo,D,141
+Carroll,Tippecanoe 1,Superintendent of Public Instruction,,Jennifer McCormick,R,315
+Carroll,Tippecanoe 1,Superintendent of Public Instruction,,Glenda Ritz,D,197
+Carroll,Tippecanoe 1,U.S. House,4,Todd Rokita,R,344
+Carroll,Tippecanoe 1,U.S. House,4,John Dale,D,142
+Carroll,Tippecanoe 1,U.S. House,4,Steven M. Mayoras,L,27
+Carroll,Tippecanoe 1,U.S. House,4,Write-in,,0
+Carroll,Tippecanoe 1,State Senate,7,Brandt Hershman,R,374
+Carroll,Tippecanoe 1,State Senate,7,Justin Notoras,D,136
+Carroll,Tippecanoe 1,State House,25,Donald J. Lehe,R,345
+Carroll,Tippecanoe 1,State House,25,Maurice O. Fuller,D,134
+Carroll,Tippecanoe 1,State House,25,Franklyn Voorhies,L,36
+Carroll,Tippecanoe 2,Voters,,Registered,,876
+Carroll,Tippecanoe 2,Voters,,Ballots Cast,,490
+Carroll,Tippecanoe 2,Voters,,Straight Ticket,D,82
+Carroll,Tippecanoe 2,Voters,,Straight Ticket,L,10
+Carroll,Tippecanoe 2,Voters,,Straight Ticket,R,159
+Carroll,Tippecanoe 2,President,,Donald J. Trump,R,309
+Carroll,Tippecanoe 2,President,,Hillary Clinton,D,139
+Carroll,Tippecanoe 2,President,,Gary Johnson,L,28
+Carroll,Tippecanoe 2,President,,Write-In,,3
+Carroll,Tippecanoe 2,U.S. Senate,,Todd Young,R,283
+Carroll,Tippecanoe 2,U.S. Senate,,Evan Bayh,D,159
+Carroll,Tippecanoe 2,U.S. Senate,,Lucy Brenton,L,36
+Carroll,Tippecanoe 2,U.S. Senate,,Write-In,,0
+Carroll,Tippecanoe 2,Governor,,Eric Holcomb,R,274
+Carroll,Tippecanoe 2,Governor,,John R. Gregg,D,177
+Carroll,Tippecanoe 2,Governor,,Rex Bell,L,24
+Carroll,Tippecanoe 2,Governor,,Write-in,,0
+Carroll,Tippecanoe 2,Attorney General,,"Curtis T. Hill, Jr.",R,328
+Carroll,Tippecanoe 2,Attorney General,,Lorenzo Arredondo,D,140
+Carroll,Tippecanoe 2,Superintendent of Public Instruction,,Jennifer McCormick,R,264
+Carroll,Tippecanoe 2,Superintendent of Public Instruction,,Glenda Ritz,D,211
+Carroll,Tippecanoe 2,U.S. House,4,Todd Rokita,R,303
+Carroll,Tippecanoe 2,U.S. House,4,John Dale,D,145
+Carroll,Tippecanoe 2,U.S. House,4,Steven M. Mayoras,L,26
+Carroll,Tippecanoe 2,U.S. House,4,Write-in,,0
+Carroll,Tippecanoe 2,State Senate,7,Brandt Hershman,R,333
+Carroll,Tippecanoe 2,State Senate,7,Justin Notoras,D,141
+Carroll,Tippecanoe 2,State House,25,Donald J. Lehe,R,314
+Carroll,Tippecanoe 2,State House,25,Maurice O. Fuller,D,117
+Carroll,Tippecanoe 2,State House,25,Franklyn Voorhies,L,38
+Carroll,Washington,Voters,,Registered,,405
+Carroll,Washington,Voters,,Ballots Cast,,278
+Carroll,Washington,Voters,,Straight Ticket,D,20
+Carroll,Washington,Voters,,Straight Ticket,L,2
+Carroll,Washington,Voters,,Straight Ticket,R,101
+Carroll,Washington,President,,Donald J. Trump,R,205
+Carroll,Washington,President,,Hillary Clinton,D,49
+Carroll,Washington,President,,Gary Johnson,L,17
+Carroll,Washington,President,,Write-In,,1
+Carroll,Washington,U.S. Senate,,Todd Young,R,184
+Carroll,Washington,U.S. Senate,,Evan Bayh,D,71
+Carroll,Washington,U.S. Senate,,Lucy Brenton,L,22
+Carroll,Washington,U.S. Senate,,Write-In,,0
+Carroll,Washington,Governor,,Eric Holcomb,R,175
+Carroll,Washington,Governor,,John R. Gregg,D,89
+Carroll,Washington,Governor,,Rex Bell,L,10
+Carroll,Washington,Governor,,Write-in,,0
+Carroll,Washington,Attorney General,,"Curtis T. Hill, Jr.",R,219
+Carroll,Washington,Attorney General,,Lorenzo Arredondo,D,50
+Carroll,Washington,Superintendent of Public Instruction,,Jennifer McCormick,R,174
+Carroll,Washington,Superintendent of Public Instruction,,Glenda Ritz,D,98
+Carroll,Washington,U.S. House,4,Todd Rokita,R,205
+Carroll,Washington,U.S. House,4,John Dale,D,56
+Carroll,Washington,U.S. House,4,Steven M. Mayoras,L,12
+Carroll,Washington,U.S. House,4,Write-in,,0
+Carroll,Washington,State Senate,18,Randall Head,R,220
+Carroll,Washington,State House,38,Heath VanNatter,R,177
+Carroll,Washington,State House,38,Jason Scott Burns,I,73
+Carroll,Total,Voters,,Registered,,14338
+Carroll,Total,Voters,,Ballots Cast,,8899
+Carroll,Total,Voters,,Straight Ticket,D,900
+Carroll,Total,Voters,,Straight Ticket,L,129
+Carroll,Total,Voters,,Straight Ticket,R,3005
+Carroll,Total,President,,Donald J. Trump,R,6273
+Carroll,Total,President,,Hillary Clinton,D,1892
+Carroll,Total,President,,Gary Johnson,L,445
+Carroll,Total,President,,Write-In,,91
+Carroll,Total,U.S. Senate,,Todd Young,R,5512
+Carroll,Total,U.S. Senate,,Evan Bayh,D,2522
+Carroll,Total,U.S. Senate,,Lucy Brenton,L,648
+Carroll,Total,U.S. Senate,,Write-In,,2
+Carroll,Total,Governor,,Eric Holcomb,R,5381
+Carroll,Total,Governor,,John R. Gregg,D,2923
+Carroll,Total,Governor,,Rex Bell,L,353
+Carroll,Total,Governor,,Write-in,,2
+Carroll,Total,Attorney General,,"Curtis T. Hill, Jr.",R,6493
+Carroll,Total,Attorney General,,Lorenzo Arredondo,D,1933
+Carroll,Total,Superintendent of Public Instruction,,Jennifer McCormick,R,5317
+Carroll,Total,Superintendent of Public Instruction,,Glenda Ritz,D,3238
+Carroll,Total,U.S. House,4,Todd Rokita,R,6113
+Carroll,Total,U.S. House,4,John Dale,D,2027
+Carroll,Total,U.S. House,4,Steven M. Mayoras,L,452
+Carroll,Total,U.S. House,4,Write-in,,2
+Carroll,Total,State Senate,7,Brandt Hershman,R,4327
+Carroll,Total,State Senate,7,Justin Notoras,D,1397
+Carroll,Total,State Senate,18,Randall Head,R,2219
+Carroll,Total,State House,25,Donald J. Lehe,R,3607
+Carroll,Total,State House,25,Maurice O. Fuller,D,1120
+Carroll,Total,State House,25,Franklyn Voorhies,L,324
+Carroll,Total,State House,38,Heath VanNatter,R,2124
+Carroll,Total,State House,38,Jason Scott Burns,I,1234


### PR DESCRIPTION
Note there are corrections relative to the originally imported data: the Congressional District 4 results for some precincts (those early in the alphabet) were incorrect.  I spotted this while double checking the precinct summation with the total.

