### PR TITLE
Add 2016 general election precinct-level results for Clay county.  No…

### DIFF
--- a/2016/20161108__in__general__clay__precinct.csv
+++ b/2016/20161108__in__general__clay__precinct.csv
@@ -1,0 +1,652 @@
+county,precinct,office,district,candidate,party,votes
+Clay,01 - Brazil,Voters,,Registered,,1347
+Clay,01 - Brazil,Voters,,Ballots Cast,,596
+Clay,01 - Brazil,Voters,,Straight Ticket,D,22
+Clay,01 - Brazil,Voters,,Straight Ticket,L,0
+Clay,01 - Brazil,Voters,,Straight Ticket,R,96
+Clay,01 - Brazil,President,,Donald J. Trump,R,400
+Clay,01 - Brazil,President,,Hillary Clinton,D,169
+Clay,01 - Brazil,President,,Gary Johnson,L,18
+Clay,01 - Brazil,President,,Write-In,,5
+Clay,01 - Brazil,U.S. Senate,,Todd Young,R,292
+Clay,01 - Brazil,U.S. Senate,,Evan Bayh,D,242
+Clay,01 - Brazil,U.S. Senate,,Lucy Brenton,L,39
+Clay,01 - Brazil,U.S. Senate,,Write-In,,1
+Clay,01 - Brazil,Governor,,Eric Holcomb,R,330
+Clay,01 - Brazil,Governor,,John R. Gregg,D,225
+Clay,01 - Brazil,Governor,,Rex Bell,L,16
+Clay,01 - Brazil,Governor,,Write-in,,2
+Clay,01 - Brazil,Attorney General,,"Curtis T. Hill, Jr.",R,379
+Clay,01 - Brazil,Attorney General,,Lorenzo Arredondo,D,168
+Clay,01 - Brazil,Superintendent of Public Instruction,,Jennifer McCormick,R,326
+Clay,01 - Brazil,Superintendent of Public Instruction,,Glenda Ritz,D,231
+Clay,01 - Brazil,U.S. House,8,Larry D. Bucshon,R,368
+Clay,01 - Brazil,U.S. House,8,Ron Drake,D,163
+Clay,01 - Brazil,U.S. House,8,Andrew Horning,L,32
+Clay,01 - Brazil,U.S. House,8,Write-in,,0
+Clay,01 - Brazil,State House,42,Alan Morrison,R,345
+Clay,01 - Brazil,State House,42,Tim Skinner,D,219
+Clay,02 - Brazil,Voters,,Registered,,1237
+Clay,02 - Brazil,Voters,,Ballots Cast,,598
+Clay,02 - Brazil,Voters,,Straight Ticket,D,11
+Clay,02 - Brazil,Voters,,Straight Ticket,L,1
+Clay,02 - Brazil,Voters,,Straight Ticket,R,110
+Clay,02 - Brazil,President,,Donald J. Trump,R,422
+Clay,02 - Brazil,President,,Hillary Clinton,D,139
+Clay,02 - Brazil,President,,Gary Johnson,L,27
+Clay,02 - Brazil,President,,Write-In,,1
+Clay,02 - Brazil,U.S. Senate,,Todd Young,R,333
+Clay,02 - Brazil,U.S. Senate,,Evan Bayh,D,202
+Clay,02 - Brazil,U.S. Senate,,Lucy Brenton,L,44
+Clay,02 - Brazil,U.S. Senate,,Write-In,,1
+Clay,02 - Brazil,Governor,,Eric Holcomb,R,321
+Clay,02 - Brazil,Governor,,John R. Gregg,D,230
+Clay,02 - Brazil,Governor,,Rex Bell,L,27
+Clay,02 - Brazil,Governor,,Write-in,,0
+Clay,02 - Brazil,Attorney General,,"Curtis T. Hill, Jr.",R,409
+Clay,02 - Brazil,Attorney General,,Lorenzo Arredondo,D,146
+Clay,02 - Brazil,Superintendent of Public Instruction,,Jennifer McCormick,R,336
+Clay,02 - Brazil,Superintendent of Public Instruction,,Glenda Ritz,D,231
+Clay,02 - Brazil,U.S. House,8,Larry D. Bucshon,R,386
+Clay,02 - Brazil,U.S. House,8,Ron Drake,D,153
+Clay,02 - Brazil,U.S. House,8,Andrew Horning,L,32
+Clay,02 - Brazil,U.S. House,8,Write-in,,0
+Clay,02 - Brazil,State House,42,Alan Morrison,R,361
+Clay,02 - Brazil,State House,42,Tim Skinner,D,209
+Clay,03 - Brazil,Voters,,Registered,,1274
+Clay,03 - Brazil,Voters,,Ballots Cast,,540
+Clay,03 - Brazil,Voters,,Straight Ticket,D,22
+Clay,03 - Brazil,Voters,,Straight Ticket,L,0
+Clay,03 - Brazil,Voters,,Straight Ticket,R,90
+Clay,03 - Brazil,President,,Donald J. Trump,R,353
+Clay,03 - Brazil,President,,Hillary Clinton,D,146
+Clay,03 - Brazil,President,,Gary Johnson,L,29
+Clay,03 - Brazil,President,,Write-In,,4
+Clay,03 - Brazil,U.S. Senate,,Todd Young,R,245
+Clay,03 - Brazil,U.S. Senate,,Evan Bayh,D,226
+Clay,03 - Brazil,U.S. Senate,,Lucy Brenton,L,38
+Clay,03 - Brazil,U.S. Senate,,Write-In,,0
+Clay,03 - Brazil,Governor,,Eric Holcomb,R,269
+Clay,03 - Brazil,Governor,,John R. Gregg,D,223
+Clay,03 - Brazil,Governor,,Rex Bell,L,16
+Clay,03 - Brazil,Governor,,Write-in,,0
+Clay,03 - Brazil,Attorney General,,"Curtis T. Hill, Jr.",R,354
+Clay,03 - Brazil,Attorney General,,Lorenzo Arredondo,D,135
+Clay,03 - Brazil,Superintendent of Public Instruction,,Jennifer McCormick,R,293
+Clay,03 - Brazil,Superintendent of Public Instruction,,Glenda Ritz,D,205
+Clay,03 - Brazil,U.S. House,8,Larry D. Bucshon,R,320
+Clay,03 - Brazil,U.S. House,8,Ron Drake,D,154
+Clay,03 - Brazil,U.S. House,8,Andrew Horning,L,36
+Clay,03 - Brazil,U.S. House,8,Write-in,,0
+Clay,03 - Brazil,State House,42,Alan Morrison,R,304
+Clay,03 - Brazil,State House,42,Tim Skinner,D,201
+Clay,04 - Brazil,Voters,,Registered,,809
+Clay,04 - Brazil,Voters,,Ballots Cast,,425
+Clay,04 - Brazil,Voters,,Straight Ticket,D,5
+Clay,04 - Brazil,Voters,,Straight Ticket,L,0
+Clay,04 - Brazil,Voters,,Straight Ticket,R,57
+Clay,04 - Brazil,President,,Donald J. Trump,R,302
+Clay,04 - Brazil,President,,Hillary Clinton,D,98
+Clay,04 - Brazil,President,,Gary Johnson,L,13
+Clay,04 - Brazil,President,,Write-In,,5
+Clay,04 - Brazil,U.S. Senate,,Todd Young,R,206
+Clay,04 - Brazil,U.S. Senate,,Evan Bayh,D,163
+Clay,04 - Brazil,U.S. Senate,,Lucy Brenton,L,41
+Clay,04 - Brazil,U.S. Senate,,Write-In,,0
+Clay,04 - Brazil,Governor,,Eric Holcomb,R,221
+Clay,04 - Brazil,Governor,,John R. Gregg,D,162
+Clay,04 - Brazil,Governor,,Rex Bell,L,18
+Clay,04 - Brazil,Governor,,Write-in,,0
+Clay,04 - Brazil,Attorney General,,"Curtis T. Hill, Jr.",R,291
+Clay,04 - Brazil,Attorney General,,Lorenzo Arredondo,D,105
+Clay,04 - Brazil,Superintendent of Public Instruction,,Jennifer McCormick,R,228
+Clay,04 - Brazil,Superintendent of Public Instruction,,Glenda Ritz,D,176
+Clay,04 - Brazil,U.S. House,8,Larry D. Bucshon,R,273
+Clay,04 - Brazil,U.S. House,8,Ron Drake,D,107
+Clay,04 - Brazil,U.S. House,8,Andrew Horning,L,27
+Clay,04 - Brazil,U.S. House,8,Write-in,,0
+Clay,04 - Brazil,State House,42,Alan Morrison,R,247
+Clay,04 - Brazil,State House,42,Tim Skinner,D,154
+Clay,05 - Brazil,Voters,,Registered,,657
+Clay,05 - Brazil,Voters,,Ballots Cast,,411
+Clay,05 - Brazil,Voters,,Straight Ticket,D,10
+Clay,05 - Brazil,Voters,,Straight Ticket,L,0
+Clay,05 - Brazil,Voters,,Straight Ticket,R,64
+Clay,05 - Brazil,President,,Donald J. Trump,R,293
+Clay,05 - Brazil,President,,Hillary Clinton,D,90
+Clay,05 - Brazil,President,,Gary Johnson,L,16
+Clay,05 - Brazil,President,,Write-In,,4
+Clay,05 - Brazil,U.S. Senate,,Todd Young,R,227
+Clay,05 - Brazil,U.S. Senate,,Evan Bayh,D,145
+Clay,05 - Brazil,U.S. Senate,,Lucy Brenton,L,22
+Clay,05 - Brazil,U.S. Senate,,Write-In,,0
+Clay,05 - Brazil,Governor,,Eric Holcomb,R,228
+Clay,05 - Brazil,Governor,,John R. Gregg,D,158
+Clay,05 - Brazil,Governor,,Rex Bell,L,12
+Clay,05 - Brazil,Governor,,Write-in,,0
+Clay,05 - Brazil,Attorney General,,"Curtis T. Hill, Jr.",R,280
+Clay,05 - Brazil,Attorney General,,Lorenzo Arredondo,D,102
+Clay,05 - Brazil,Superintendent of Public Instruction,,Jennifer McCormick,R,229
+Clay,05 - Brazil,Superintendent of Public Instruction,,Glenda Ritz,D,160
+Clay,05 - Brazil,U.S. House,8,Larry D. Bucshon,R,283
+Clay,05 - Brazil,U.S. House,8,Ron Drake,D,84
+Clay,05 - Brazil,U.S. House,8,Andrew Horning,L,30
+Clay,05 - Brazil,U.S. House,8,Write-in,,0
+Clay,05 - Brazil,State House,42,Alan Morrison,R,265
+Clay,05 - Brazil,State House,42,Tim Skinner,D,131
+Clay,06 - Brazil,Voters,,Registered,,646
+Clay,06 - Brazil,Voters,,Ballots Cast,,265
+Clay,06 - Brazil,Voters,,Straight Ticket,D,7
+Clay,06 - Brazil,Voters,,Straight Ticket,L,0
+Clay,06 - Brazil,Voters,,Straight Ticket,R,55
+Clay,06 - Brazil,President,,Donald J. Trump,R,198
+Clay,06 - Brazil,President,,Hillary Clinton,D,52
+Clay,06 - Brazil,President,,Gary Johnson,L,10
+Clay,06 - Brazil,President,,Write-In,,1
+Clay,06 - Brazil,U.S. Senate,,Todd Young,R,151
+Clay,06 - Brazil,U.S. Senate,,Evan Bayh,D,92
+Clay,06 - Brazil,U.S. Senate,,Lucy Brenton,L,12
+Clay,06 - Brazil,U.S. Senate,,Write-In,,0
+Clay,06 - Brazil,Governor,,Eric Holcomb,R,148
+Clay,06 - Brazil,Governor,,John R. Gregg,D,100
+Clay,06 - Brazil,Governor,,Rex Bell,L,6
+Clay,06 - Brazil,Governor,,Write-in,,0
+Clay,06 - Brazil,Attorney General,,"Curtis T. Hill, Jr.",R,180
+Clay,06 - Brazil,Attorney General,,Lorenzo Arredondo,D,63
+Clay,06 - Brazil,Superintendent of Public Instruction,,Jennifer McCormick,R,161
+Clay,06 - Brazil,Superintendent of Public Instruction,,Glenda Ritz,D,91
+Clay,06 - Brazil,U.S. House,8,Larry D. Bucshon,R,183
+Clay,06 - Brazil,U.S. House,8,Ron Drake,D,60
+Clay,06 - Brazil,U.S. House,8,Andrew Horning,L,10
+Clay,06 - Brazil,U.S. House,8,Write-in,,0
+Clay,06 - Brazil,State House,42,Alan Morrison,R,176
+Clay,06 - Brazil,State House,42,Tim Skinner,D,77
+Clay,07 - Cass,Voters,,Registered,,237
+Clay,07 - Cass,Voters,,Ballots Cast,,134
+Clay,07 - Cass,Voters,,Straight Ticket,D,3
+Clay,07 - Cass,Voters,,Straight Ticket,L,0
+Clay,07 - Cass,Voters,,Straight Ticket,R,31
+Clay,07 - Cass,President,,Donald J. Trump,R,99
+Clay,07 - Cass,President,,Hillary Clinton,D,28
+Clay,07 - Cass,President,,Gary Johnson,L,5
+Clay,07 - Cass,President,,Write-In,,1
+Clay,07 - Cass,U.S. Senate,,Todd Young,R,77
+Clay,07 - Cass,U.S. Senate,,Evan Bayh,D,46
+Clay,07 - Cass,U.S. Senate,,Lucy Brenton,L,6
+Clay,07 - Cass,U.S. Senate,,Write-In,,0
+Clay,07 - Cass,Governor,,Eric Holcomb,R,79
+Clay,07 - Cass,Governor,,John R. Gregg,D,47
+Clay,07 - Cass,Governor,,Rex Bell,L,5
+Clay,07 - Cass,Governor,,Write-in,,0
+Clay,07 - Cass,Attorney General,,"Curtis T. Hill, Jr.",R,94
+Clay,07 - Cass,Attorney General,,Lorenzo Arredondo,D,29
+Clay,07 - Cass,Superintendent of Public Instruction,,Jennifer McCormick,R,80
+Clay,07 - Cass,Superintendent of Public Instruction,,Glenda Ritz,D,47
+Clay,07 - Cass,U.S. House,8,Larry D. Bucshon,R,93
+Clay,07 - Cass,U.S. House,8,Ron Drake,D,32
+Clay,07 - Cass,U.S. House,8,Andrew Horning,L,4
+Clay,07 - Cass,State House,44,James (Jim) Baird,R,90
+Clay,07 - Cass,State House,44,Kimberly Fidler,D,39
+Clay,08 - Dick Johnson,Voters,,Registered,,1068
+Clay,08 - Dick Johnson,Voters,,Ballots Cast,,640
+Clay,08 - Dick Johnson,Voters,,Straight Ticket,D,17
+Clay,08 - Dick Johnson,Voters,,Straight Ticket,L,0
+Clay,08 - Dick Johnson,Voters,,Straight Ticket,R,103
+Clay,08 - Dick Johnson,President,,Donald J. Trump,R,506
+Clay,08 - Dick Johnson,President,,Hillary Clinton,D,104
+Clay,08 - Dick Johnson,President,,Gary Johnson,L,23
+Clay,08 - Dick Johnson,President,,Write-In,,2
+Clay,08 - Dick Johnson,U.S. Senate,,Todd Young,R,370
+Clay,08 - Dick Johnson,U.S. Senate,,Evan Bayh,D,223
+Clay,08 - Dick Johnson,U.S. Senate,,Lucy Brenton,L,35
+Clay,08 - Dick Johnson,U.S. Senate,,Write-In,,0
+Clay,08 - Dick Johnson,Governor,,Eric Holcomb,R,387
+Clay,08 - Dick Johnson,Governor,,John R. Gregg,D,212
+Clay,08 - Dick Johnson,Governor,,Rex Bell,L,20
+Clay,08 - Dick Johnson,Governor,,Write-in,,1
+Clay,08 - Dick Johnson,Attorney General,,"Curtis T. Hill, Jr.",R,468
+Clay,08 - Dick Johnson,Attorney General,,Lorenzo Arredondo,D,123
+Clay,08 - Dick Johnson,Superintendent of Public Instruction,,Jennifer McCormick,R,366
+Clay,08 - Dick Johnson,Superintendent of Public Instruction,,Glenda Ritz,D,241
+Clay,08 - Dick Johnson,U.S. House,8,Larry D. Bucshon,R,460
+Clay,08 - Dick Johnson,U.S. House,8,Ron Drake,D,129
+Clay,08 - Dick Johnson,U.S. House,8,Andrew Horning,L,24
+Clay,08 - Dick Johnson,U.S. House,8,Write-in,,0
+Clay,08 - Dick Johnson,State House,42,Alan Morrison,R,411
+Clay,08 - Dick Johnson,State House,42,Tim Skinner,D,207
+Clay,09 - Harrison 1,Voters,,Registered,,791
+Clay,09 - Harrison 1,Voters,,Ballots Cast,,468
+Clay,09 - Harrison 1,Voters,,Straight Ticket,D,6
+Clay,09 - Harrison 1,Voters,,Straight Ticket,L,0
+Clay,09 - Harrison 1,Voters,,Straight Ticket,R,66
+Clay,09 - Harrison 1,President,,Donald J. Trump,R,367
+Clay,09 - Harrison 1,President,,Hillary Clinton,D,76
+Clay,09 - Harrison 1,President,,Gary Johnson,L,17
+Clay,09 - Harrison 1,President,,Write-In,,4
+Clay,09 - Harrison 1,U.S. Senate,,Todd Young,R,267
+Clay,09 - Harrison 1,U.S. Senate,,Evan Bayh,D,161
+Clay,09 - Harrison 1,U.S. Senate,,Lucy Brenton,L,22
+Clay,09 - Harrison 1,U.S. Senate,,Write-In,,0
+Clay,09 - Harrison 1,Governor,,Eric Holcomb,R,259
+Clay,09 - Harrison 1,Governor,,John R. Gregg,D,171
+Clay,09 - Harrison 1,Governor,,Rex Bell,L,13
+Clay,09 - Harrison 1,Governor,,Write-in,,0
+Clay,09 - Harrison 1,Attorney General,,"Curtis T. Hill, Jr.",R,316
+Clay,09 - Harrison 1,Attorney General,,Lorenzo Arredondo,D,96
+Clay,09 - Harrison 1,Superintendent of Public Instruction,,Jennifer McCormick,R,249
+Clay,09 - Harrison 1,Superintendent of Public Instruction,,Glenda Ritz,D,179
+Clay,09 - Harrison 1,U.S. House,8,Larry D. Bucshon,R,317
+Clay,09 - Harrison 1,U.S. House,8,Ron Drake,D,101
+Clay,09 - Harrison 1,U.S. House,8,Andrew Horning,L,18
+Clay,09 - Harrison 1,U.S. House,8,Write-in,,0
+Clay,09 - Harrison 1,State House,46,Bob Heaton,R,332
+Clay,09 - Harrison 1,State House,46,Bill Breeden,D,107
+Clay,10 - Harrison 2,Voters,,Registered,,851
+Clay,10 - Harrison 2,Voters,,Ballots Cast,,574
+Clay,10 - Harrison 2,Voters,,Straight Ticket,D,9
+Clay,10 - Harrison 2,Voters,,Straight Ticket,L,0
+Clay,10 - Harrison 2,Voters,,Straight Ticket,R,98
+Clay,10 - Harrison 2,President,,Donald J. Trump,R,462
+Clay,10 - Harrison 2,President,,Hillary Clinton,D,80
+Clay,10 - Harrison 2,President,,Gary Johnson,L,20
+Clay,10 - Harrison 2,President,,Write-In,,5
+Clay,10 - Harrison 2,U.S. Senate,,Todd Young,R,370
+Clay,10 - Harrison 2,U.S. Senate,,Evan Bayh,D,156
+Clay,10 - Harrison 2,U.S. Senate,,Lucy Brenton,L,33
+Clay,10 - Harrison 2,U.S. Senate,,Write-In,,0
+Clay,10 - Harrison 2,Governor,,Eric Holcomb,R,358
+Clay,10 - Harrison 2,Governor,,John R. Gregg,D,185
+Clay,10 - Harrison 2,Governor,,Rex Bell,L,17
+Clay,10 - Harrison 2,Governor,,Write-in,,1
+Clay,10 - Harrison 2,Attorney General,,"Curtis T. Hill, Jr.",R,443
+Clay,10 - Harrison 2,Attorney General,,Lorenzo Arredondo,D,90
+Clay,10 - Harrison 2,Superintendent of Public Instruction,,Jennifer McCormick,R,351
+Clay,10 - Harrison 2,Superintendent of Public Instruction,,Glenda Ritz,D,199
+Clay,10 - Harrison 2,U.S. House,8,Larry D. Bucshon,R,431
+Clay,10 - Harrison 2,U.S. House,8,Ron Drake,D,96
+Clay,10 - Harrison 2,U.S. House,8,Andrew Horning,L,28
+Clay,10 - Harrison 2,U.S. House,8,Write-in,,0
+Clay,10 - Harrison 2,State House,46,Bob Heaton,R,425
+Clay,10 - Harrison 2,State House,46,Bill Breeden,D,136
+Clay,11 - Jackson 1,Voters,,Registered,,702
+Clay,11 - Jackson 1,Voters,,Ballots Cast,,464
+Clay,11 - Jackson 1,Voters,,Straight Ticket,D,2
+Clay,11 - Jackson 1,Voters,,Straight Ticket,L,0
+Clay,11 - Jackson 1,Voters,,Straight Ticket,R,85
+Clay,11 - Jackson 1,President,,Donald J. Trump,R,358
+Clay,11 - Jackson 1,President,,Hillary Clinton,D,82
+Clay,11 - Jackson 1,President,,Gary Johnson,L,14
+Clay,11 - Jackson 1,President,,Write-In,,5
+Clay,11 - Jackson 1,U.S. Senate,,Todd Young,R,259
+Clay,11 - Jackson 1,U.S. Senate,,Evan Bayh,D,159
+Clay,11 - Jackson 1,U.S. Senate,,Lucy Brenton,L,29
+Clay,11 - Jackson 1,U.S. Senate,,Write-In,,0
+Clay,11 - Jackson 1,Governor,,Eric Holcomb,R,265
+Clay,11 - Jackson 1,Governor,,John R. Gregg,D,165
+Clay,11 - Jackson 1,Governor,,Rex Bell,L,15
+Clay,11 - Jackson 1,Governor,,Write-in,,0
+Clay,11 - Jackson 1,Attorney General,,"Curtis T. Hill, Jr.",R,327
+Clay,11 - Jackson 1,Attorney General,,Lorenzo Arredondo,D,101
+Clay,11 - Jackson 1,Superintendent of Public Instruction,,Jennifer McCormick,R,261
+Clay,11 - Jackson 1,Superintendent of Public Instruction,,Glenda Ritz,D,174
+Clay,11 - Jackson 1,U.S. House,8,Larry D. Bucshon,R,327
+Clay,11 - Jackson 1,U.S. House,8,Ron Drake,D,90
+Clay,11 - Jackson 1,U.S. House,8,Andrew Horning,L,18
+Clay,11 - Jackson 1,U.S. House,8,Write-in,,0
+Clay,11 - Jackson 1,State House,44,James (Jim) Baird,R,308
+Clay,11 - Jackson 1,State House,44,Kimberly Fidler,D,126
+Clay,12 - Jackson 2,Voters,,Registered,,1263
+Clay,12 - Jackson 2,Voters,,Ballots Cast,,826
+Clay,12 - Jackson 2,Voters,,Straight Ticket,D,18
+Clay,12 - Jackson 2,Voters,,Straight Ticket,L,0
+Clay,12 - Jackson 2,Voters,,Straight Ticket,R,110
+Clay,12 - Jackson 2,President,,Donald J. Trump,R,611
+Clay,12 - Jackson 2,President,,Hillary Clinton,D,165
+Clay,12 - Jackson 2,President,,Gary Johnson,L,23
+Clay,12 - Jackson 2,President,,Write-In,,8
+Clay,12 - Jackson 2,U.S. Senate,,Todd Young,R,487
+Clay,12 - Jackson 2,U.S. Senate,,Evan Bayh,D,281
+Clay,12 - Jackson 2,U.S. Senate,,Lucy Brenton,L,36
+Clay,12 - Jackson 2,U.S. Senate,,Write-In,,0
+Clay,12 - Jackson 2,Governor,,Eric Holcomb,R,474
+Clay,12 - Jackson 2,Governor,,John R. Gregg,D,298
+Clay,12 - Jackson 2,Governor,,Rex Bell,L,22
+Clay,12 - Jackson 2,Governor,,Write-in,,1
+Clay,12 - Jackson 2,Attorney General,,"Curtis T. Hill, Jr.",R,568
+Clay,12 - Jackson 2,Attorney General,,Lorenzo Arredondo,D,176
+Clay,12 - Jackson 2,Superintendent of Public Instruction,,Jennifer McCormick,R,463
+Clay,12 - Jackson 2,Superintendent of Public Instruction,,Glenda Ritz,D,316
+Clay,12 - Jackson 2,U.S. House,8,Larry D. Bucshon,R,588
+Clay,12 - Jackson 2,U.S. House,8,Ron Drake,D,173
+Clay,12 - Jackson 2,U.S. House,8,Andrew Horning,L,25
+Clay,12 - Jackson 2,U.S. House,8,Write-in,,0
+Clay,12 - Jackson 2,State House,44,James (Jim) Baird,R,557
+Clay,12 - Jackson 2,State House,44,Kimberly Fidler,D,221
+Clay,13 - Jackson 3,Voters,,Registered,,353
+Clay,13 - Jackson 3,Voters,,Ballots Cast,,264
+Clay,13 - Jackson 3,Voters,,Straight Ticket,D,8
+Clay,13 - Jackson 3,Voters,,Straight Ticket,L,0
+Clay,13 - Jackson 3,Voters,,Straight Ticket,R,31
+Clay,13 - Jackson 3,President,,Donald J. Trump,R,192
+Clay,13 - Jackson 3,President,,Hillary Clinton,D,59
+Clay,13 - Jackson 3,President,,Gary Johnson,L,10
+Clay,13 - Jackson 3,President,,Write-In,,1
+Clay,13 - Jackson 3,U.S. Senate,,Todd Young,R,153
+Clay,13 - Jackson 3,U.S. Senate,,Evan Bayh,D,102
+Clay,13 - Jackson 3,U.S. Senate,,Lucy Brenton,L,6
+Clay,13 - Jackson 3,U.S. Senate,,Write-In,,0
+Clay,13 - Jackson 3,Governor,,Eric Holcomb,R,158
+Clay,13 - Jackson 3,Governor,,John R. Gregg,D,98
+Clay,13 - Jackson 3,Governor,,Rex Bell,L,2
+Clay,13 - Jackson 3,Governor,,Write-in,,0
+Clay,13 - Jackson 3,Attorney General,,"Curtis T. Hill, Jr.",R,186
+Clay,13 - Jackson 3,Attorney General,,Lorenzo Arredondo,D,60
+Clay,13 - Jackson 3,Superintendent of Public Instruction,,Jennifer McCormick,R,141
+Clay,13 - Jackson 3,Superintendent of Public Instruction,,Glenda Ritz,D,110
+Clay,13 - Jackson 3,U.S. House,8,Larry D. Bucshon,R,178
+Clay,13 - Jackson 3,U.S. House,8,Ron Drake,D,64
+Clay,13 - Jackson 3,U.S. House,8,Andrew Horning,L,9
+Clay,13 - Jackson 3,U.S. House,8,Write-in,,0
+Clay,13 - Jackson 3,State House,44,James (Jim) Baird,R,168
+Clay,13 - Jackson 3,State House,44,Kimberly Fidler,D,85
+Clay,14 - Lewis,Voters,,Registered,,950
+Clay,14 - Lewis,Voters,,Ballots Cast,,644
+Clay,14 - Lewis,Voters,,Straight Ticket,D,31
+Clay,14 - Lewis,Voters,,Straight Ticket,L,0
+Clay,14 - Lewis,Voters,,Straight Ticket,R,108
+Clay,14 - Lewis,President,,Donald J. Trump,R,493
+Clay,14 - Lewis,President,,Hillary Clinton,D,110
+Clay,14 - Lewis,President,,Gary Johnson,L,28
+Clay,14 - Lewis,President,,Write-In,,5
+Clay,14 - Lewis,U.S. Senate,,Todd Young,R,349
+Clay,14 - Lewis,U.S. Senate,,Evan Bayh,D,224
+Clay,14 - Lewis,U.S. Senate,,Lucy Brenton,L,47
+Clay,14 - Lewis,U.S. Senate,,Write-In,,0
+Clay,14 - Lewis,Governor,,Eric Holcomb,R,296
+Clay,14 - Lewis,Governor,,John R. Gregg,D,315
+Clay,14 - Lewis,Governor,,Rex Bell,L,15
+Clay,14 - Lewis,Governor,,Write-in,,0
+Clay,14 - Lewis,Attorney General,,"Curtis T. Hill, Jr.",R,443
+Clay,14 - Lewis,Attorney General,,Lorenzo Arredondo,D,142
+Clay,14 - Lewis,Superintendent of Public Instruction,,Jennifer McCormick,R,340
+Clay,14 - Lewis,Superintendent of Public Instruction,,Glenda Ritz,D,262
+Clay,14 - Lewis,U.S. House,8,Larry D. Bucshon,R,417
+Clay,14 - Lewis,U.S. House,8,Ron Drake,D,162
+Clay,14 - Lewis,U.S. House,8,Andrew Horning,L,26
+Clay,14 - Lewis,U.S. House,8,Write-in,,0
+Clay,14 - Lewis,State House,46,Bob Heaton,R,438
+Clay,14 - Lewis,State House,46,Bill Breeden,D,180
+Clay,15 - Perry,Voters,,Registered,,681
+Clay,15 - Perry,Voters,,Ballots Cast,,485
+Clay,15 - Perry,Voters,,Straight Ticket,D,7
+Clay,15 - Perry,Voters,,Straight Ticket,L,0
+Clay,15 - Perry,Voters,,Straight Ticket,R,80
+Clay,15 - Perry,President,,Donald J. Trump,R,393
+Clay,15 - Perry,President,,Hillary Clinton,D,76
+Clay,15 - Perry,President,,Gary Johnson,L,9
+Clay,15 - Perry,President,,Write-In,,0
+Clay,15 - Perry,U.S. Senate,,Todd Young,R,306
+Clay,15 - Perry,U.S. Senate,,Evan Bayh,D,142
+Clay,15 - Perry,U.S. Senate,,Lucy Brenton,L,21
+Clay,15 - Perry,U.S. Senate,,Write-In,,0
+Clay,15 - Perry,Governor,,Eric Holcomb,R,289
+Clay,15 - Perry,Governor,,John R. Gregg,D,163
+Clay,15 - Perry,Governor,,Rex Bell,L,13
+Clay,15 - Perry,Governor,,Write-in,,0
+Clay,15 - Perry,Attorney General,,"Curtis T. Hill, Jr.",R,366
+Clay,15 - Perry,Attorney General,,Lorenzo Arredondo,D,79
+Clay,15 - Perry,Superintendent of Public Instruction,,Jennifer McCormick,R,283
+Clay,15 - Perry,Superintendent of Public Instruction,,Glenda Ritz,D,167
+Clay,15 - Perry,U.S. House,8,Larry D. Bucshon,R,363
+Clay,15 - Perry,U.S. House,8,Ron Drake,D,86
+Clay,15 - Perry,U.S. House,8,Andrew Horning,L,15
+Clay,15 - Perry,U.S. House,8,Write-in,,0
+Clay,15 - Perry,State House,46,Bob Heaton,R,349
+Clay,15 - Perry,State House,46,Bill Breeden,D,116
+Clay,16 - Posey 1,Voters,,Registered,,1138
+Clay,16 - Posey 1,Voters,,Ballots Cast,,718
+Clay,16 - Posey 1,Voters,,Straight Ticket,D,16
+Clay,16 - Posey 1,Voters,,Straight Ticket,L,0
+Clay,16 - Posey 1,Voters,,Straight Ticket,R,111
+Clay,16 - Posey 1,President,,Donald J. Trump,R,517
+Clay,16 - Posey 1,President,,Hillary Clinton,D,169
+Clay,16 - Posey 1,President,,Gary Johnson,L,18
+Clay,16 - Posey 1,President,,Write-In,,8
+Clay,16 - Posey 1,U.S. Senate,,Todd Young,R,399
+Clay,16 - Posey 1,U.S. Senate,,Evan Bayh,D,254
+Clay,16 - Posey 1,U.S. Senate,,Lucy Brenton,L,47
+Clay,16 - Posey 1,U.S. Senate,,Write-In,,1
+Clay,16 - Posey 1,Governor,,Eric Holcomb,R,404
+Clay,16 - Posey 1,Governor,,John R. Gregg,D,268
+Clay,16 - Posey 1,Governor,,Rex Bell,L,19
+Clay,16 - Posey 1,Governor,,Write-in,,0
+Clay,16 - Posey 1,Attorney General,,"Curtis T. Hill, Jr.",R,494
+Clay,16 - Posey 1,Attorney General,,Lorenzo Arredondo,D,176
+Clay,16 - Posey 1,Superintendent of Public Instruction,,Jennifer McCormick,R,385
+Clay,16 - Posey 1,Superintendent of Public Instruction,,Glenda Ritz,D,296
+Clay,16 - Posey 1,U.S. House,8,Larry D. Bucshon,R,495
+Clay,16 - Posey 1,U.S. House,8,Ron Drake,D,162
+Clay,16 - Posey 1,U.S. House,8,Andrew Horning,L,30
+Clay,16 - Posey 1,U.S. House,8,Write-in,,0
+Clay,16 - Posey 1,State House,42,Alan Morrison,R,427
+Clay,16 - Posey 1,State House,42,Tim Skinner,D,259
+Clay,17 - Posey 2,Voters,,Registered,,653
+Clay,17 - Posey 2,Voters,,Ballots Cast,,356
+Clay,17 - Posey 2,Voters,,Straight Ticket,D,6
+Clay,17 - Posey 2,Voters,,Straight Ticket,L,0
+Clay,17 - Posey 2,Voters,,Straight Ticket,R,59
+Clay,17 - Posey 2,President,,Donald J. Trump,R,263
+Clay,17 - Posey 2,President,,Hillary Clinton,D,76
+Clay,17 - Posey 2,President,,Gary Johnson,L,13
+Clay,17 - Posey 2,President,,Write-In,,1
+Clay,17 - Posey 2,U.S. Senate,,Todd Young,R,200
+Clay,17 - Posey 2,U.S. Senate,,Evan Bayh,D,119
+Clay,17 - Posey 2,U.S. Senate,,Lucy Brenton,L,29
+Clay,17 - Posey 2,U.S. Senate,,Write-In,,0
+Clay,17 - Posey 2,Governor,,Eric Holcomb,R,211
+Clay,17 - Posey 2,Governor,,John R. Gregg,D,117
+Clay,17 - Posey 2,Governor,,Rex Bell,L,19
+Clay,17 - Posey 2,Governor,,Write-in,,0
+Clay,17 - Posey 2,Attorney General,,"Curtis T. Hill, Jr.",R,246
+Clay,17 - Posey 2,Attorney General,,Lorenzo Arredondo,D,87
+Clay,17 - Posey 2,Superintendent of Public Instruction,,Jennifer McCormick,R,201
+Clay,17 - Posey 2,Superintendent of Public Instruction,,Glenda Ritz,D,135
+Clay,17 - Posey 2,U.S. House,8,Larry D. Bucshon,R,239
+Clay,17 - Posey 2,U.S. House,8,Ron Drake,D,84
+Clay,17 - Posey 2,U.S. House,8,Andrew Horning,L,24
+Clay,17 - Posey 2,U.S. House,8,Write-in,,0
+Clay,17 - Posey 2,State House,42,Alan Morrison,R,215
+Clay,17 - Posey 2,State House,42,Tim Skinner,D,131
+Clay,18 - Posey 3,Voters,,Registered,,1221
+Clay,18 - Posey 3,Voters,,Ballots Cast,,790
+Clay,18 - Posey 3,Voters,,Straight Ticket,D,32
+Clay,18 - Posey 3,Voters,,Straight Ticket,L,1
+Clay,18 - Posey 3,Voters,,Straight Ticket,R,118
+Clay,18 - Posey 3,President,,Donald J. Trump,R,563
+Clay,18 - Posey 3,President,,Hillary Clinton,D,173
+Clay,18 - Posey 3,President,,Gary Johnson,L,41
+Clay,18 - Posey 3,President,,Write-In,,4
+Clay,18 - Posey 3,U.S. Senate,,Todd Young,R,433
+Clay,18 - Posey 3,U.S. Senate,,Evan Bayh,D,279
+Clay,18 - Posey 3,U.S. Senate,,Lucy Brenton,L,58
+Clay,18 - Posey 3,U.S. Senate,,Write-In,,0
+Clay,18 - Posey 3,Governor,,Eric Holcomb,R,432
+Clay,18 - Posey 3,Governor,,John R. Gregg,D,314
+Clay,18 - Posey 3,Governor,,Rex Bell,L,21
+Clay,18 - Posey 3,Governor,,Write-in,,0
+Clay,18 - Posey 3,Attorney General,,"Curtis T. Hill, Jr.",R,547
+Clay,18 - Posey 3,Attorney General,,Lorenzo Arredondo,D,197
+Clay,18 - Posey 3,Superintendent of Public Instruction,,Jennifer McCormick,R,426
+Clay,18 - Posey 3,Superintendent of Public Instruction,,Glenda Ritz,D,327
+Clay,18 - Posey 3,U.S. House,8,Larry D. Bucshon,R,531
+Clay,18 - Posey 3,U.S. House,8,Ron Drake,D,193
+Clay,18 - Posey 3,U.S. House,8,Andrew Horning,L,32
+Clay,18 - Posey 3,U.S. House,8,Write-in,,0
+Clay,18 - Posey 3,State House,42,Alan Morrison,R,467
+Clay,18 - Posey 3,State House,42,Tim Skinner,D,290
+Clay,19 - Sugar Ridge,Voters,,Registered,,726
+Clay,19 - Sugar Ridge,Voters,,Ballots Cast,,489
+Clay,19 - Sugar Ridge,Voters,,Straight Ticket,D,12
+Clay,19 - Sugar Ridge,Voters,,Straight Ticket,L,0
+Clay,19 - Sugar Ridge,Voters,,Straight Ticket,R,77
+Clay,19 - Sugar Ridge,President,,Donald J. Trump,R,377
+Clay,19 - Sugar Ridge,President,,Hillary Clinton,D,94
+Clay,19 - Sugar Ridge,President,,Gary Johnson,L,13
+Clay,19 - Sugar Ridge,President,,Write-In,,1
+Clay,19 - Sugar Ridge,U.S. Senate,,Todd Young,R,292
+Clay,19 - Sugar Ridge,U.S. Senate,,Evan Bayh,D,161
+Clay,19 - Sugar Ridge,U.S. Senate,,Lucy Brenton,L,26
+Clay,19 - Sugar Ridge,U.S. Senate,,Write-In,,0
+Clay,19 - Sugar Ridge,Governor,,Eric Holcomb,R,270
+Clay,19 - Sugar Ridge,Governor,,John R. Gregg,D,195
+Clay,19 - Sugar Ridge,Governor,,Rex Bell,L,14
+Clay,19 - Sugar Ridge,Governor,,Write-in,,0
+Clay,19 - Sugar Ridge,Attorney General,,"Curtis T. Hill, Jr.",R,353
+Clay,19 - Sugar Ridge,Attorney General,,Lorenzo Arredondo,D,96
+Clay,19 - Sugar Ridge,Superintendent of Public Instruction,,Jennifer McCormick,R,272
+Clay,19 - Sugar Ridge,Superintendent of Public Instruction,,Glenda Ritz,D,188
+Clay,19 - Sugar Ridge,U.S. House,8,Larry D. Bucshon,R,347
+Clay,19 - Sugar Ridge,U.S. House,8,Ron Drake,D,106
+Clay,19 - Sugar Ridge,U.S. House,8,Andrew Horning,L,15
+Clay,19 - Sugar Ridge,U.S. House,8,Write-in,,0
+Clay,19 - Sugar Ridge,State House,46,Bob Heaton,R,343
+Clay,19 - Sugar Ridge,State House,46,Bill Breeden,D,133
+Clay,20 - Van Buren 1,Voters,,Registered,,530
+Clay,20 - Van Buren 1,Voters,,Ballots Cast,,268
+Clay,20 - Van Buren 1,Voters,,Straight Ticket,D,6
+Clay,20 - Van Buren 1,Voters,,Straight Ticket,L,0
+Clay,20 - Van Buren 1,Voters,,Straight Ticket,R,46
+Clay,20 - Van Buren 1,President,,Donald J. Trump,R,206
+Clay,20 - Van Buren 1,President,,Hillary Clinton,D,45
+Clay,20 - Van Buren 1,President,,Gary Johnson,L,13
+Clay,20 - Van Buren 1,President,,Write-In,,1
+Clay,20 - Van Buren 1,U.S. Senate,,Todd Young,R,149
+Clay,20 - Van Buren 1,U.S. Senate,,Evan Bayh,D,100
+Clay,20 - Van Buren 1,U.S. Senate,,Lucy Brenton,L,13
+Clay,20 - Van Buren 1,U.S. Senate,,Write-In,,0
+Clay,20 - Van Buren 1,Governor,,Eric Holcomb,R,161
+Clay,20 - Van Buren 1,Governor,,John R. Gregg,D,87
+Clay,20 - Van Buren 1,Governor,,Rex Bell,L,10
+Clay,20 - Van Buren 1,Governor,,Write-in,,0
+Clay,20 - Van Buren 1,Attorney General,,"Curtis T. Hill, Jr.",R,190
+Clay,20 - Van Buren 1,Attorney General,,Lorenzo Arredondo,D,60
+Clay,20 - Van Buren 1,Superintendent of Public Instruction,,Jennifer McCormick,R,164
+Clay,20 - Van Buren 1,Superintendent of Public Instruction,,Glenda Ritz,D,90
+Clay,20 - Van Buren 1,U.S. House,8,Larry D. Bucshon,R,187
+Clay,20 - Van Buren 1,U.S. House,8,Ron Drake,D,62
+Clay,20 - Van Buren 1,U.S. House,8,Andrew Horning,L,12
+Clay,20 - Van Buren 1,U.S. House,8,Write-in,,0
+Clay,20 - Van Buren 1,State House,44,James (Jim) Baird,R,174
+Clay,20 - Van Buren 1,State House,44,Kimberly Fidler,D,81
+Clay,21 - Van Buren 2,Voters,,Registered,,723
+Clay,21 - Van Buren 2,Voters,,Ballots Cast,,399
+Clay,21 - Van Buren 2,Voters,,Straight Ticket,D,5
+Clay,21 - Van Buren 2,Voters,,Straight Ticket,L,0
+Clay,21 - Van Buren 2,Voters,,Straight Ticket,R,63
+Clay,21 - Van Buren 2,President,,Donald J. Trump,R,283
+Clay,21 - Van Buren 2,President,,Hillary Clinton,D,85
+Clay,21 - Van Buren 2,President,,Gary Johnson,L,24
+Clay,21 - Van Buren 2,President,,Write-In,,1
+Clay,21 - Van Buren 2,U.S. Senate,,Todd Young,R,201
+Clay,21 - Van Buren 2,U.S. Senate,,Evan Bayh,D,156
+Clay,21 - Van Buren 2,U.S. Senate,,Lucy Brenton,L,22
+Clay,21 - Van Buren 2,U.S. Senate,,Write-In,,0
+Clay,21 - Van Buren 2,Governor,,Eric Holcomb,R,219
+Clay,21 - Van Buren 2,Governor,,John R. Gregg,D,145
+Clay,21 - Van Buren 2,Governor,,Rex Bell,L,16
+Clay,21 - Van Buren 2,Governor,,Write-in,,0
+Clay,21 - Van Buren 2,Attorney General,,"Curtis T. Hill, Jr.",R,277
+Clay,21 - Van Buren 2,Attorney General,,Lorenzo Arredondo,D,90
+Clay,21 - Van Buren 2,Superintendent of Public Instruction,,Jennifer McCormick,R,219
+Clay,21 - Van Buren 2,Superintendent of Public Instruction,,Glenda Ritz,D,154
+Clay,21 - Van Buren 2,U.S. House,8,Larry D. Bucshon,R,263
+Clay,21 - Van Buren 2,U.S. House,8,Ron Drake,D,94
+Clay,21 - Van Buren 2,U.S. House,8,Andrew Horning,L,18
+Clay,21 - Van Buren 2,U.S. House,8,Write-in,,0
+Clay,21 - Van Buren 2,State House,42,Alan Morrison,R,244
+Clay,21 - Van Buren 2,State House,42,Tim Skinner,D,126
+Clay,22 - Van Buren 3,Voters,,Registered,,1084
+Clay,22 - Van Buren 3,Voters,,Ballots Cast,,703
+Clay,22 - Van Buren 3,Voters,,Straight Ticket,D,16
+Clay,22 - Van Buren 3,Voters,,Straight Ticket,L,0
+Clay,22 - Van Buren 3,Voters,,Straight Ticket,R,114
+Clay,22 - Van Buren 3,President,,Donald J. Trump,R,541
+Clay,22 - Van Buren 3,President,,Hillary Clinton,D,120
+Clay,22 - Van Buren 3,President,,Gary Johnson,L,30
+Clay,22 - Van Buren 3,President,,Write-In,,1
+Clay,22 - Van Buren 3,U.S. Senate,,Todd Young,R,409
+Clay,22 - Van Buren 3,U.S. Senate,,Evan Bayh,D,228
+Clay,22 - Van Buren 3,U.S. Senate,,Lucy Brenton,L,48
+Clay,22 - Van Buren 3,U.S. Senate,,Write-In,,0
+Clay,22 - Van Buren 3,Governor,,Eric Holcomb,R,418
+Clay,22 - Van Buren 3,Governor,,John R. Gregg,D,242
+Clay,22 - Van Buren 3,Governor,,Rex Bell,L,16
+Clay,22 - Van Buren 3,Governor,,Write-in,,0
+Clay,22 - Van Buren 3,Attorney General,,"Curtis T. Hill, Jr.",R,520
+Clay,22 - Van Buren 3,Attorney General,,Lorenzo Arredondo,D,130
+Clay,22 - Van Buren 3,Superintendent of Public Instruction,,Jennifer McCormick,R,408
+Clay,22 - Van Buren 3,Superintendent of Public Instruction,,Glenda Ritz,D,260
+Clay,22 - Van Buren 3,U.S. House,8,Larry D. Bucshon,R,502
+Clay,22 - Van Buren 3,U.S. House,8,Ron Drake,D,139
+Clay,22 - Van Buren 3,U.S. House,8,Andrew Horning,L,31
+Clay,22 - Van Buren 3,U.S. House,8,Write-in,,0
+Clay,22 - Van Buren 3,State House,44,James (Jim) Baird,R,474
+Clay,22 - Van Buren 3,State House,44,Kimberly Fidler,D,201
+Clay,23 - Washington,Voters,,Registered,,640
+Clay,23 - Washington,Voters,,Ballots Cast,,422
+Clay,23 - Washington,Voters,,Straight Ticket,D,3
+Clay,23 - Washington,Voters,,Straight Ticket,L,0
+Clay,23 - Washington,Voters,,Straight Ticket,R,73
+Clay,23 - Washington,President,,Donald J. Trump,R,329
+Clay,23 - Washington,President,,Hillary Clinton,D,70
+Clay,23 - Washington,President,,Gary Johnson,L,11
+Clay,23 - Washington,President,,Write-In,,4
+Clay,23 - Washington,U.S. Senate,,Todd Young,R,264
+Clay,23 - Washington,U.S. Senate,,Evan Bayh,D,118
+Clay,23 - Washington,U.S. Senate,,Lucy Brenton,L,23
+Clay,23 - Washington,U.S. Senate,,Write-In,,0
+Clay,23 - Washington,Governor,,Eric Holcomb,R,260
+Clay,23 - Washington,Governor,,John R. Gregg,D,140
+Clay,23 - Washington,Governor,,Rex Bell,L,5
+Clay,23 - Washington,Governor,,Write-in,,0
+Clay,23 - Washington,Attorney General,,"Curtis T. Hill, Jr.",R,313
+Clay,23 - Washington,Attorney General,,Lorenzo Arredondo,D,70
+Clay,23 - Washington,Superintendent of Public Instruction,,Jennifer McCormick,R,252
+Clay,23 - Washington,Superintendent of Public Instruction,,Glenda Ritz,D,140
+Clay,23 - Washington,U.S. House,8,Larry D. Bucshon,R,308
+Clay,23 - Washington,U.S. House,8,Ron Drake,D,78
+Clay,23 - Washington,U.S. House,8,Andrew Horning,L,18
+Clay,23 - Washington,U.S. House,8,Write-in,,0
+Clay,23 - Washington,State House,46,Bob Heaton,R,327
+Clay,23 - Washington,State House,46,Bill Breeden,D,80
+Clay,Total,Voters,,Registered,,19581
+Clay,Total,Voters,,Ballots Cast,,11479
+Clay,Total,Voters,,Straight Ticket,D,274
+Clay,Total,Voters,,Straight Ticket,L,2
+Clay,Total,Voters,,Straight Ticket,R,1845
+Clay,Total,President,,Donald J. Trump,R,8531
+Clay,Total,President,,Hillary Clinton,D,2306
+Clay,Total,President,,Gary Johnson,L,426
+Clay,Total,President,,Write-In,,68
+Clay,Total,U.S. Senate,,Todd Young,R,6439
+Clay,Total,U.S. Senate,,Evan Bayh,D,3979
+Clay,Total,U.S. Senate,,Lucy Brenton,L,697
+Clay,Total,U.S. Senate,,Write-In,,3
+Clay,Total,Governor,,Eric Holcomb,R,6457
+Clay,Total,Governor,,John R. Gregg,D,4260
+Clay,Total,Governor,,Rex Bell,L,337
+Clay,Total,Governor,,Write-in,,5
+Clay,Total,Attorney General,,"Curtis T. Hill, Jr.",R,8044
+Clay,Total,Attorney General,,Lorenzo Arredondo,D,2521
+Clay,Total,Superintendent of Public Instruction,,Jennifer McCormick,R,6434
+Clay,Total,Superintendent of Public Instruction,,Glenda Ritz,D,4379
+Clay,Total,U.S. House,8,Larry D. Bucshon,R,7859
+Clay,Total,U.S. House,8,Ron Drake,D,2572
+Clay,Total,U.S. House,8,Andrew Horning,L,514
+Clay,Total,U.S. House,8,Write-in,,0
+Clay,Total,State House,42,Alan Morrison,R,3462
+Clay,Total,State House,42,Tim Skinner,D,2004
+Clay,Total,State House,44,James (Jim) Baird,R,1771
+Clay,Total,State House,44,Kimberly Fidler,D,753
+Clay,Total,State House,46,Bob Heaton,R,2214
+Clay,Total,State House,46,Bill Breeden,D,752


### PR DESCRIPTION
…te that the Trump/Johnson/Write-in totals are off by a handful of votes.  The totals are correct, but there is are a few per-precinct errors due to some write-in abnormalities.  See note at the end of CLAY-2.pdf

Thanks again to @lephead for the xls files