### PR TITLE
Correct typos and add CD 3 special in 2010

### DIFF
--- a/2002/20020507__in__primary__county.csv
+++ b/2002/20020507__in__primary__county.csv
@@ -121,18 +121,18 @@ Cass,State House,23,William C. Friend,Republican,0
 Cass,State House,23,Tom (Red) Taylor,Republican,0
 Cass,Prosecuting Attorney,Cass 29Th Circuit,James H. Austen,Democratic,1131
 Cass,Prosecuting Attorney,Cass 29Th Circuit,Kevin S. Enyeart,Republican,2480
-Clar,U.S. House,9,Baron P. Hill,Democratic,6392
-Clar,U.S. House,9,Jeff Ellington,Republican,134
-Clar,U.S. House,9,David Fowler,Republican,92
-Clar,U.S. House,9,Chris Redmon,Republican,225
-Clar,U.S. House,9,Mike Sodrel,Republican,1646
-Clar,State Senator,45,"James (Jim) A. Lewis, Jr.",Democratic,3508
-Clar,State Senator,45,Walter H. Schulz,Republican,693
-Clar,State House,66,Terry Goodin,Democratic,1236
-Clar,State House,66,Tom Powers,Republican,407
-Clar,State House,66,Charles A. (Tony) Singleton,Republican,1007
-Clar,Judge Of The Superior Court,"Clark County, No. 2",Cecile (Cile) A. Blau,Democratic,5293
-Clar,Prosecuting Attorney,"Clark 4Th Circt, No. 1",Steven D. Stewart,Democratic,5355
+Clark,U.S. House,9,Baron P. Hill,Democratic,6392
+Clark,U.S. House,9,Jeff Ellington,Republican,134
+Clark,U.S. House,9,David Fowler,Republican,92
+Clark,U.S. House,9,Chris Redmon,Republican,225
+Clark,U.S. House,9,Mike Sodrel,Republican,1646
+Clark,State Senator,45,"James (Jim) A. Lewis, Jr.",Democratic,3508
+Clark,State Senator,45,Walter H. Schulz,Republican,693
+Clark,State House,66,Terry Goodin,Democratic,1236
+Clark,State House,66,Tom Powers,Republican,407
+Clark,State House,66,Charles A. (Tony) Singleton,Republican,1007
+Clark,Judge Of The Superior Court,"Clark County, No. 2",Cecile (Cile) A. Blau,Democratic,5293
+Clark,Prosecuting Attorney,"Clark 4Th Circt, No. 1",Steven D. Stewart,Democratic,5355
 Clay,U.S. House,8,Michael Graf,Democratic,625
 Clay,U.S. House,8,Bryan Hartke,Democratic,1447
 Clay,U.S. House,8,John N. Hostettler,Republican,2201
@@ -570,26 +570,26 @@ Lake,State House,1,William (Del) Cathey,Republican,439
 Lake,State House,1,Pamela M. Roth,Republican,1382
 Lake,Judge Of The Superior Court,"Lake County, No. 1",Nicholas J. Schiralli,Democratic,31958
 Lake,Prosecuting Attorney,Lake 31St Circuit,Bernard A. Carter,Democratic,40745
-LaPort,U.S. House,1,Ralph Spelbring,Democratic,0
-LaPort,U.S. House,1,Peter J. Visclosky,Democratic,0
-LaPort,U.S. House,1,Cyril B. (Cy) Huerter,Republican,0
-LaPort,U.S. House,1,Mark J. Leyva,Republican,0
-LaPort,U.S. House,1,Kathy Cekanski Farrand,Republican,382
-LaPort,U.S. House,1,Mark J. Meissner,Republican,941
-LaPort,U.S. House,1,Steven W. Osborn,Republican,504
-LaPort,U.S. House,1,Jill Long Thompson,Republican,2913
-LaPort,U.S. House,1,Chris Chocola,Republican,3368
-LaPort,U.S. House,1,Lewis F. (Farmer) Hass,Republican,499
-LaPort,State Senator,4,Rose Ann Antich,Democratic,0
-LaPort,State Senator,4,Larry Chubb,Democratic,0
-LaPort,State Senator,4,Connie G. Collins,Republican,0
-LaPort,State Senator,4,M. Shane Stillman,Republican,0
-LaPort,State House,8,Ryan M. Dvorak,Democratic,0
-LaPort,State House,8,Carl H. Baxmeyer,Republican,0
-LaPort,State House,8,James P. Ehrhard,Republican,0
-LaPort,Judge Of The Superior Court,"Laporte County, No. 1",Walter P. Chapala,Democratic,5078
-LaPort,Judge Of The Superior Court,"Laporte County, No. 1",R. Steven (Steve) Bom,Republican,3243
-LaPort,Prosecuting Attorney,La Porte 32Nd Circuit,Robert J. Beckman,Democratic,4696
+LaPorte,U.S. House,1,Ralph Spelbring,Democratic,0
+LaPorte,U.S. House,1,Peter J. Visclosky,Democratic,0
+LaPorte,U.S. House,1,Cyril B. (Cy) Huerter,Republican,0
+LaPorte,U.S. House,1,Mark J. Leyva,Republican,0
+LaPorte,U.S. House,1,Kathy Cekanski Farrand,Republican,382
+LaPorte,U.S. House,1,Mark J. Meissner,Republican,941
+LaPorte,U.S. House,1,Steven W. Osborn,Republican,504
+LaPorte,U.S. House,1,Jill Long Thompson,Republican,2913
+LaPorte,U.S. House,1,Chris Chocola,Republican,3368
+LaPorte,U.S. House,1,Lewis F. (Farmer) Hass,Republican,499
+LaPorte,State Senator,4,Rose Ann Antich,Democratic,0
+LaPorte,State Senator,4,Larry Chubb,Democratic,0
+LaPorte,State Senator,4,Connie G. Collins,Republican,0
+LaPorte,State Senator,4,M. Shane Stillman,Republican,0
+LaPorte,State House,8,Ryan M. Dvorak,Democratic,0
+LaPorte,State House,8,Carl H. Baxmeyer,Republican,0
+LaPorte,State House,8,James P. Ehrhard,Republican,0
+LaPorte,Judge Of The Superior Court,"Laporte County, No. 1",Walter P. Chapala,Democratic,5078
+LaPorte,Judge Of The Superior Court,"Laporte County, No. 1",R. Steven (Steve) Bom,Republican,3243
+LaPorte,Prosecuting Attorney,La Porte 32Nd Circuit,Robert J. Beckman,Democratic,4696
 Lawrence,U.S. House,9,Baron P. Hill,Democratic,0
 Lawrence,U.S. House,9,Jeff Ellington,Republican,0
 Lawrence,U.S. House,9,David Fowler,Republican,0

--- a/2002/20021105__in__general__county.csv
+++ b/2002/20021105__in__general__county.csv
@@ -452,90 +452,90 @@ Cass,State Convention Delegate,Cass County,Steve Sims,Republican,0
 Cass,State Convention Delegate,Cass County,W Edward Ed Smith,Republican,0
 Cass,State Convention Delegate,Cass County,George W Stephenson,Republican,0
 Cass,State Convention Delegate,Cass County,Kay A Weatherwax,Republican,0
-Clar,Secretary Of State,,John Fernandez,Democratic,11706
-Clar,Secretary Of State,,Rebecca Sink-Burris,Libertarian,899
-Clar,Secretary Of State,,Todd Rokita,Republican,10583
-Clar,Auditor Of State,,Barbara Huston,Democratic,11534
-Clar,Auditor Of State,,Bruce A Parisi,Libertarian,611
-Clar,Auditor Of State,,Connie K Nass,Republican,11003
-Clar,Treasurer Of State,,Day Smith,Democratic,11518
-Clar,Treasurer Of State,,Sam Goldstein,Libertarian,789
-Clar,Treasurer Of State,,Tim Berry,Republican,10968
-Clar,Clerk Of The Supreme Court,,Jon Bond,Democratic,11379
-Clar,Clerk Of The Supreme Court,,Lisa L Tennies,Libertarian,870
-Clar,Clerk Of The Supreme Court,,Brian Bishop,Republican,10842
-Clar,U.S. House,9,Baron P Hill,Democratic,12783
-Clar,U.S. House,9,Jeff Melton,Green,190
-Clar,U.S. House,9,Al Cox,Libertarian,186
-Clar,U.S. House,9,Mike Sodrel,Republican,11800
-Clar,State Senator,45,"James A Lewis, Jr.",Democratic,8708
-Clar,State Senator,45,Debbie Huber-Harbeson,Libertarian,1471
-Clar,State Senator,46,Connie Weigleb Sipes,Democratic,7043
-Clar,State Senator,46,Walter H Schulz,Republican,4218
-Clar,State House,66,Terry A Goodin,Democratic,2668
-Clar,State House,70,Paul J Robertson,Democratic,2637
-Clar,State House,70,Tom Powers,Republican,2142
-Clar,State House,71,James L Bottorff,Democratic,9385
-Clar,State House,71,Charles A Tony Singleton,Republican,5388
-Clar,State House,73,Dennie Oxley,Democratic,557
-Clar,Judge Of The Superior Court,"Clark County, No. 2",Cecile Cile A Blau,Democratic,17215
-Clar,Judge Of The Superior Court,"Clark County, No. 3",Steven M Fleece,Democratic,17174
-Clar,Prosecuting Attorney,Clark 4Th Circuit,Steven D Stewart,Democratic,17118
-Clar,Clerk Of The Circuit Court,Clark County,Keith D Groth,Democratic,17104
-Clar,County Auditor,Clark County,Barbara Bratcher-Haas,Democratic,17011
-Clar,County Recorder,Clark County,Shirley Nolot,Democratic,13235
-Clar,County Treasurer,Clark County,Dick Sr Jones,Democratic,16997
-Clar,County Sheriff,Clark County,Mike Becher,Democratic,13791
-Clar,County Surveyor,Clark County,Robert Lee Isgrigg,Democratic,16266
-Clar,County Assessor,Clark County,Carolyn P Makowsky,Democratic,16570
-Clar,State Convention Delegate,Clark County,David Ray Abbott,Democratic,0
-Clar,State Convention Delegate,Clark County,Fay Allen,Democratic,0
-Clar,State Convention Delegate,Clark County,Larry Beeler,Democratic,0
-Clar,State Convention Delegate,Clark County,Edward Culpepper Cooper,Democratic,0
-Clar,State Convention Delegate,Clark County,"David C Duggins, Jr.",Democratic,0
-Clar,State Convention Delegate,Clark County,Ron Ellis,Democratic,0
-Clar,State Convention Delegate,Clark County,Anita C Fields,Democratic,0
-Clar,State Convention Delegate,Clark County,Ronald L Fields,Democratic,0
-Clar,State Convention Delegate,Clark County,Elmer L Hoehn,Democratic,0
-Clar,State Convention Delegate,Clark County,Barbara C Hollis,Democratic,0
-Clar,State Convention Delegate,Clark County,Marjorie B Jenkins,Democratic,0
-Clar,State Convention Delegate,Clark County,Richard P Dick Jones,Democratic,0
-Clar,State Convention Delegate,Clark County,Al Kamer,Democratic,0
-Clar,State Convention Delegate,Clark County,Charles King,Democratic,0
-Clar,State Convention Delegate,Clark County,Norma L Lockard,Democratic,0
-Clar,State Convention Delegate,Clark County,Rex Lockard,Democratic,0
-Clar,State Convention Delegate,Clark County,Kenny D Sr Martin,Democratic,0
-Clar,State Convention Delegate,Clark County,Claude J Morris,Democratic,0
-Clar,State Convention Delegate,Clark County,Ginger Lockard Neal,Democratic,0
-Clar,State Convention Delegate,Clark County,Betty Ogden,Democratic,0
-Clar,State Convention Delegate,Clark County,"Kenneth ""Ray"" Ogden",Democratic,0
-Clar,State Convention Delegate,Clark County,Benita Pate,Democratic,0
-Clar,State Convention Delegate,Clark County,Rodney Pate,Democratic,0
-Clar,State Convention Delegate,Clark County,Stephanie K Redd-Nelson,Democratic,0
-Clar,State Convention Delegate,Clark County,Roy E Richardson,Democratic,0
-Clar,State Convention Delegate,Clark County,Daniel Rodden,Democratic,0
-Clar,State Convention Delegate,Clark County,Paula J Stewart,Democratic,0
-Clar,State Convention Delegate,Clark County,William Stewart,Democratic,0
-Clar,State Convention Delegate,Clark County,Sylvester L Tutt,Democratic,0
-Clar,State Convention Delegate,Clark County,Travis M Walters,Democratic,0
-Clar,State Convention Delegate,Clark County,Dustin T White,Democratic,0
-Clar,State Convention Delegate,Clark County,Barbara L Wilson,Democratic,0
-Clar,State Convention Delegate,Clark County,John P Crawford,Republican,0
-Clar,State Convention Delegate,Clark County,Janet Ellingsworth,Republican,0
-Clar,State Convention Delegate,Clark County,Thomas H Ellingsworth,Republican,0
-Clar,State Convention Delegate,Clark County,Ron Grooms,Republican,0
-Clar,State Convention Delegate,Clark County,Teresa A Knittle,Republican,0
-Clar,State Convention Delegate,Clark County,Elizabeth L Law,Republican,0
-Clar,State Convention Delegate,Clark County,Rachel E Loy,Republican,0
-Clar,State Convention Delegate,Clark County,John Montgomery,Republican,0
-Clar,State Convention Delegate,Clark County,Glenn Murphy,Republican,0
-Clar,State Convention Delegate,Clark County,Charles A Singleton,Republican,0
-Clar,State Convention Delegate,Clark County,Jim Smith,Republican,0
-Clar,State Convention Delegate,Clark County,Jeremy L Snelling,Republican,0
-Clar,State Convention Delegate,Clark County,Deena R Stoess,Republican,0
-Clar,State Convention Delegate,Clark County,Edward Ritchie Stoess,Republican,0
-Clar,State Convention Delegate,Clark County,Fred Taylor,Republican,0
-Clar,State Convention Delegate,Clark County,Scott Williams,Republican,0
+Clark,Secretary Of State,,John Fernandez,Democratic,11706
+Clark,Secretary Of State,,Rebecca Sink-Burris,Libertarian,899
+Clark,Secretary Of State,,Todd Rokita,Republican,10583
+Clark,Auditor Of State,,Barbara Huston,Democratic,11534
+Clark,Auditor Of State,,Bruce A Parisi,Libertarian,611
+Clark,Auditor Of State,,Connie K Nass,Republican,11003
+Clark,Treasurer Of State,,Day Smith,Democratic,11518
+Clark,Treasurer Of State,,Sam Goldstein,Libertarian,789
+Clark,Treasurer Of State,,Tim Berry,Republican,10968
+Clark,Clerk Of The Supreme Court,,Jon Bond,Democratic,11379
+Clark,Clerk Of The Supreme Court,,Lisa L Tennies,Libertarian,870
+Clark,Clerk Of The Supreme Court,,Brian Bishop,Republican,10842
+Clark,U.S. House,9,Baron P Hill,Democratic,12783
+Clark,U.S. House,9,Jeff Melton,Green,190
+Clark,U.S. House,9,Al Cox,Libertarian,186
+Clark,U.S. House,9,Mike Sodrel,Republican,11800
+Clark,State Senator,45,"James A Lewis, Jr.",Democratic,8708
+Clark,State Senator,45,Debbie Huber-Harbeson,Libertarian,1471
+Clark,State Senator,46,Connie Weigleb Sipes,Democratic,7043
+Clark,State Senator,46,Walter H Schulz,Republican,4218
+Clark,State House,66,Terry A Goodin,Democratic,2668
+Clark,State House,70,Paul J Robertson,Democratic,2637
+Clark,State House,70,Tom Powers,Republican,2142
+Clark,State House,71,James L Bottorff,Democratic,9385
+Clark,State House,71,Charles A Tony Singleton,Republican,5388
+Clark,State House,73,Dennie Oxley,Democratic,557
+Clark,Judge Of The Superior Court,"Clark County, No. 2",Cecile Cile A Blau,Democratic,17215
+Clark,Judge Of The Superior Court,"Clark County, No. 3",Steven M Fleece,Democratic,17174
+Clark,Prosecuting Attorney,Clark 4Th Circuit,Steven D Stewart,Democratic,17118
+Clark,Clerk Of The Circuit Court,Clark County,Keith D Groth,Democratic,17104
+Clark,County Auditor,Clark County,Barbara Bratcher-Haas,Democratic,17011
+Clark,County Recorder,Clark County,Shirley Nolot,Democratic,13235
+Clark,County Treasurer,Clark County,Dick Sr Jones,Democratic,16997
+Clark,County Sheriff,Clark County,Mike Becher,Democratic,13791
+Clark,County Surveyor,Clark County,Robert Lee Isgrigg,Democratic,16266
+Clark,County Assessor,Clark County,Carolyn P Makowsky,Democratic,16570
+Clark,State Convention Delegate,Clark County,David Ray Abbott,Democratic,0
+Clark,State Convention Delegate,Clark County,Fay Allen,Democratic,0
+Clark,State Convention Delegate,Clark County,Larry Beeler,Democratic,0
+Clark,State Convention Delegate,Clark County,Edward Culpepper Cooper,Democratic,0
+Clark,State Convention Delegate,Clark County,"David C Duggins, Jr.",Democratic,0
+Clark,State Convention Delegate,Clark County,Ron Ellis,Democratic,0
+Clark,State Convention Delegate,Clark County,Anita C Fields,Democratic,0
+Clark,State Convention Delegate,Clark County,Ronald L Fields,Democratic,0
+Clark,State Convention Delegate,Clark County,Elmer L Hoehn,Democratic,0
+Clark,State Convention Delegate,Clark County,Barbara C Hollis,Democratic,0
+Clark,State Convention Delegate,Clark County,Marjorie B Jenkins,Democratic,0
+Clark,State Convention Delegate,Clark County,Richard P Dick Jones,Democratic,0
+Clark,State Convention Delegate,Clark County,Al Kamer,Democratic,0
+Clark,State Convention Delegate,Clark County,Charles King,Democratic,0
+Clark,State Convention Delegate,Clark County,Norma L Lockard,Democratic,0
+Clark,State Convention Delegate,Clark County,Rex Lockard,Democratic,0
+Clark,State Convention Delegate,Clark County,Kenny D Sr Martin,Democratic,0
+Clark,State Convention Delegate,Clark County,Claude J Morris,Democratic,0
+Clark,State Convention Delegate,Clark County,Ginger Lockard Neal,Democratic,0
+Clark,State Convention Delegate,Clark County,Betty Ogden,Democratic,0
+Clark,State Convention Delegate,Clark County,"Kenneth ""Ray"" Ogden",Democratic,0
+Clark,State Convention Delegate,Clark County,Benita Pate,Democratic,0
+Clark,State Convention Delegate,Clark County,Rodney Pate,Democratic,0
+Clark,State Convention Delegate,Clark County,Stephanie K Redd-Nelson,Democratic,0
+Clark,State Convention Delegate,Clark County,Roy E Richardson,Democratic,0
+Clark,State Convention Delegate,Clark County,Daniel Rodden,Democratic,0
+Clark,State Convention Delegate,Clark County,Paula J Stewart,Democratic,0
+Clark,State Convention Delegate,Clark County,William Stewart,Democratic,0
+Clark,State Convention Delegate,Clark County,Sylvester L Tutt,Democratic,0
+Clark,State Convention Delegate,Clark County,Travis M Walters,Democratic,0
+Clark,State Convention Delegate,Clark County,Dustin T White,Democratic,0
+Clark,State Convention Delegate,Clark County,Barbara L Wilson,Democratic,0
+Clark,State Convention Delegate,Clark County,John P Crawford,Republican,0
+Clark,State Convention Delegate,Clark County,Janet Ellingsworth,Republican,0
+Clark,State Convention Delegate,Clark County,Thomas H Ellingsworth,Republican,0
+Clark,State Convention Delegate,Clark County,Ron Grooms,Republican,0
+Clark,State Convention Delegate,Clark County,Teresa A Knittle,Republican,0
+Clark,State Convention Delegate,Clark County,Elizabeth L Law,Republican,0
+Clark,State Convention Delegate,Clark County,Rachel E Loy,Republican,0
+Clark,State Convention Delegate,Clark County,John Montgomery,Republican,0
+Clark,State Convention Delegate,Clark County,Glenn Murphy,Republican,0
+Clark,State Convention Delegate,Clark County,Charles A Singleton,Republican,0
+Clark,State Convention Delegate,Clark County,Jim Smith,Republican,0
+Clark,State Convention Delegate,Clark County,Jeremy L Snelling,Republican,0
+Clark,State Convention Delegate,Clark County,Deena R Stoess,Republican,0
+Clark,State Convention Delegate,Clark County,Edward Ritchie Stoess,Republican,0
+Clark,State Convention Delegate,Clark County,Fred Taylor,Republican,0
+Clark,State Convention Delegate,Clark County,Scott Williams,Republican,0
 Clay,Secretary Of State,,John Fernandez,Democratic,3135
 Clay,Secretary Of State,,Rebecca Sink-Burris,Libertarian,296
 Clay,Secretary Of State,,Todd Rokita,Republican,3828
@@ -2428,87 +2428,87 @@ Lake,State Convention Delegate,Lake County,Susan Sue F Smith,Republican,0
 Lake,State Convention Delegate,Lake County,Drew Sterley,Republican,0
 Lake,State Convention Delegate,Lake County,Kenneth Vernon Tanis,Republican,0
 Lake,State Convention Delegate,Lake County,Peter J Thayer,Republican,0
-LaPort,Secretary Of State,,John Fernandez,Democratic,14728
-LaPort,Secretary Of State,,Rebecca Sink-Burris,Libertarian,2227
-LaPort,Secretary Of State,,Todd Rokita,Republican,12496
-LaPort,Auditor Of State,,Barbara Huston,Democratic,16209
-LaPort,Auditor Of State,,Bruce A Parisi,Libertarian,1666
-LaPort,Auditor Of State,,Connie K Nass,Republican,11716
-LaPort,Treasurer Of State,,Day Smith,Democratic,13462
-LaPort,Treasurer Of State,,Sam Goldstein,Libertarian,2254
-LaPort,Treasurer Of State,,Tim Berry,Republican,13503
-LaPort,Clerk Of The Supreme Court,,Jon Bond,Democratic,13630
-LaPort,Clerk Of The Supreme Court,,Lisa L Tennies,Libertarian,2367
-LaPort,Clerk Of The Supreme Court,,Brian Bishop,Republican,13159
-LaPort,U.S. House,1,Peter J Visclosky,Democratic,0
-LaPort,U.S. House,1,Timothy P Brennan,Libertarian,0
-LaPort,U.S. House,1,Mark J Leyva,Republican,0
-LaPort,U.S. House,2,Jill Long Thompson,Democratic,15238
-LaPort,U.S. House,2,Sharon Metheny,Libertarian,1944
-LaPort,U.S. House,2,Chris Chocola,Republican,13059
-LaPort,U.S. House,2,M Myer Blatt,Independent,1
-LaPort,U.S. House,2,James A Mello,Independent,3
-LaPort,State Senator,4,Rose Ann Antich,Democratic,0
-LaPort,State Senator,4,M Shane Stillman,Republican,0
-LaPort,State House,8,Ryan M Dvorak,Democratic,0
-LaPort,State House,8,Carl H Baxmeyer,Republican,0
-LaPort,State House,9,Scott D Pelath,Democratic,11769
-LaPort,State House,9,Gregory D Kelver,Libertarian,1874
-LaPort,State House,20,Janet F Gillon,Libertarian,2258
-LaPort,State House,20,Mary Kay Budak,Republican,9747
-LaPort,Judge Of The Superior Court,"Laporte County, No. 1",Walter P Chapala,Democratic,23486
-LaPort,Judge Of The Superior Court,"Laporte County, No. 2",Steven E King,Democratic,23188
-LaPort,Judge Of The Superior Court,"Laporte County, No. 3",Paul J Baldoni,Democratic,17589
-LaPort,Judge Of The Superior Court,"Laporte County, No. 3",R Steven Steve Bom,Republican,11736
-LaPort,Judge Of The Superior Court,"Laporte County, No. 4",William J Boklund,Democratic,23043
-LaPort,Prosecuting Attorney,Laporte 32Nd Circuit,Robert J Beckman,Democratic,22598
-LaPort,County Sheriff,La Porte County,Jim Arnold,Democratic,14592
-LaPort,State Convention Delegate,La Porte County,Jim Arnold,Democratic,0
-LaPort,State Convention Delegate,La Porte County,Leland R Campbell,Democratic,0
-LaPort,State Convention Delegate,La Porte County,Anne H Daley,Democratic,0
-LaPort,State Convention Delegate,La Porte County,Jeri Lyn Favia,Democratic,0
-LaPort,State Convention Delegate,La Porte County,William Bill Hager,Democratic,0
-LaPort,State Convention Delegate,La Porte County,Carolyn Harmon,Democratic,0
-LaPort,State Convention Delegate,La Porte County,Stanley J Hynek,Democratic,0
-LaPort,State Convention Delegate,La Porte County,James Sr Irwin,Democratic,0
-LaPort,State Convention Delegate,La Porte County,W Ken Massengill,Democratic,0
-LaPort,State Convention Delegate,La Porte County,John G Mcdaniel,Democratic,0
-LaPort,State Convention Delegate,La Porte County,Linda J Meadows,Democratic,0
-LaPort,State Convention Delegate,La Porte County,Willie B Milsap,Democratic,0
-LaPort,State Convention Delegate,La Porte County,Rudolph Rudy Nichols,Democratic,0
-LaPort,State Convention Delegate,La Porte County,Al Ott,Democratic,0
-LaPort,State Convention Delegate,La Porte County,Donald L Pagos,Democratic,0
-LaPort,State Convention Delegate,La Porte County,Andrea L Renner,Democratic,0
-LaPort,State Convention Delegate,La Porte County,Michael E Sandy,Democratic,0
-LaPort,State Convention Delegate,La Porte County,Mike Schultz,Democratic,0
-LaPort,State Convention Delegate,La Porte County,Ann Spevak,Democratic,0
-LaPort,State Convention Delegate,La Porte County,Richard E Uzzell,Democratic,0
-LaPort,State Convention Delegate,La Porte County,Paul A Young,Democratic,0
-LaPort,State Convention Delegate,La Porte County,Deb Arnold,Republican,0
-LaPort,State Convention Delegate,La Porte County,Edward Arnold,Republican,0
-LaPort,State Convention Delegate,La Porte County,Merle Bannwart,Republican,0
-LaPort,State Convention Delegate,La Porte County,J Tim Barnhart,Republican,0
-LaPort,State Convention Delegate,La Porte County,Mary Kay Budak,Republican,0
-LaPort,State Convention Delegate,La Porte County,Connie Cross,Republican,0
-LaPort,State Convention Delegate,La Porte County,Phil Cross,Republican,0
-LaPort,State Convention Delegate,La Porte County,Janice D Daniels,Republican,0
-LaPort,State Convention Delegate,La Porte County,Barbara J Dreiner,Republican,0
-LaPort,State Convention Delegate,La Porte County,Fred E Dunham,Republican,0
-LaPort,State Convention Delegate,La Porte County,Scott E Emerick,Republican,0
-LaPort,State Convention Delegate,La Porte County,Edward R Gondeck,Republican,0
-LaPort,State Convention Delegate,La Porte County,Mike Gonder,Republican,0
-LaPort,State Convention Delegate,La Porte County,John F Harnett,Republican,0
-LaPort,State Convention Delegate,La Porte County,Charles D Hendricks,Republican,0
-LaPort,State Convention Delegate,La Porte County,Judith A Keller,Republican,0
-LaPort,State Convention Delegate,La Porte County,Mary L Lombard,Republican,0
-LaPort,State Convention Delegate,La Porte County,Ronald D Lombard,Republican,0
-LaPort,State Convention Delegate,La Porte County,Joan B Martin,Republican,0
-LaPort,State Convention Delegate,La Porte County,Lois E Miller,Republican,0
-LaPort,State Convention Delegate,La Porte County,Randall C Miller,Republican,0
-LaPort,State Convention Delegate,La Porte County,Alice Mueller,Republican,0
-LaPort,State Convention Delegate,La Porte County,David Scarborough,Republican,0
-LaPort,State Convention Delegate,La Porte County,Sherry K Waters,Republican,0
-LaPort,State Convention Delegate,La Porte County,Darren Wojcieszak,Republican,0
+LaPorte,Secretary Of State,,John Fernandez,Democratic,14728
+LaPorte,Secretary Of State,,Rebecca Sink-Burris,Libertarian,2227
+LaPorte,Secretary Of State,,Todd Rokita,Republican,12496
+LaPorte,Auditor Of State,,Barbara Huston,Democratic,16209
+LaPorte,Auditor Of State,,Bruce A Parisi,Libertarian,1666
+LaPorte,Auditor Of State,,Connie K Nass,Republican,11716
+LaPorte,Treasurer Of State,,Day Smith,Democratic,13462
+LaPorte,Treasurer Of State,,Sam Goldstein,Libertarian,2254
+LaPorte,Treasurer Of State,,Tim Berry,Republican,13503
+LaPorte,Clerk Of The Supreme Court,,Jon Bond,Democratic,13630
+LaPorte,Clerk Of The Supreme Court,,Lisa L Tennies,Libertarian,2367
+LaPorte,Clerk Of The Supreme Court,,Brian Bishop,Republican,13159
+LaPorte,U.S. House,1,Peter J Visclosky,Democratic,0
+LaPorte,U.S. House,1,Timothy P Brennan,Libertarian,0
+LaPorte,U.S. House,1,Mark J Leyva,Republican,0
+LaPorte,U.S. House,2,Jill Long Thompson,Democratic,15238
+LaPorte,U.S. House,2,Sharon Metheny,Libertarian,1944
+LaPorte,U.S. House,2,Chris Chocola,Republican,13059
+LaPorte,U.S. House,2,M Myer Blatt,Independent,1
+LaPorte,U.S. House,2,James A Mello,Independent,3
+LaPorte,State Senator,4,Rose Ann Antich,Democratic,0
+LaPorte,State Senator,4,M Shane Stillman,Republican,0
+LaPorte,State House,8,Ryan M Dvorak,Democratic,0
+LaPorte,State House,8,Carl H Baxmeyer,Republican,0
+LaPorte,State House,9,Scott D Pelath,Democratic,11769
+LaPorte,State House,9,Gregory D Kelver,Libertarian,1874
+LaPorte,State House,20,Janet F Gillon,Libertarian,2258
+LaPorte,State House,20,Mary Kay Budak,Republican,9747
+LaPorte,Judge Of The Superior Court,"Laporte County, No. 1",Walter P Chapala,Democratic,23486
+LaPorte,Judge Of The Superior Court,"Laporte County, No. 2",Steven E King,Democratic,23188
+LaPorte,Judge Of The Superior Court,"Laporte County, No. 3",Paul J Baldoni,Democratic,17589
+LaPorte,Judge Of The Superior Court,"Laporte County, No. 3",R Steven Steve Bom,Republican,11736
+LaPorte,Judge Of The Superior Court,"Laporte County, No. 4",William J Boklund,Democratic,23043
+LaPorte,Prosecuting Attorney,Laporte 32Nd Circuit,Robert J Beckman,Democratic,22598
+LaPorte,County Sheriff,La Porte County,Jim Arnold,Democratic,14592
+LaPorte,State Convention Delegate,La Porte County,Jim Arnold,Democratic,0
+LaPorte,State Convention Delegate,La Porte County,Leland R Campbell,Democratic,0
+LaPorte,State Convention Delegate,La Porte County,Anne H Daley,Democratic,0
+LaPorte,State Convention Delegate,La Porte County,Jeri Lyn Favia,Democratic,0
+LaPorte,State Convention Delegate,La Porte County,William Bill Hager,Democratic,0
+LaPorte,State Convention Delegate,La Porte County,Carolyn Harmon,Democratic,0
+LaPorte,State Convention Delegate,La Porte County,Stanley J Hynek,Democratic,0
+LaPorte,State Convention Delegate,La Porte County,James Sr Irwin,Democratic,0
+LaPorte,State Convention Delegate,La Porte County,W Ken Massengill,Democratic,0
+LaPorte,State Convention Delegate,La Porte County,John G Mcdaniel,Democratic,0
+LaPorte,State Convention Delegate,La Porte County,Linda J Meadows,Democratic,0
+LaPorte,State Convention Delegate,La Porte County,Willie B Milsap,Democratic,0
+LaPorte,State Convention Delegate,La Porte County,Rudolph Rudy Nichols,Democratic,0
+LaPorte,State Convention Delegate,La Porte County,Al Ott,Democratic,0
+LaPorte,State Convention Delegate,La Porte County,Donald L Pagos,Democratic,0
+LaPorte,State Convention Delegate,La Porte County,Andrea L Renner,Democratic,0
+LaPorte,State Convention Delegate,La Porte County,Michael E Sandy,Democratic,0
+LaPorte,State Convention Delegate,La Porte County,Mike Schultz,Democratic,0
+LaPorte,State Convention Delegate,La Porte County,Ann Spevak,Democratic,0
+LaPorte,State Convention Delegate,La Porte County,Richard E Uzzell,Democratic,0
+LaPorte,State Convention Delegate,La Porte County,Paul A Young,Democratic,0
+LaPorte,State Convention Delegate,La Porte County,Deb Arnold,Republican,0
+LaPorte,State Convention Delegate,La Porte County,Edward Arnold,Republican,0
+LaPorte,State Convention Delegate,La Porte County,Merle Bannwart,Republican,0
+LaPorte,State Convention Delegate,La Porte County,J Tim Barnhart,Republican,0
+LaPorte,State Convention Delegate,La Porte County,Mary Kay Budak,Republican,0
+LaPorte,State Convention Delegate,La Porte County,Connie Cross,Republican,0
+LaPorte,State Convention Delegate,La Porte County,Phil Cross,Republican,0
+LaPorte,State Convention Delegate,La Porte County,Janice D Daniels,Republican,0
+LaPorte,State Convention Delegate,La Porte County,Barbara J Dreiner,Republican,0
+LaPorte,State Convention Delegate,La Porte County,Fred E Dunham,Republican,0
+LaPorte,State Convention Delegate,La Porte County,Scott E Emerick,Republican,0
+LaPorte,State Convention Delegate,La Porte County,Edward R Gondeck,Republican,0
+LaPorte,State Convention Delegate,La Porte County,Mike Gonder,Republican,0
+LaPorte,State Convention Delegate,La Porte County,John F Harnett,Republican,0
+LaPorte,State Convention Delegate,La Porte County,Charles D Hendricks,Republican,0
+LaPorte,State Convention Delegate,La Porte County,Judith A Keller,Republican,0
+LaPorte,State Convention Delegate,La Porte County,Mary L Lombard,Republican,0
+LaPorte,State Convention Delegate,La Porte County,Ronald D Lombard,Republican,0
+LaPorte,State Convention Delegate,La Porte County,Joan B Martin,Republican,0
+LaPorte,State Convention Delegate,La Porte County,Lois E Miller,Republican,0
+LaPorte,State Convention Delegate,La Porte County,Randall C Miller,Republican,0
+LaPorte,State Convention Delegate,La Porte County,Alice Mueller,Republican,0
+LaPorte,State Convention Delegate,La Porte County,David Scarborough,Republican,0
+LaPorte,State Convention Delegate,La Porte County,Sherry K Waters,Republican,0
+LaPorte,State Convention Delegate,La Porte County,Darren Wojcieszak,Republican,0
 Lawrence,Secretary Of State,,John Fernandez,Democratic,3773
 Lawrence,Secretary Of State,,Rebecca Sink-Burris,Libertarian,440
 Lawrence,Secretary Of State,,Todd Rokita,Republican,6460

--- a/2004/20040504__in__primary__county.csv
+++ b/2004/20040504__in__primary__county.csv
@@ -192,24 +192,24 @@ Cass,State House,23,C.L. Alfred,Republican,0
 Cass,State House,23,William C. Friend,Republican,0
 Cass,State House,23,Dennis K. Foreman,Republican,0
 Cass,Judge Of The Superior Court,"Cass County, Court 1",Thomas C. Perrone,Democratic,1661
-Clar,President,,Wesley K. Clark,Democratic,585
-Clar,President,,Howard Dean,Democratic,764
-Clar,President,,John Edwards,Democratic,1220
-Clar,President,,John F. Kerry,Democratic,6414
-Clar,President,,Dennis J. Kucinich,Democratic,171
-Clar,President,,"Lyndon H. Larouche, Jr.",Democratic,193
-Clar,President,,George W. Bush,Republican,3590
-Clar,U.S. Senator,,Evan Bayh,Democratic,9517
-Clar,U.S. Senator,,Marvin Scott,Republican,2509
-Clar,Governor,,Joe Kernan,Democratic,8511
-Clar,Governor,,Mitch Daniels,Republican,1872
-Clar,Governor,,Eric Miller,Republican,1674
-Clar,U.S. House,9,Baron Hill,Democratic,9078
-Clar,U.S. House,9,Lendall B. Terry,Democratic,1356
-Clar,U.S. House,9,Mike Sodrel,Republican,3344
-Clar,State House,66,Terry Goodin,Democratic,1650
-Clar,State House,66,Jack Gillespie,Republican,351
-Clar,Judge Of The Circuit Court,"Clark 4Th Circt, No. 1",Daniel F. Donahue,Democratic,8896
+Clark,President,,Wesley K. Clark,Democratic,585
+Clark,President,,Howard Dean,Democratic,764
+Clark,President,,John Edwards,Democratic,1220
+Clark,President,,John F. Kerry,Democratic,6414
+Clark,President,,Dennis J. Kucinich,Democratic,171
+Clark,President,,"Lyndon H. Larouche, Jr.",Democratic,193
+Clark,President,,George W. Bush,Republican,3590
+Clark,U.S. Senator,,Evan Bayh,Democratic,9517
+Clark,U.S. Senator,,Marvin Scott,Republican,2509
+Clark,Governor,,Joe Kernan,Democratic,8511
+Clark,Governor,,Mitch Daniels,Republican,1872
+Clark,Governor,,Eric Miller,Republican,1674
+Clark,U.S. House,9,Baron Hill,Democratic,9078
+Clark,U.S. House,9,Lendall B. Terry,Democratic,1356
+Clark,U.S. House,9,Mike Sodrel,Republican,3344
+Clark,State House,66,Terry Goodin,Democratic,1650
+Clark,State House,66,Jack Gillespie,Republican,351
+Clark,Judge Of The Circuit Court,"Clark 4Th Circt, No. 1",Daniel F. Donahue,Democratic,8896
 Clay,President,,Wesley K. Clark,Democratic,134
 Clay,President,,Howard Dean,Democratic,153
 Clay,President,,John Edwards,Democratic,312
@@ -923,32 +923,32 @@ Lake,State House,1,Donald J. Lehe,Republican,742
 Lake,State House,1,"John Anthony, Malan",Republican,523
 Lake,State House,1,Ron Cooper,Republican,1416
 Lake,Judge Of The Circuit Court,Lake 31St Circuit,Lorenzo Arredondo,Democratic,31508
-LaPort,President,,Wesley K. Clark,Democratic,361
-LaPort,President,,Howard Dean,Democratic,588
-LaPort,President,,John Edwards,Democratic,765
-LaPort,President,,John F. Kerry,Democratic,5414
-LaPort,President,,Dennis J. Kucinich,Democratic,139
-LaPort,President,,"Lyndon H. Larouche, Jr.",Democratic,127
-LaPort,President,,George W. Bush,Republican,4462
-LaPort,U.S. Senator,,Evan Bayh,Democratic,6990
-LaPort,U.S. Senator,,Marvin Scott,Republican,3072
-LaPort,Governor,,Joe Kernan,Democratic,6652
-LaPort,Governor,,Mitch Daniels,Republican,2839
-LaPort,Governor,,Eric Miller,Republican,1782
-LaPort,U.S. House,1,Peter J. Visclosky,Democratic,0
-LaPort,U.S. House,1,Cyril B. (Cy) Huerter,Republican,0
-LaPort,U.S. House,1,Frank E. Kendrick,Republican,0
-LaPort,U.S. House,1,Mark J. Leyva,Republican,0
-LaPort,U.S. House,1,Chris Chocola,Republican,3908
-LaPort,U.S. House,1,Tony Zirkle,Republican,872
-LaPort,State Senator,5,Nancy Dembowski,Democratic,322
-LaPort,State Senator,5,Victor Heinold,Republican,373
-LaPort,State Senator,5,Cresley W. Walker,Republican,68
-LaPort,State Senator,5,Allen L. Stevens Jr.,Republican,3510
-LaPort,State House,8,Ryan M. Dvorak,Democratic,0
-LaPort,State House,8,Howard M. Smith,Democratic,432
-LaPort,State House,8,Lynne Spevak,Democratic,1460
-LaPort,State House,8,Mary Kay Budak,Republican,2058
+LaPorte,President,,Wesley K. Clark,Democratic,361
+LaPorte,President,,Howard Dean,Democratic,588
+LaPorte,President,,John Edwards,Democratic,765
+LaPorte,President,,John F. Kerry,Democratic,5414
+LaPorte,President,,Dennis J. Kucinich,Democratic,139
+LaPorte,President,,"Lyndon H. Larouche, Jr.",Democratic,127
+LaPorte,President,,George W. Bush,Republican,4462
+LaPorte,U.S. Senator,,Evan Bayh,Democratic,6990
+LaPorte,U.S. Senator,,Marvin Scott,Republican,3072
+LaPorte,Governor,,Joe Kernan,Democratic,6652
+LaPorte,Governor,,Mitch Daniels,Republican,2839
+LaPorte,Governor,,Eric Miller,Republican,1782
+LaPorte,U.S. House,1,Peter J. Visclosky,Democratic,0
+LaPorte,U.S. House,1,Cyril B. (Cy) Huerter,Republican,0
+LaPorte,U.S. House,1,Frank E. Kendrick,Republican,0
+LaPorte,U.S. House,1,Mark J. Leyva,Republican,0
+LaPorte,U.S. House,1,Chris Chocola,Republican,3908
+LaPorte,U.S. House,1,Tony Zirkle,Republican,872
+LaPorte,State Senator,5,Nancy Dembowski,Democratic,322
+LaPorte,State Senator,5,Victor Heinold,Republican,373
+LaPorte,State Senator,5,Cresley W. Walker,Republican,68
+LaPorte,State Senator,5,Allen L. Stevens Jr.,Republican,3510
+LaPorte,State House,8,Ryan M. Dvorak,Democratic,0
+LaPorte,State House,8,Howard M. Smith,Democratic,432
+LaPorte,State House,8,Lynne Spevak,Democratic,1460
+LaPorte,State House,8,Mary Kay Budak,Republican,2058
 Lawrence,President,,Wesley K. Clark,Democratic,96
 Lawrence,President,,Howard Dean,Democratic,88
 Lawrence,President,,John Edwards,Democratic,146

--- a/2004/20041102__in__general__county.csv
+++ b/2004/20041102__in__general__county.csv
@@ -313,39 +313,39 @@ Cass,County Coroner,Cass County,Lee Ann Bates,Democratic,4610
 Cass,County Coroner,Cass County,Gene Pawlen,Republican,9171
 Cass,County Surveyor,Cass County,Nan Ford,Democratic,4174
 Cass,County Surveyor,Cass County,Jenny Lombardi,Republican,9363
-Clar,President,,John F Kerry,Democratic,17648
-Clar,President,,Michael Badnarik,Libertarian,194
-Clar,President,,George Walker Bush,Republican,24495
-Clar,President,,John Joseph Kennedy,Democratic,0
-Clar,President,,David Cobb,Green,0
-Clar,President,,Lawson Mitchell Bone,Independent,0
-Clar,President,,Ralph Nader,Independent,0
-Clar,President,,Walt Brown,Socialist,0
-Clar,U.S. Senator,,Evan Bayh,Democratic,26054
-Clar,U.S. Senator,,Albert Barger,Libertarian,368
-Clar,U.S. Senator,,Marvin Scott,Republican,15091
-Clar,Governor,,Joseph E Kernan,Democratic,20964
-Clar,Governor,,Kenn Gividen,Libertarian,360
-Clar,Governor,,"Mitchell E Daniels, Jr.",Republican,20471
-Clar,Governor,,Velko Kapetanov,Independent,0
-Clar,Attorney General,,Joseph H Hogsett,Democratic,18773
-Clar,Attorney General,,Aaron T Milewski,Libertarian,724
-Clar,Attorney General,,Steve Carter,Republican,20451
-Clar,Superintendent Of Public Instruction,,Susan Williams,Democratic,18966
-Clar,Superintendent Of Public Instruction,,Joe Hauptmann,Libertarian,915
-Clar,Superintendent Of Public Instruction,,Suellen Reed,Republican,19696
-Clar,U.S. House,9,Baron Hill,Democratic,21109
-Clar,U.S. House,9,Al Cox,Libertarian,402
-Clar,U.S. House,9,Mike Sodrel,Republican,20494
-Clar,State House,66,Terry Goodin,Democratic,3522
-Clar,State House,66,Jack R Gillespie,Republican,2547
-Clar,State House,70,Paul J Robertson,Democratic,3764
-Clar,State House,70,Brian C Thomas,Republican,4114
-Clar,State House,71,James L Bottorff,Democratic,17949
-Clar,State House,73,Dennie Oxley,Democratic,809
-Clar,Judge Of The Circuit Court,"Clark 4Th Circt, No. 1",Daniel F Donahue,Democratic,28102
-Clar,County Coroner,Clark County,Edwin M Coots,Democratic,23731
-Clar,County Coroner,Clark County,Richard Rd D Pyke,Republican,16618
+Clark,President,,John F Kerry,Democratic,17648
+Clark,President,,Michael Badnarik,Libertarian,194
+Clark,President,,George Walker Bush,Republican,24495
+Clark,President,,John Joseph Kennedy,Democratic,0
+Clark,President,,David Cobb,Green,0
+Clark,President,,Lawson Mitchell Bone,Independent,0
+Clark,President,,Ralph Nader,Independent,0
+Clark,President,,Walt Brown,Socialist,0
+Clark,U.S. Senator,,Evan Bayh,Democratic,26054
+Clark,U.S. Senator,,Albert Barger,Libertarian,368
+Clark,U.S. Senator,,Marvin Scott,Republican,15091
+Clark,Governor,,Joseph E Kernan,Democratic,20964
+Clark,Governor,,Kenn Gividen,Libertarian,360
+Clark,Governor,,"Mitchell E Daniels, Jr.",Republican,20471
+Clark,Governor,,Velko Kapetanov,Independent,0
+Clark,Attorney General,,Joseph H Hogsett,Democratic,18773
+Clark,Attorney General,,Aaron T Milewski,Libertarian,724
+Clark,Attorney General,,Steve Carter,Republican,20451
+Clark,Superintendent Of Public Instruction,,Susan Williams,Democratic,18966
+Clark,Superintendent Of Public Instruction,,Joe Hauptmann,Libertarian,915
+Clark,Superintendent Of Public Instruction,,Suellen Reed,Republican,19696
+Clark,U.S. House,9,Baron Hill,Democratic,21109
+Clark,U.S. House,9,Al Cox,Libertarian,402
+Clark,U.S. House,9,Mike Sodrel,Republican,20494
+Clark,State House,66,Terry Goodin,Democratic,3522
+Clark,State House,66,Jack R Gillespie,Republican,2547
+Clark,State House,70,Paul J Robertson,Democratic,3764
+Clark,State House,70,Brian C Thomas,Republican,4114
+Clark,State House,71,James L Bottorff,Democratic,17949
+Clark,State House,73,Dennie Oxley,Democratic,809
+Clark,Judge Of The Circuit Court,"Clark 4Th Circt, No. 1",Daniel F Donahue,Democratic,28102
+Clark,County Coroner,Clark County,Edwin M Coots,Democratic,23731
+Clark,County Coroner,Clark County,Richard Rd D Pyke,Republican,16618
 Clay,President,,John F Kerry,Democratic,3333
 Clay,President,,Michael Badnarik,Libertarian,80
 Clay,President,,George Walker Bush,Republican,7361
@@ -1581,56 +1581,56 @@ Lake,County Recorder,Lake County,Sherry A Nagel-Smith,Republican,63466
 Lake,County Coroner,Lake County,David J Pastrick,Democratic,122023
 Lake,County Surveyor,Lake County,George W Van Til,Democratic,118938
 Lake,County Surveyor,Lake County,Jayson H Reeves,Republican,55691
-LaPort,President,,John F Kerry,Democratic,21114
-LaPort,President,,Michael Badnarik,Libertarian,552
-LaPort,President,,George Walker Bush,Republican,20916
-LaPort,President,,John Joseph Kennedy,Democratic,0
-LaPort,President,,David Cobb,Green,3
-LaPort,President,,Lawson Mitchell Bone,Independent,0
-LaPort,President,,Ralph Nader,Independent,19
-LaPort,President,,Walt Brown,Socialist,2
-LaPort,U.S. Senator,,Evan Bayh,Democratic,28826
-LaPort,U.S. Senator,,Albert Barger,Libertarian,840
-LaPort,U.S. Senator,,Marvin Scott,Republican,11685
-LaPort,Governor,,Joseph E Kernan,Democratic,25049
-LaPort,Governor,,Kenn Gividen,Libertarian,881
-LaPort,Governor,,"Mitchell E Daniels, Jr.",Republican,16234
-LaPort,Governor,,Velko Kapetanov,Independent,0
-LaPort,Attorney General,,Joseph H Hogsett,Democratic,21117
-LaPort,Attorney General,,Aaron T Milewski,Libertarian,1367
-LaPort,Attorney General,,Steve Carter,Republican,18366
-LaPort,Superintendent Of Public Instruction,,Susan Williams,Democratic,20848
-LaPort,Superintendent Of Public Instruction,,Joe Hauptmann,Libertarian,1847
-LaPort,Superintendent Of Public Instruction,,Suellen Reed,Republican,17816
-LaPort,U.S. House,1,Peter J Visclosky,Democratic,0
-LaPort,U.S. House,1,Mark J Leyva,Republican,0
-LaPort,U.S. House,2,Joseph S Donnelly,Democratic,21693
-LaPort,U.S. House,2,Douglas Barnes,Libertarian,931
-LaPort,U.S. House,2,J Chris Chocola,Republican,19641
-LaPort,State Senator,5,Nancy J Dembowski,Democratic,1206
-LaPort,State Senator,5,Victor R Heinold,Republican,1355
-LaPort,State Senator,8,Anita O Bowser,Democratic,21457
-LaPort,State Senator,8,Janet F Gillon,Libertarian,1586
-LaPort,State Senator,8,"Allen L Stevens, Jr.",Republican,16066
-LaPort,State House,8,Ryan M Dvorak,Democratic,0
-LaPort,State House,9,Scott D Pelath,Democratic,17110
-LaPort,State House,9,Gregory D Kelver,Libertarian,2176
-LaPort,State House,20,Lynne F Spevak,Democratic,7916
-LaPort,State House,20,William Bill Schadowsky,Libertarian,858
-LaPort,State House,20,Mary Kay Budak,Republican,9028
-LaPort,Clerk Of The Circuit Court,La Porte County,Robert Bob Behler,Democratic,22392
-LaPort,Clerk Of The Circuit Court,La Porte County,Judith A Keller,Republican,18751
-LaPort,County Auditor,La Porte County,Michael T Quinn,Democratic,19927
-LaPort,County Auditor,La Porte County,Teresa M Shuter,Republican,20567
-LaPort,County Recorder,La Porte County,Barbara A Dean,Democratic,22952
-LaPort,County Recorder,La Porte County,Jeff Stepanek,Republican,17101
-LaPort,County Treasurer,La Porte County,Nancy K Hawkins,Democratic,19134
-LaPort,County Treasurer,La Porte County,Kenneth E Layton,Republican,21747
-LaPort,County Coroner,La Porte County,Vidya Kora,Democratic,24712
-LaPort,County Coroner,La Porte County,Dan Stephens,Republican,16130
-LaPort,County Surveyor,La Porte County,Robert P Przybylinski,Democratic,19717
-LaPort,County Surveyor,La Porte County,John Jack Lemley,Libertarian,2384
-LaPort,County Surveyor,La Porte County,James H Keil,Republican,18567
+LaPorte,President,,John F Kerry,Democratic,21114
+LaPorte,President,,Michael Badnarik,Libertarian,552
+LaPorte,President,,George Walker Bush,Republican,20916
+LaPorte,President,,John Joseph Kennedy,Democratic,0
+LaPorte,President,,David Cobb,Green,3
+LaPorte,President,,Lawson Mitchell Bone,Independent,0
+LaPorte,President,,Ralph Nader,Independent,19
+LaPorte,President,,Walt Brown,Socialist,2
+LaPorte,U.S. Senator,,Evan Bayh,Democratic,28826
+LaPorte,U.S. Senator,,Albert Barger,Libertarian,840
+LaPorte,U.S. Senator,,Marvin Scott,Republican,11685
+LaPorte,Governor,,Joseph E Kernan,Democratic,25049
+LaPorte,Governor,,Kenn Gividen,Libertarian,881
+LaPorte,Governor,,"Mitchell E Daniels, Jr.",Republican,16234
+LaPorte,Governor,,Velko Kapetanov,Independent,0
+LaPorte,Attorney General,,Joseph H Hogsett,Democratic,21117
+LaPorte,Attorney General,,Aaron T Milewski,Libertarian,1367
+LaPorte,Attorney General,,Steve Carter,Republican,18366
+LaPorte,Superintendent Of Public Instruction,,Susan Williams,Democratic,20848
+LaPorte,Superintendent Of Public Instruction,,Joe Hauptmann,Libertarian,1847
+LaPorte,Superintendent Of Public Instruction,,Suellen Reed,Republican,17816
+LaPorte,U.S. House,1,Peter J Visclosky,Democratic,0
+LaPorte,U.S. House,1,Mark J Leyva,Republican,0
+LaPorte,U.S. House,2,Joseph S Donnelly,Democratic,21693
+LaPorte,U.S. House,2,Douglas Barnes,Libertarian,931
+LaPorte,U.S. House,2,J Chris Chocola,Republican,19641
+LaPorte,State Senator,5,Nancy J Dembowski,Democratic,1206
+LaPorte,State Senator,5,Victor R Heinold,Republican,1355
+LaPorte,State Senator,8,Anita O Bowser,Democratic,21457
+LaPorte,State Senator,8,Janet F Gillon,Libertarian,1586
+LaPorte,State Senator,8,"Allen L Stevens, Jr.",Republican,16066
+LaPorte,State House,8,Ryan M Dvorak,Democratic,0
+LaPorte,State House,9,Scott D Pelath,Democratic,17110
+LaPorte,State House,9,Gregory D Kelver,Libertarian,2176
+LaPorte,State House,20,Lynne F Spevak,Democratic,7916
+LaPorte,State House,20,William Bill Schadowsky,Libertarian,858
+LaPorte,State House,20,Mary Kay Budak,Republican,9028
+LaPorte,Clerk Of The Circuit Court,La Porte County,Robert Bob Behler,Democratic,22392
+LaPorte,Clerk Of The Circuit Court,La Porte County,Judith A Keller,Republican,18751
+LaPorte,County Auditor,La Porte County,Michael T Quinn,Democratic,19927
+LaPorte,County Auditor,La Porte County,Teresa M Shuter,Republican,20567
+LaPorte,County Recorder,La Porte County,Barbara A Dean,Democratic,22952
+LaPorte,County Recorder,La Porte County,Jeff Stepanek,Republican,17101
+LaPorte,County Treasurer,La Porte County,Nancy K Hawkins,Democratic,19134
+LaPorte,County Treasurer,La Porte County,Kenneth E Layton,Republican,21747
+LaPorte,County Coroner,La Porte County,Vidya Kora,Democratic,24712
+LaPorte,County Coroner,La Porte County,Dan Stephens,Republican,16130
+LaPorte,County Surveyor,La Porte County,Robert P Przybylinski,Democratic,19717
+LaPorte,County Surveyor,La Porte County,John Jack Lemley,Libertarian,2384
+LaPorte,County Surveyor,La Porte County,James H Keil,Republican,18567
 Lawrence,President,,John F Kerry,Democratic,5346
 Lawrence,President,,Michael Badnarik,Libertarian,145
 Lawrence,President,,George Walker Bush,Republican,12207

--- a/2006/20060502__in__primary__county.csv
+++ b/2006/20060502__in__primary__county.csv
@@ -133,27 +133,27 @@ Cass,Judge Of The Circuit Court,Cass 29Th Circuit,Patrick E. Mcnarny,Republican,
 Cass,Judge Of The Circuit Court,Cass 29Th Circuit,Sheryl M. Pherson,Republican,1900
 Cass,Judge Of The Superior Court,"Cass County, Court 2",Rick Maughmer,Republican,3697
 Cass,Prosecuting Attorney,Cass 29Th Circuit,Kevin S. Enyeart,Republican,3625
-Clar,U.S. Senator,,Richard G. Lugar,Republican,2349
-Clar,U.S. House,9,Gretchen Clearwater,Democratic,1802
-Clar,U.S. House,9,Baron P. Hill,Democratic,11093
-Clar,U.S. House,9,John (Cosmo) Hockersmith,Democratic,489
-Clar,U.S. House,9,Lendall B. Terry,Democratic,509
-Clar,U.S. House,9,Sam Schultz,Republican,263
-Clar,U.S. House,9,Mike Sodrel,Republican,2324
-Clar,State Senator,45,James (Jim) Lewis,Democratic,4906
-Clar,State Senator,45,Steve Meyer,Democratic,3280
-Clar,State Senator,45,Floyd Coates,Republican,1195
-Clar,State Senator,45,Ryan Bergman,Republican,837
-Clar,State House,66,Terry Goodin,Democratic,2222
-Clar,State House,66,Christopher L. Byrd,Republican,442
-Clar,State House,66,James R. Mcclure Jr.,Republican,275
-Clar,State House,66,Steven R. Stemler,Republican,4207
-Clar,State House,66,Greg Marquart,Republican,309
-Clar,State House,66,Joe Theobald,Republican,978
-Clar,Judge Of The Superior Court,"Clark County, No. 1",Vicki Carmichael,Democratic,7963
-Clar,Judge Of The Superior Court,"Clark County, No. 1",Jerome F. (Jerry) Jacobi,Democratic,6768
-Clar,Judge Of The Superior Court,"Clark County, No. 1",Steven P. (Steve) Langdon,Republican,2109
-Clar,Prosecuting Attorney,Clark 4Th Circuit,Steven D. Stewart,Democratic,11129
+Clark,U.S. Senator,,Richard G. Lugar,Republican,2349
+Clark,U.S. House,9,Gretchen Clearwater,Democratic,1802
+Clark,U.S. House,9,Baron P. Hill,Democratic,11093
+Clark,U.S. House,9,John (Cosmo) Hockersmith,Democratic,489
+Clark,U.S. House,9,Lendall B. Terry,Democratic,509
+Clark,U.S. House,9,Sam Schultz,Republican,263
+Clark,U.S. House,9,Mike Sodrel,Republican,2324
+Clark,State Senator,45,James (Jim) Lewis,Democratic,4906
+Clark,State Senator,45,Steve Meyer,Democratic,3280
+Clark,State Senator,45,Floyd Coates,Republican,1195
+Clark,State Senator,45,Ryan Bergman,Republican,837
+Clark,State House,66,Terry Goodin,Democratic,2222
+Clark,State House,66,Christopher L. Byrd,Republican,442
+Clark,State House,66,James R. Mcclure Jr.,Republican,275
+Clark,State House,66,Steven R. Stemler,Republican,4207
+Clark,State House,66,Greg Marquart,Republican,309
+Clark,State House,66,Joe Theobald,Republican,978
+Clark,Judge Of The Superior Court,"Clark County, No. 1",Vicki Carmichael,Democratic,7963
+Clark,Judge Of The Superior Court,"Clark County, No. 1",Jerome F. (Jerry) Jacobi,Democratic,6768
+Clark,Judge Of The Superior Court,"Clark County, No. 1",Steven P. (Steve) Langdon,Republican,2109
+Clark,Prosecuting Attorney,Clark 4Th Circuit,Steven D. Stewart,Democratic,11129
 Clay,U.S. Senator,,Richard G. Lugar,Republican,1714
 Clay,U.S. House,8,Brad Ellsworth,Democratic,1841
 Clay,U.S. House,8,John N. Hostettler,Republican,1484
@@ -642,33 +642,33 @@ Lake,Judge Of The Superior Court,"Lake Co. County Division,",Stanley W. Jablonsk
 Lake,Judge Of The Superior Court,"Lake Co. County Division,",Jesse M. Villalpando,Democratic,26358
 Lake,Prosecuting Attorney,Lake 31St Circuit,Bernard A. Carter,Democratic,41286
 Lake,Prosecuting Attorney,Lake 31St Circuit,Douglas (Doug) Grimes,Republican,6437
-LaPort,U.S. Senator,,Richard G. Lugar,Republican,5802
-LaPort,U.S. House,1,Peter J. Visclosky,Democratic,0
-LaPort,U.S. House,1,Lewis (149 Farmer) Hass,Republican,0
-LaPort,U.S. House,1,Richard (Ric) Holtz,Republican,0
-LaPort,U.S. House,1,Mark J. Leyva,Republican,0
-LaPort,U.S. House,1,Jayson Reeves,Republican,0
-LaPort,U.S. House,1,Steve Francis,Republican,1466
-LaPort,U.S. House,1,Chris Chocola,Republican,4421
-LaPort,U.S. House,1,Tony Zirkle,Republican,2097
-LaPort,State Senator,4,Larry Chubb,Democratic,0
-LaPort,State Senator,4,Karen Tallian,Democratic,0
-LaPort,State Senator,4,Paul L. Childress,Republican,0
-LaPort,State Senator,4,Timothy E. Vojslavek,Republican,0
-LaPort,State House,8,Ryan M. Dvorak,Democratic,0
-LaPort,State House,8,Dorothy Snyder,Democratic,0
-LaPort,State House,8,Howard M. Smith,Democratic,1347
-LaPort,State House,8,Mary Kay Budak,Republican,1015
-LaPort,State House,8,Tom Dermody,Republican,3036
-LaPort,Judge Of The Circuit Court,La Porte 32Nd Circuit,Thomas Alevizos,Democratic,4152
-LaPort,Judge Of The Circuit Court,La Porte 32Nd Circuit,Donald E. Baugher,Democratic,1950
-LaPort,Judge Of The Circuit Court,La Porte 32Nd Circuit,Kevin B. Mcgrath,Democratic,959
-LaPort,Judge Of The Circuit Court,La Porte 32Nd Circuit,Robert C. Szilagyi,Democratic,2283
-LaPort,Judge Of The Circuit Court,La Porte 32Nd Circuit,R. Steven (Steve) Bom Sr.,Republican,1376
-LaPort,Judge Of The Circuit Court,La Porte 32Nd Circuit,W. Jonathan Forker,Republican,2187
-LaPort,Judge Of The Circuit Court,La Porte 32Nd Circuit,John Lake,Republican,1595
-LaPort,Judge Of The Circuit Court,La Porte 32Nd Circuit,Thomas J. Rutkowski,Republican,1328
-LaPort,Prosecuting Attorney,Laporte 32Nd Circuit,Robert J. Beckman,Democratic,7786
+LaPorte,U.S. Senator,,Richard G. Lugar,Republican,5802
+LaPorte,U.S. House,1,Peter J. Visclosky,Democratic,0
+LaPorte,U.S. House,1,Lewis (149 Farmer) Hass,Republican,0
+LaPorte,U.S. House,1,Richard (Ric) Holtz,Republican,0
+LaPorte,U.S. House,1,Mark J. Leyva,Republican,0
+LaPorte,U.S. House,1,Jayson Reeves,Republican,0
+LaPorte,U.S. House,1,Steve Francis,Republican,1466
+LaPorte,U.S. House,1,Chris Chocola,Republican,4421
+LaPorte,U.S. House,1,Tony Zirkle,Republican,2097
+LaPorte,State Senator,4,Larry Chubb,Democratic,0
+LaPorte,State Senator,4,Karen Tallian,Democratic,0
+LaPorte,State Senator,4,Paul L. Childress,Republican,0
+LaPorte,State Senator,4,Timothy E. Vojslavek,Republican,0
+LaPorte,State House,8,Ryan M. Dvorak,Democratic,0
+LaPorte,State House,8,Dorothy Snyder,Democratic,0
+LaPorte,State House,8,Howard M. Smith,Democratic,1347
+LaPorte,State House,8,Mary Kay Budak,Republican,1015
+LaPorte,State House,8,Tom Dermody,Republican,3036
+LaPorte,Judge Of The Circuit Court,La Porte 32Nd Circuit,Thomas Alevizos,Democratic,4152
+LaPorte,Judge Of The Circuit Court,La Porte 32Nd Circuit,Donald E. Baugher,Democratic,1950
+LaPorte,Judge Of The Circuit Court,La Porte 32Nd Circuit,Kevin B. Mcgrath,Democratic,959
+LaPorte,Judge Of The Circuit Court,La Porte 32Nd Circuit,Robert C. Szilagyi,Democratic,2283
+LaPorte,Judge Of The Circuit Court,La Porte 32Nd Circuit,R. Steven (Steve) Bom Sr.,Republican,1376
+LaPorte,Judge Of The Circuit Court,La Porte 32Nd Circuit,W. Jonathan Forker,Republican,2187
+LaPorte,Judge Of The Circuit Court,La Porte 32Nd Circuit,John Lake,Republican,1595
+LaPorte,Judge Of The Circuit Court,La Porte 32Nd Circuit,Thomas J. Rutkowski,Republican,1328
+LaPorte,Prosecuting Attorney,Laporte 32Nd Circuit,Robert J. Beckman,Democratic,7786
 Lawrence,U.S. Senator,,Richard G. Lugar,Republican,5671
 Lawrence,U.S. House,9,Gretchen Clearwater,Democratic,0
 Lawrence,U.S. House,9,Baron P. Hill,Democratic,0

--- a/2006/20061106__in__general__county.csv
+++ b/2006/20061106__in__general__county.csv
@@ -209,35 +209,35 @@ Cass,Judge Of The Circuit Court,Cass 29Th Circuit,Leo T Burns,Democratic,5982
 Cass,Judge Of The Circuit Court,Cass 29Th Circuit,Sheryl M Pherson,Republican,5140
 Cass,Judge Of The Superior Court,"Cass County, Court 2",Richard A Maughmer,Republican,8090
 Cass,Prosecuting Attorney,Cass 29Th Circuit,Kevin S Enyeart,Republican,7999
-Clar,U.S. Senator,,Steve Osborn,Libertarian,3358
-Clar,U.S. Senator,,Richard G Lugar,Republican,21690
-Clar,U.S. Senator,,Jack H Baldwin,Democratic,0
-Clar,U.S. Senator,,Mark Pool,Independent,0
-Clar,Secretary Of State,,Joe Pearson,Democratic,16736
-Clar,Secretary Of State,,Mike Kole,Libertarian,1009
-Clar,Secretary Of State,,Todd Rokita,Republican,13736
-Clar,Secretary Of State,,Bill Stant,Green,0
-Clar,Auditor Of State,,Judy Anderson,Democratic,17327
-Clar,Auditor Of State,,Tim Berry,Republican,14023
-Clar,Treasurer Of State,,Michael W Griffin,Democratic,16968
-Clar,Treasurer Of State,,Richard E Mourdock,Republican,14213
-Clar,U.S. House,9,Baron Hill,Democratic,16411
-Clar,U.S. House,9,D Eric Schansberg,Libertarian,1095
-Clar,U.S. House,9,Michael E Sodrel,Republican,15891
-Clar,U.S. House,9,Donald W Mantooth,Republican,0
-Clar,State Senator,45,James Lewis,Democratic,10076
-Clar,State Senator,45,Floyd E Coates,Republican,7634
-Clar,State Senator,46,Connie Weigleb Sipes,Democratic,10018
-Clar,State Senator,46,Ryan J Bergman,Republican,4843
-Clar,State House,66,Terry Goodin,Democratic,3738
-Clar,State House,70,Paul J Robertson,Democratic,3554
-Clar,State House,70,Christopher L Byrd,Republican,3030
-Clar,State House,71,Steven R Stemler,Democratic,12621
-Clar,State House,71,Joseph L Theobald,Republican,7036
-Clar,State House,73,Dennie Oxley,Democratic,693
-Clar,Judge Of The Superior Court,"Clark County, No. 1",Vicki L Carmichael,Democratic,19887
-Clar,Judge Of The Superior Court,"Clark County, No. 1",Steven P Langdon,Republican,12806
-Clar,Prosecuting Attorney,Clark 4Th Circuit,Steven D Stewart,Democratic,22632
+Clark,U.S. Senator,,Steve Osborn,Libertarian,3358
+Clark,U.S. Senator,,Richard G Lugar,Republican,21690
+Clark,U.S. Senator,,Jack H Baldwin,Democratic,0
+Clark,U.S. Senator,,Mark Pool,Independent,0
+Clark,Secretary Of State,,Joe Pearson,Democratic,16736
+Clark,Secretary Of State,,Mike Kole,Libertarian,1009
+Clark,Secretary Of State,,Todd Rokita,Republican,13736
+Clark,Secretary Of State,,Bill Stant,Green,0
+Clark,Auditor Of State,,Judy Anderson,Democratic,17327
+Clark,Auditor Of State,,Tim Berry,Republican,14023
+Clark,Treasurer Of State,,Michael W Griffin,Democratic,16968
+Clark,Treasurer Of State,,Richard E Mourdock,Republican,14213
+Clark,U.S. House,9,Baron Hill,Democratic,16411
+Clark,U.S. House,9,D Eric Schansberg,Libertarian,1095
+Clark,U.S. House,9,Michael E Sodrel,Republican,15891
+Clark,U.S. House,9,Donald W Mantooth,Republican,0
+Clark,State Senator,45,James Lewis,Democratic,10076
+Clark,State Senator,45,Floyd E Coates,Republican,7634
+Clark,State Senator,46,Connie Weigleb Sipes,Democratic,10018
+Clark,State Senator,46,Ryan J Bergman,Republican,4843
+Clark,State House,66,Terry Goodin,Democratic,3738
+Clark,State House,70,Paul J Robertson,Democratic,3554
+Clark,State House,70,Christopher L Byrd,Republican,3030
+Clark,State House,71,Steven R Stemler,Democratic,12621
+Clark,State House,71,Joseph L Theobald,Republican,7036
+Clark,State House,73,Dennie Oxley,Democratic,693
+Clark,Judge Of The Superior Court,"Clark County, No. 1",Vicki L Carmichael,Democratic,19887
+Clark,Judge Of The Superior Court,"Clark County, No. 1",Steven P Langdon,Republican,12806
+Clark,Prosecuting Attorney,Clark 4Th Circuit,Steven D Stewart,Democratic,22632
 Clay,U.S. Senator,,Steve Osborn,Libertarian,987
 Clay,U.S. Senator,,Richard G Lugar,Republican,6597
 Clay,U.S. Senator,,Jack H Baldwin,Democratic,0
@@ -1072,33 +1072,33 @@ Lake,State House,19,Eric Hammond,Republican,4270
 Lake,Judge Of The Superior Court,"Lake Co. County Division,",Jesse M Villalpando,Democratic,69022
 Lake,Prosecuting Attorney,Lake 31St Circuit,Bernard A Carter,Democratic,62246
 Lake,Prosecuting Attorney,Lake 31St Circuit,Douglas M Grimes,Republican,31923
-LaPort,U.S. Senator,,Steve Osborn,Libertarian,4773
-LaPort,U.S. Senator,,Richard G Lugar,Republican,18967
-LaPort,U.S. Senator,,Jack H Baldwin,Democratic,0
-LaPort,U.S. Senator,,Mark Pool,Independent,0
-LaPort,Secretary Of State,,Joe Pearson,Democratic,16877
-LaPort,Secretary Of State,,Mike Kole,Libertarian,1849
-LaPort,Secretary Of State,,Todd Rokita,Republican,11223
-LaPort,Secretary Of State,,Bill Stant,Green,0
-LaPort,Auditor Of State,,Judy Anderson,Democratic,17789
-LaPort,Auditor Of State,,Tim Berry,Republican,11270
-LaPort,Treasurer Of State,,Michael W Griffin,Democratic,17525
-LaPort,Treasurer Of State,,Richard E Mourdock,Republican,11479
-LaPort,U.S. House,1,Peter J Visclosky,Democratic,0
-LaPort,U.S. House,1,Mark J Leyva,Republican,0
-LaPort,U.S. House,1,Charles E Barman,Independent,0
-LaPort,U.S. House,2,Joseph S Donnelly,Democratic,18340
-LaPort,U.S. House,2,J Christopher Chocola,Republican,11697
-LaPort,State Senator,4,Karen Tallian,Democratic,0
-LaPort,State Senator,4,Dale Brewer,Republican,0
-LaPort,State House,8,Ryan M Dvorak,Democratic,0
-LaPort,State House,9,Scott D Pelath,Democratic,13105
-LaPort,State House,20,Andrea L Renner,Democratic,5773
-LaPort,State House,20,Gregory D Kelver,Libertarian,1279
-LaPort,State House,20,Tom Dermody,Republican,6633
-LaPort,Judge Of The Circuit Court,La Porte 32Nd Circuit,Thomas J Alevizos,Democratic,17838
-LaPort,Judge Of The Circuit Court,La Porte 32Nd Circuit,W Jonathan Forker,Republican,12640
-LaPort,Prosecuting Attorney,Laporte 32Nd Circuit,Robert J Beckman,Democratic,23993
+LaPorte,U.S. Senator,,Steve Osborn,Libertarian,4773
+LaPorte,U.S. Senator,,Richard G Lugar,Republican,18967
+LaPorte,U.S. Senator,,Jack H Baldwin,Democratic,0
+LaPorte,U.S. Senator,,Mark Pool,Independent,0
+LaPorte,Secretary Of State,,Joe Pearson,Democratic,16877
+LaPorte,Secretary Of State,,Mike Kole,Libertarian,1849
+LaPorte,Secretary Of State,,Todd Rokita,Republican,11223
+LaPorte,Secretary Of State,,Bill Stant,Green,0
+LaPorte,Auditor Of State,,Judy Anderson,Democratic,17789
+LaPorte,Auditor Of State,,Tim Berry,Republican,11270
+LaPorte,Treasurer Of State,,Michael W Griffin,Democratic,17525
+LaPorte,Treasurer Of State,,Richard E Mourdock,Republican,11479
+LaPorte,U.S. House,1,Peter J Visclosky,Democratic,0
+LaPorte,U.S. House,1,Mark J Leyva,Republican,0
+LaPorte,U.S. House,1,Charles E Barman,Independent,0
+LaPorte,U.S. House,2,Joseph S Donnelly,Democratic,18340
+LaPorte,U.S. House,2,J Christopher Chocola,Republican,11697
+LaPorte,State Senator,4,Karen Tallian,Democratic,0
+LaPorte,State Senator,4,Dale Brewer,Republican,0
+LaPorte,State House,8,Ryan M Dvorak,Democratic,0
+LaPorte,State House,9,Scott D Pelath,Democratic,13105
+LaPorte,State House,20,Andrea L Renner,Democratic,5773
+LaPorte,State House,20,Gregory D Kelver,Libertarian,1279
+LaPorte,State House,20,Tom Dermody,Republican,6633
+LaPorte,Judge Of The Circuit Court,La Porte 32Nd Circuit,Thomas J Alevizos,Democratic,17838
+LaPorte,Judge Of The Circuit Court,La Porte 32Nd Circuit,W Jonathan Forker,Republican,12640
+LaPorte,Prosecuting Attorney,Laporte 32Nd Circuit,Robert J Beckman,Democratic,23993
 Lawrence,U.S. Senator,,Steve Osborn,Libertarian,1335
 Lawrence,U.S. Senator,,Richard G Lugar,Republican,9404
 Lawrence,U.S. Senator,,Jack H Baldwin,Democratic,33

--- a/2008/20080506__in__primary__county.csv
+++ b/2008/20080506__in__primary__county.csv
@@ -171,28 +171,28 @@ Cass,State Senator,18,Phillip R. Messer,Republican,402
 Cass,State Senator,18,Brian Thomas,Republican,620
 Cass,State House,23,William C. Friend,Republican,0
 Cass,State House,23,James (Jim) R. Buck,Republican,0
-Clar,President,,Hillary Clinton,Democratic,18094
-Clar,President,,Barack Obama,Democratic,8710
-Clar,President,,Mike Huckabee,Republican,320
-Clar,President,,John Mccain,Republican,2724
-Clar,President,,Ron Paul,Republican,128
-Clar,President,,Mitt Romney,Republican,127
-Clar,Governor,,Jim Schellinger,Democratic,13707
-Clar,Governor,,Jill Long Thompson,Democratic,9508
-Clar,Governor,,Mitch Daniels,Republican,3012
-Clar,U.S. House,9,John R. Bottorff,Democratic,5939
-Clar,U.S. House,9,Gretchen Clearwater,Democratic,2809
-Clar,U.S. House,9,Baron P. Hill,Democratic,15665
-Clar,U.S. House,9,Lendall B. Terry,Democratic,729
-Clar,U.S. House,9,Mike Sodrel,Republican,3071
-Clar,State House,66,Terry Goodin,Democratic,3409
-Clar,State House,66,Jack R. Gillespie,Republican,369
-Clar,State House,66,Tim Hunt,Republican,723
-Clar,State House,66,Steve Davisson,Republican,111
-Clar,Judge Of The Superior Court,"Clark County, No. 2",Andrew (Drew) Adams,Democratic,5238
-Clar,Judge Of The Superior Court,"Clark County, No. 2",Jerome F. (Jerry) Jacobi,Democratic,9727
-Clar,Judge Of The Superior Court,"Clark County, No. 2",Shelley J. Marble,Democratic,5595
-Clar,Judge Of The Superior Court,"Clark County, No. 2",Daniel E. Moore,Democratic,5025
+Clark,President,,Hillary Clinton,Democratic,18094
+Clark,President,,Barack Obama,Democratic,8710
+Clark,President,,Mike Huckabee,Republican,320
+Clark,President,,John Mccain,Republican,2724
+Clark,President,,Ron Paul,Republican,128
+Clark,President,,Mitt Romney,Republican,127
+Clark,Governor,,Jim Schellinger,Democratic,13707
+Clark,Governor,,Jill Long Thompson,Democratic,9508
+Clark,Governor,,Mitch Daniels,Republican,3012
+Clark,U.S. House,9,John R. Bottorff,Democratic,5939
+Clark,U.S. House,9,Gretchen Clearwater,Democratic,2809
+Clark,U.S. House,9,Baron P. Hill,Democratic,15665
+Clark,U.S. House,9,Lendall B. Terry,Democratic,729
+Clark,U.S. House,9,Mike Sodrel,Republican,3071
+Clark,State House,66,Terry Goodin,Democratic,3409
+Clark,State House,66,Jack R. Gillespie,Republican,369
+Clark,State House,66,Tim Hunt,Republican,723
+Clark,State House,66,Steve Davisson,Republican,111
+Clark,Judge Of The Superior Court,"Clark County, No. 2",Andrew (Drew) Adams,Democratic,5238
+Clark,Judge Of The Superior Court,"Clark County, No. 2",Jerome F. (Jerry) Jacobi,Democratic,9727
+Clark,Judge Of The Superior Court,"Clark County, No. 2",Shelley J. Marble,Democratic,5595
+Clark,Judge Of The Superior Court,"Clark County, No. 2",Daniel E. Moore,Democratic,5025
 Clay,President,,Hillary Clinton,Democratic,4011
 Clay,President,,Barack Obama,Democratic,2028
 Clay,President,,Mike Huckabee,Republican,270
@@ -905,40 +905,40 @@ Lake,Judge Of The Superior Court,"Lake County, No. 1",Nicholas J. Schiralli,Demo
 Lake,Judge Of The Superior Court,"Lake County, No. 1",Randy A. Godshalk,Democratic,9743
 Lake,Judge Of The Superior Court,"Lake County, No. 1",Jeremiah T. Sheets,Democratic,7056
 Lake,Judge Of The Superior Court,"Lake County, No. 1",Nancy Moore Tiller,Democratic,31681
-LaPort,President,,Hillary Clinton,Democratic,13627
-LaPort,President,,Barack Obama,Democratic,12544
-LaPort,President,,Mike Huckabee,Republican,342
-LaPort,President,,John Mccain,Republican,3177
-LaPort,President,,Ron Paul,Republican,631
-LaPort,President,,Mitt Romney,Republican,153
-LaPort,Governor,,Jim Schellinger,Democratic,11999
-LaPort,Governor,,Jill Long Thompson,Democratic,12400
-LaPort,Governor,,Mitch Daniels,Republican,3079
-LaPort,U.S. House,1,Peter J. Visclosky,Democratic,0
-LaPort,U.S. House,1,Chuck Barman,Republican,0
-LaPort,U.S. House,1,Mark E. Coleman,Republican,0
-LaPort,U.S. House,1,Richard (Ric) Holtz,Republican,0
-LaPort,U.S. House,1,Mark Leyva,Republican,0
-LaPort,U.S. House,1,Jayson Reeves,Republican,0
-LaPort,U.S. House,1,Luke Puckett,Republican,1727
-LaPort,U.S. House,1,Joseph Roush,Republican,1275
-LaPort,U.S. House,1,Tony Zirkle,Republican,669
-LaPort,State Senator,5,Larry W. Balmer,Democratic,880
-LaPort,State Senator,5,Ed Charbonneau,Republican,353
-LaPort,State Senator,5,Debra J. Birkholz,Republican,7790
-LaPort,State Senator,5,Maxine Spenner,Republican,1435
-LaPort,State Senator,5,"Allen L. Stevens, Jr.",Republican,3024
-LaPort,State House,8,Ryan M. Dvorak,Democratic,0
-LaPort,State House,8,Dale R. Devon,Republican,0
-LaPort,Judge Of The Superior Court,"Laporte County, No. 1",Michael S. Bergerson,Democratic,18735
-LaPort,Judge Of The Superior Court,"Laporte County, No. 1",Kathleen Lang,Republican,3516
-LaPort,Judge Of The Superior Court,"Laporte County, No. 1",Kevin Mcgrath,Republican,6085
-LaPort,Judge Of The Superior Court,"Laporte County, No. 1","Richard R. Stalbrink, Jr.",Republican,10445
-LaPort,Judge Of The Superior Court,"Laporte County, No. 1",Thomas J. Rutkowski,Republican,3266
-LaPort,Judge Of The Superior Court,"Laporte County, No. 1",Edward (Ed) Janes,Republican,5676
-LaPort,Judge Of The Superior Court,"Laporte County, No. 1",Robert Neary,Republican,6919
-LaPort,Judge Of The Superior Court,"Laporte County, No. 1","Robert S. (Steve) Bom, Sr.",Republican,1189
-LaPort,Judge Of The Superior Court,"Laporte County, No. 1",Gregory H. Hofer,Republican,2546
+LaPorte,President,,Hillary Clinton,Democratic,13627
+LaPorte,President,,Barack Obama,Democratic,12544
+LaPorte,President,,Mike Huckabee,Republican,342
+LaPorte,President,,John Mccain,Republican,3177
+LaPorte,President,,Ron Paul,Republican,631
+LaPorte,President,,Mitt Romney,Republican,153
+LaPorte,Governor,,Jim Schellinger,Democratic,11999
+LaPorte,Governor,,Jill Long Thompson,Democratic,12400
+LaPorte,Governor,,Mitch Daniels,Republican,3079
+LaPorte,U.S. House,1,Peter J. Visclosky,Democratic,0
+LaPorte,U.S. House,1,Chuck Barman,Republican,0
+LaPorte,U.S. House,1,Mark E. Coleman,Republican,0
+LaPorte,U.S. House,1,Richard (Ric) Holtz,Republican,0
+LaPorte,U.S. House,1,Mark Leyva,Republican,0
+LaPorte,U.S. House,1,Jayson Reeves,Republican,0
+LaPorte,U.S. House,1,Luke Puckett,Republican,1727
+LaPorte,U.S. House,1,Joseph Roush,Republican,1275
+LaPorte,U.S. House,1,Tony Zirkle,Republican,669
+LaPorte,State Senator,5,Larry W. Balmer,Democratic,880
+LaPorte,State Senator,5,Ed Charbonneau,Republican,353
+LaPorte,State Senator,5,Debra J. Birkholz,Republican,7790
+LaPorte,State Senator,5,Maxine Spenner,Republican,1435
+LaPorte,State Senator,5,"Allen L. Stevens, Jr.",Republican,3024
+LaPorte,State House,8,Ryan M. Dvorak,Democratic,0
+LaPorte,State House,8,Dale R. Devon,Republican,0
+LaPorte,Judge Of The Superior Court,"Laporte County, No. 1",Michael S. Bergerson,Democratic,18735
+LaPorte,Judge Of The Superior Court,"Laporte County, No. 1",Kathleen Lang,Republican,3516
+LaPorte,Judge Of The Superior Court,"Laporte County, No. 1",Kevin Mcgrath,Republican,6085
+LaPorte,Judge Of The Superior Court,"Laporte County, No. 1","Richard R. Stalbrink, Jr.",Republican,10445
+LaPorte,Judge Of The Superior Court,"Laporte County, No. 1",Thomas J. Rutkowski,Republican,3266
+LaPorte,Judge Of The Superior Court,"Laporte County, No. 1",Edward (Ed) Janes,Republican,5676
+LaPorte,Judge Of The Superior Court,"Laporte County, No. 1",Robert Neary,Republican,6919
+LaPorte,Judge Of The Superior Court,"Laporte County, No. 1","Robert S. (Steve) Bom, Sr.",Republican,1189
+LaPorte,Judge Of The Superior Court,"Laporte County, No. 1",Gregory H. Hofer,Republican,2546
 Lawrence,President,,Hillary Clinton,Democratic,4637
 Lawrence,President,,Barack Obama,Democratic,2407
 Lawrence,President,,Mike Huckabee,Republican,461

--- a/2008/20081104__in__general__county.csv
+++ b/2008/20081104__in__general__county.csv
@@ -576,86 +576,86 @@ Cass,State Convention Delegate,Cass County,Elizabeth Troxell,Democratic,0
 Cass,State Convention Delegate,Cass County,Daniel J Mckee,Republican,0
 Cass,State Convention Delegate,Cass County,David W Miller,Republican,0
 Cass,State Convention Delegate,Cass County,W Ed Smith,Republican,0
-Clar,President,,Barack Obama,Democratic,21953
-Clar,President,,Bob Barr,Libertarian,406
-Clar,President,,John Mccain,Republican,25326
-Clar,President,,Darrell L Castle,Constitution,0
-Clar,President,,Cynthia A Mckinney,Green,1
-Clar,President,,Michael L Faith,Americas Independent,11
-Clar,President,,Chuck Baldwin,Independent,9
-Clar,President,,Lawson Mitchell Bone,Independent,0
-Clar,President,,Kevin Mottus,Independent,6
-Clar,President,,Ralph Nader,Independent,13
-Clar,President,,John Leroy Plemons,Independent,0
-Clar,President,,"""Lou"" Kujawski",Republican,0
-Clar,President,,Brian Moore,Socialist,0
-Clar,Governor,,Jill Long Thompson,Democratic,17821
-Clar,Governor,,Andy Horning,Libertarian,682
-Clar,Governor,,Mitchell E Daniels,Republican,28622
-Clar,Governor,,Timothy Lee Frye,Independent,0
-Clar,Governor,,Christopher Stried,Independent,0
-Clar,Attorney General,,Linda Pence,Democratic,21282
-Clar,Attorney General,,Greg Zoeller,Republican,23418
-Clar,Superintendent Of Public Instruction,,Richard D Wood,Democratic,19826
-Clar,Superintendent Of Public Instruction,,Tony Bennett,Republican,25061
-Clar,Superintendent Of Public Instruction,,Kevin R Brown,Democratic,24
-Clar,U.S. House,9,Baron P Hill,Democratic,26913
-Clar,U.S. House,9,D Eric Schansberg,Libertarian,1383
-Clar,U.S. House,9,Michael E Sodrel,Republican,19054
-Clar,State House,66,Terry Goodin,Democratic,4116
-Clar,State House,66,Jack R Gillespie,Republican,2531
-Clar,State House,70,Paul J Robertson,Democratic,4821
-Clar,State House,70,Robert T Hunt,Republican,4398
-Clar,State House,71,Steven Ray Stemler,Democratic,21202
-Clar,State House,73,Dennie Oxley,Democratic,707
-Clar,State House,73,Steven J Davisson,Republican,704
-Clar,Judge Of The Circuit Court,"Clark 4Th Circt, No. 1",Dan Moore,Democratic,26721
-Clar,Judge Of The Circuit Court,"Clark 4Th Circt, No. 1",Abraham Abe Navarro,Republican,18460
-Clar,Judge Of The Superior Court,"Clark County, No. 2",Jerome Jacobi,Democratic,32995
-Clar,Judge Of The Superior Court,"Clark County, No. 3",Joseph P Weber,Democratic,32406
-Clar,State Convention Delegate,Clark County,David Ray Abbott Sr,Democratic,0
-Clar,State Convention Delegate,Clark County,Fay Allen,Democratic,0
-Clar,State Convention Delegate,Clark County,Clementine B Barthold,Democratic,0
-Clar,State Convention Delegate,Clark County,Barbara Bratcher-Haas,Democratic,0
-Clar,State Convention Delegate,Clark County,Mary A Briscoe,Democratic,0
-Clar,State Convention Delegate,Clark County,John D Eckert,Democratic,0
-Clar,State Convention Delegate,Clark County,Leila Eckert,Democratic,0
-Clar,State Convention Delegate,Clark County,Donna Ennis,Democratic,0
-Clar,State Convention Delegate,Clark County,Edward J Flaugh,Democratic,0
-Clar,State Convention Delegate,Clark County,John L Gilkey,Democratic,0
-Clar,State Convention Delegate,Clark County,Virginia A Gilkey,Democratic,0
-Clar,State Convention Delegate,Clark County,Jerry Sue Griffith,Democratic,0
-Clar,State Convention Delegate,Clark County,Michael D Hall,Democratic,0
-Clar,State Convention Delegate,Clark County,Majorie B Jenkins,Democratic,0
-Clar,State Convention Delegate,Clark County,Nancy Jo Kraft,Democratic,0
-Clar,State Convention Delegate,Clark County,Shirley Meisner,Democratic,0
-Clar,State Convention Delegate,Clark County,Charles W Milburn,Democratic,0
-Clar,State Convention Delegate,Clark County,Leonard Miles Sr,Democratic,0
-Clar,State Convention Delegate,Clark County,Opal C Nein,Democratic,0
-Clar,State Convention Delegate,Clark County,Shirley A Nolot,Democratic,0
-Clar,State Convention Delegate,Clark County,Nancy N Palmquist,Democratic,0
-Clar,State Convention Delegate,Clark County,Benita G Pate,Democratic,0
-Clar,State Convention Delegate,Clark County,Rodney T Pate,Democratic,0
-Clar,State Convention Delegate,Clark County,John Perkins,Democratic,0
-Clar,State Convention Delegate,Clark County,Billy Sue Smith,Democratic,0
-Clar,State Convention Delegate,Clark County,Robert Smith,Democratic,0
-Clar,State Convention Delegate,Clark County,Derek Spence,Democratic,0
-Clar,State Convention Delegate,Clark County,Diane E Swank,Democratic,0
-Clar,State Convention Delegate,Clark County,Edith Tanner,Democratic,0
-Clar,State Convention Delegate,Clark County,Brian D Walker,Democratic,0
-Clar,State Convention Delegate,Clark County,Susan R Walker,Democratic,0
-Clar,State Convention Delegate,Clark County,Steve West,Democratic,0
-Clar,State Convention Delegate,Clark County,Dustin Tyrone White,Democratic,0
-Clar,State Convention Delegate,Clark County,Peggy Wilder,Democratic,0
-Clar,State Convention Delegate,Clark County,Barbara L Wilson,Democratic,0
-Clar,State Convention Delegate,Clark County,Tina Burkhead,Republican,0
-Clar,State Convention Delegate,Clark County,Daniel Erbele,Republican,0
-Clar,State Convention Delegate,Clark County,Marrisa Flanagan,Republican,0
-Clar,State Convention Delegate,Clark County,Timothy Kerns,Republican,0
-Clar,State Convention Delegate,Clark County,Gary R Kopp,Republican,0
-Clar,State Convention Delegate,Clark County,Glenn Porzig,Republican,0
-Clar,State Convention Delegate,Clark County,Charles Charlie Shaw,Republican,0
-Clar,State Convention Delegate,Clark County,Martin P Webster,Republican,0
+Clark,President,,Barack Obama,Democratic,21953
+Clark,President,,Bob Barr,Libertarian,406
+Clark,President,,John Mccain,Republican,25326
+Clark,President,,Darrell L Castle,Constitution,0
+Clark,President,,Cynthia A Mckinney,Green,1
+Clark,President,,Michael L Faith,Americas Independent,11
+Clark,President,,Chuck Baldwin,Independent,9
+Clark,President,,Lawson Mitchell Bone,Independent,0
+Clark,President,,Kevin Mottus,Independent,6
+Clark,President,,Ralph Nader,Independent,13
+Clark,President,,John Leroy Plemons,Independent,0
+Clark,President,,"""Lou"" Kujawski",Republican,0
+Clark,President,,Brian Moore,Socialist,0
+Clark,Governor,,Jill Long Thompson,Democratic,17821
+Clark,Governor,,Andy Horning,Libertarian,682
+Clark,Governor,,Mitchell E Daniels,Republican,28622
+Clark,Governor,,Timothy Lee Frye,Independent,0
+Clark,Governor,,Christopher Stried,Independent,0
+Clark,Attorney General,,Linda Pence,Democratic,21282
+Clark,Attorney General,,Greg Zoeller,Republican,23418
+Clark,Superintendent Of Public Instruction,,Richard D Wood,Democratic,19826
+Clark,Superintendent Of Public Instruction,,Tony Bennett,Republican,25061
+Clark,Superintendent Of Public Instruction,,Kevin R Brown,Democratic,24
+Clark,U.S. House,9,Baron P Hill,Democratic,26913
+Clark,U.S. House,9,D Eric Schansberg,Libertarian,1383
+Clark,U.S. House,9,Michael E Sodrel,Republican,19054
+Clark,State House,66,Terry Goodin,Democratic,4116
+Clark,State House,66,Jack R Gillespie,Republican,2531
+Clark,State House,70,Paul J Robertson,Democratic,4821
+Clark,State House,70,Robert T Hunt,Republican,4398
+Clark,State House,71,Steven Ray Stemler,Democratic,21202
+Clark,State House,73,Dennie Oxley,Democratic,707
+Clark,State House,73,Steven J Davisson,Republican,704
+Clark,Judge Of The Circuit Court,"Clark 4Th Circt, No. 1",Dan Moore,Democratic,26721
+Clark,Judge Of The Circuit Court,"Clark 4Th Circt, No. 1",Abraham Abe Navarro,Republican,18460
+Clark,Judge Of The Superior Court,"Clark County, No. 2",Jerome Jacobi,Democratic,32995
+Clark,Judge Of The Superior Court,"Clark County, No. 3",Joseph P Weber,Democratic,32406
+Clark,State Convention Delegate,Clark County,David Ray Abbott Sr,Democratic,0
+Clark,State Convention Delegate,Clark County,Fay Allen,Democratic,0
+Clark,State Convention Delegate,Clark County,Clementine B Barthold,Democratic,0
+Clark,State Convention Delegate,Clark County,Barbara Bratcher-Haas,Democratic,0
+Clark,State Convention Delegate,Clark County,Mary A Briscoe,Democratic,0
+Clark,State Convention Delegate,Clark County,John D Eckert,Democratic,0
+Clark,State Convention Delegate,Clark County,Leila Eckert,Democratic,0
+Clark,State Convention Delegate,Clark County,Donna Ennis,Democratic,0
+Clark,State Convention Delegate,Clark County,Edward J Flaugh,Democratic,0
+Clark,State Convention Delegate,Clark County,John L Gilkey,Democratic,0
+Clark,State Convention Delegate,Clark County,Virginia A Gilkey,Democratic,0
+Clark,State Convention Delegate,Clark County,Jerry Sue Griffith,Democratic,0
+Clark,State Convention Delegate,Clark County,Michael D Hall,Democratic,0
+Clark,State Convention Delegate,Clark County,Majorie B Jenkins,Democratic,0
+Clark,State Convention Delegate,Clark County,Nancy Jo Kraft,Democratic,0
+Clark,State Convention Delegate,Clark County,Shirley Meisner,Democratic,0
+Clark,State Convention Delegate,Clark County,Charles W Milburn,Democratic,0
+Clark,State Convention Delegate,Clark County,Leonard Miles Sr,Democratic,0
+Clark,State Convention Delegate,Clark County,Opal C Nein,Democratic,0
+Clark,State Convention Delegate,Clark County,Shirley A Nolot,Democratic,0
+Clark,State Convention Delegate,Clark County,Nancy N Palmquist,Democratic,0
+Clark,State Convention Delegate,Clark County,Benita G Pate,Democratic,0
+Clark,State Convention Delegate,Clark County,Rodney T Pate,Democratic,0
+Clark,State Convention Delegate,Clark County,John Perkins,Democratic,0
+Clark,State Convention Delegate,Clark County,Billy Sue Smith,Democratic,0
+Clark,State Convention Delegate,Clark County,Robert Smith,Democratic,0
+Clark,State Convention Delegate,Clark County,Derek Spence,Democratic,0
+Clark,State Convention Delegate,Clark County,Diane E Swank,Democratic,0
+Clark,State Convention Delegate,Clark County,Edith Tanner,Democratic,0
+Clark,State Convention Delegate,Clark County,Brian D Walker,Democratic,0
+Clark,State Convention Delegate,Clark County,Susan R Walker,Democratic,0
+Clark,State Convention Delegate,Clark County,Steve West,Democratic,0
+Clark,State Convention Delegate,Clark County,Dustin Tyrone White,Democratic,0
+Clark,State Convention Delegate,Clark County,Peggy Wilder,Democratic,0
+Clark,State Convention Delegate,Clark County,Barbara L Wilson,Democratic,0
+Clark,State Convention Delegate,Clark County,Tina Burkhead,Republican,0
+Clark,State Convention Delegate,Clark County,Daniel Erbele,Republican,0
+Clark,State Convention Delegate,Clark County,Marrisa Flanagan,Republican,0
+Clark,State Convention Delegate,Clark County,Timothy Kerns,Republican,0
+Clark,State Convention Delegate,Clark County,Gary R Kopp,Republican,0
+Clark,State Convention Delegate,Clark County,Glenn Porzig,Republican,0
+Clark,State Convention Delegate,Clark County,Charles Charlie Shaw,Republican,0
+Clark,State Convention Delegate,Clark County,Martin P Webster,Republican,0
 Clay,President,,Barack Obama,Democratic,4954
 Clay,President,,Bob Barr,Libertarian,168
 Clay,President,,John Mccain,Republican,6267
@@ -2762,82 +2762,82 @@ Lake,State Convention Delegate,Lake County,Russell Alan White,Republican,0
 Lake,State Convention Delegate,Lake County,Thomas Wichlinski,Republican,0
 Lake,State Convention Delegate,Lake County,Amy L Wigsmoen,Republican,0
 Lake,State Convention Delegate,Lake County,Robert E Wilczynski,Republican,0
-LaPort,President,,Barack Obama,Democratic,28258
-LaPort,President,,Bob Barr,Libertarian,681
-LaPort,President,,John Mccain,Republican,17918
-LaPort,President,,Darrell L Castle,Constitution,0
-LaPort,President,,Cynthia A Mckinney,Green,3
-LaPort,President,,Michael L Faith,Americas Independent,0
-LaPort,President,,Chuck Baldwin,Independent,29
-LaPort,President,,Lawson Mitchell Bone,Independent,0
-LaPort,President,,Kevin Mottus,Independent,3
-LaPort,President,,Ralph Nader,Independent,25
-LaPort,President,,John Leroy Plemons,Independent,0
-LaPort,President,,"""Lou"" Kujawski",Republican,0
-LaPort,President,,Brian Moore,Socialist,2
-LaPort,Governor,,Jill Long Thompson,Democratic,28922
-LaPort,Governor,,Andy Horning,Libertarian,1240
-LaPort,Governor,,Mitchell E Daniels,Republican,15495
-LaPort,Governor,,Timothy Lee Frye,Independent,0
-LaPort,Governor,,Christopher Stried,Independent,1
-LaPort,Attorney General,,Linda Pence,Democratic,26380
-LaPort,Attorney General,,Greg Zoeller,Republican,16676
-LaPort,Superintendent Of Public Instruction,,Richard D Wood,Democratic,26453
-LaPort,Superintendent Of Public Instruction,,Tony Bennett,Republican,16292
-LaPort,Superintendent Of Public Instruction,,Kevin R Brown,Democratic,3
-LaPort,U.S. House,1,Peter J Visclosky,Democratic,0
-LaPort,U.S. House,1,Jeff Duensing,Libertarian,0
-LaPort,U.S. House,1,Mark J Leyva,Republican,0
-LaPort,U.S. House,2,Joseph S Donnelly,Democratic,32991
-LaPort,U.S. House,2,Mark Vogel,Libertarian,1608
-LaPort,U.S. House,2,Luke Wayne Puckett,Republican,11250
-LaPort,State Senator,5,Larry W Balmer,Democratic,1244
-LaPort,State Senator,5,Ed Charbonneau,Republican,1408
-LaPort,State Senator,8,Jim Arnold,Democratic,30006
-LaPort,State Senator,8,Gregory D Kelver,Libertarian,1896
-LaPort,State Senator,8,"Allen L Stevens, Jr.",Republican,10717
-LaPort,State House,8,Ryan M Dvorak,Democratic,0
-LaPort,State House,8,Dale R Devon,Republican,0
-LaPort,State House,9,Scott D Pelath,Democratic,20509
-LaPort,State House,9,K P Nfr,Libertarian,1818
-LaPort,State House,20,Jerry P Cooley,Democratic,6985
-LaPort,State House,20,Thomas P Dermody,Republican,11988
-LaPort,Judge Of The Superior Court,"Laporte County, No. 1",Michael S Bergerson,Democratic,22198
-LaPort,Judge Of The Superior Court,"Laporte County, No. 1",Kathleen B Lang,Republican,22581
-LaPort,Judge Of The Superior Court,"Laporte County, No. 2","Richard R Stalbrink, Jr.",Democratic,29527
-LaPort,Judge Of The Superior Court,"Laporte County, No. 2",Thomas J Rutkowski,Republican,14981
-LaPort,Judge Of The Superior Court,"Laporte County, No. 3",Jennifer L Evans,Democratic,27016
-LaPort,Judge Of The Superior Court,"Laporte County, No. 3",Gregory H Hofer,Republican,17598
-LaPort,Judge Of The Superior Court,"Laporte County, No. 4",William J Boklund,Democratic,36584
-LaPort,State Convention Delegate,La Porte County,Matthew Bernacchi,Democratic,0
-LaPort,State Convention Delegate,La Porte County,Suzanne Burns,Democratic,0
-LaPort,State Convention Delegate,La Porte County,Jerry P Cooley,Democratic,0
-LaPort,State Convention Delegate,La Porte County,Barbara Huston,Democratic,0
-LaPort,State Convention Delegate,La Porte County,Donna Kavanagh,Democratic,0
-LaPort,State Convention Delegate,La Porte County,Henry Pettigrew,Democratic,0
-LaPort,State Convention Delegate,La Porte County,Mike Schultz,Democratic,0
-LaPort,State Convention Delegate,La Porte County,Michael D Stevens,Democratic,0
-LaPort,State Convention Delegate,La Porte County,Paul A Young,Democratic,0
-LaPort,State Convention Delegate,La Porte County,David Balka,Republican,0
-LaPort,State Convention Delegate,La Porte County,Steven D Benson,Republican,0
-LaPort,State Convention Delegate,La Porte County,Michelle L Dombowski,Republican,0
-LaPort,State Convention Delegate,La Porte County,Barbarra J Dreiner,Republican,0
-LaPort,State Convention Delegate,La Porte County,Edward R Gondeck,Republican,0
-LaPort,State Convention Delegate,La Porte County,Mike Gonder,Republican,0
-LaPort,State Convention Delegate,La Porte County,Matthew G Hayes,Republican,0
-LaPort,State Convention Delegate,La Porte County,David G Kaufman,Republican,0
-LaPort,State Convention Delegate,La Porte County,David Christopher Miller,Republican,0
-LaPort,State Convention Delegate,La Porte County,Randall C Miller,Republican,0
-LaPort,State Convention Delegate,La Porte County,Sarah Brooke Miller,Republican,0
-LaPort,State Convention Delegate,La Porte County,Edwin Mueller,Republican,0
-LaPort,State Convention Delegate,La Porte County,James Jim Powers,Republican,0
-LaPort,State Convention Delegate,La Porte County,Larry A Pryor,Republican,0
-LaPort,State Convention Delegate,La Porte County,Dave Scarborough,Republican,0
-LaPort,State Convention Delegate,La Porte County,Loretta Scarborough,Republican,0
-LaPort,State Convention Delegate,La Porte County,Ken Shilt,Republican,0
-LaPort,State Convention Delegate,La Porte County,"Allen L Stevens, Jr.",Republican,0
-LaPort,State Convention Delegate,La Porte County,Debra S Strieter,Republican,0
-LaPort,State Convention Delegate,La Porte County,Henry Wood,Republican,0
+LaPorte,President,,Barack Obama,Democratic,28258
+LaPorte,President,,Bob Barr,Libertarian,681
+LaPorte,President,,John Mccain,Republican,17918
+LaPorte,President,,Darrell L Castle,Constitution,0
+LaPorte,President,,Cynthia A Mckinney,Green,3
+LaPorte,President,,Michael L Faith,Americas Independent,0
+LaPorte,President,,Chuck Baldwin,Independent,29
+LaPorte,President,,Lawson Mitchell Bone,Independent,0
+LaPorte,President,,Kevin Mottus,Independent,3
+LaPorte,President,,Ralph Nader,Independent,25
+LaPorte,President,,John Leroy Plemons,Independent,0
+LaPorte,President,,"""Lou"" Kujawski",Republican,0
+LaPorte,President,,Brian Moore,Socialist,2
+LaPorte,Governor,,Jill Long Thompson,Democratic,28922
+LaPorte,Governor,,Andy Horning,Libertarian,1240
+LaPorte,Governor,,Mitchell E Daniels,Republican,15495
+LaPorte,Governor,,Timothy Lee Frye,Independent,0
+LaPorte,Governor,,Christopher Stried,Independent,1
+LaPorte,Attorney General,,Linda Pence,Democratic,26380
+LaPorte,Attorney General,,Greg Zoeller,Republican,16676
+LaPorte,Superintendent Of Public Instruction,,Richard D Wood,Democratic,26453
+LaPorte,Superintendent Of Public Instruction,,Tony Bennett,Republican,16292
+LaPorte,Superintendent Of Public Instruction,,Kevin R Brown,Democratic,3
+LaPorte,U.S. House,1,Peter J Visclosky,Democratic,0
+LaPorte,U.S. House,1,Jeff Duensing,Libertarian,0
+LaPorte,U.S. House,1,Mark J Leyva,Republican,0
+LaPorte,U.S. House,2,Joseph S Donnelly,Democratic,32991
+LaPorte,U.S. House,2,Mark Vogel,Libertarian,1608
+LaPorte,U.S. House,2,Luke Wayne Puckett,Republican,11250
+LaPorte,State Senator,5,Larry W Balmer,Democratic,1244
+LaPorte,State Senator,5,Ed Charbonneau,Republican,1408
+LaPorte,State Senator,8,Jim Arnold,Democratic,30006
+LaPorte,State Senator,8,Gregory D Kelver,Libertarian,1896
+LaPorte,State Senator,8,"Allen L Stevens, Jr.",Republican,10717
+LaPorte,State House,8,Ryan M Dvorak,Democratic,0
+LaPorte,State House,8,Dale R Devon,Republican,0
+LaPorte,State House,9,Scott D Pelath,Democratic,20509
+LaPorte,State House,9,K P Nfr,Libertarian,1818
+LaPorte,State House,20,Jerry P Cooley,Democratic,6985
+LaPorte,State House,20,Thomas P Dermody,Republican,11988
+LaPorte,Judge Of The Superior Court,"Laporte County, No. 1",Michael S Bergerson,Democratic,22198
+LaPorte,Judge Of The Superior Court,"Laporte County, No. 1",Kathleen B Lang,Republican,22581
+LaPorte,Judge Of The Superior Court,"Laporte County, No. 2","Richard R Stalbrink, Jr.",Democratic,29527
+LaPorte,Judge Of The Superior Court,"Laporte County, No. 2",Thomas J Rutkowski,Republican,14981
+LaPorte,Judge Of The Superior Court,"Laporte County, No. 3",Jennifer L Evans,Democratic,27016
+LaPorte,Judge Of The Superior Court,"Laporte County, No. 3",Gregory H Hofer,Republican,17598
+LaPorte,Judge Of The Superior Court,"Laporte County, No. 4",William J Boklund,Democratic,36584
+LaPorte,State Convention Delegate,La Porte County,Matthew Bernacchi,Democratic,0
+LaPorte,State Convention Delegate,La Porte County,Suzanne Burns,Democratic,0
+LaPorte,State Convention Delegate,La Porte County,Jerry P Cooley,Democratic,0
+LaPorte,State Convention Delegate,La Porte County,Barbara Huston,Democratic,0
+LaPorte,State Convention Delegate,La Porte County,Donna Kavanagh,Democratic,0
+LaPorte,State Convention Delegate,La Porte County,Henry Pettigrew,Democratic,0
+LaPorte,State Convention Delegate,La Porte County,Mike Schultz,Democratic,0
+LaPorte,State Convention Delegate,La Porte County,Michael D Stevens,Democratic,0
+LaPorte,State Convention Delegate,La Porte County,Paul A Young,Democratic,0
+LaPorte,State Convention Delegate,La Porte County,David Balka,Republican,0
+LaPorte,State Convention Delegate,La Porte County,Steven D Benson,Republican,0
+LaPorte,State Convention Delegate,La Porte County,Michelle L Dombowski,Republican,0
+LaPorte,State Convention Delegate,La Porte County,Barbarra J Dreiner,Republican,0
+LaPorte,State Convention Delegate,La Porte County,Edward R Gondeck,Republican,0
+LaPorte,State Convention Delegate,La Porte County,Mike Gonder,Republican,0
+LaPorte,State Convention Delegate,La Porte County,Matthew G Hayes,Republican,0
+LaPorte,State Convention Delegate,La Porte County,David G Kaufman,Republican,0
+LaPorte,State Convention Delegate,La Porte County,David Christopher Miller,Republican,0
+LaPorte,State Convention Delegate,La Porte County,Randall C Miller,Republican,0
+LaPorte,State Convention Delegate,La Porte County,Sarah Brooke Miller,Republican,0
+LaPorte,State Convention Delegate,La Porte County,Edwin Mueller,Republican,0
+LaPorte,State Convention Delegate,La Porte County,James Jim Powers,Republican,0
+LaPorte,State Convention Delegate,La Porte County,Larry A Pryor,Republican,0
+LaPorte,State Convention Delegate,La Porte County,Dave Scarborough,Republican,0
+LaPorte,State Convention Delegate,La Porte County,Loretta Scarborough,Republican,0
+LaPorte,State Convention Delegate,La Porte County,Ken Shilt,Republican,0
+LaPorte,State Convention Delegate,La Porte County,"Allen L Stevens, Jr.",Republican,0
+LaPorte,State Convention Delegate,La Porte County,Debra S Strieter,Republican,0
+LaPorte,State Convention Delegate,La Porte County,Henry Wood,Republican,0
 Lawrence,President,,Barack Obama,Democratic,7208
 Lawrence,President,,Bob Barr,Libertarian,287
 Lawrence,President,,John Mccain,Republican,11018

--- a/2010/20100504__in__primary__county.csv
+++ b/2010/20100504__in__primary__county.csv
@@ -203,31 +203,31 @@ Cass,State House,23,Dan Pool,Republican,0
 Cass,State House,23,Heath Vannatter,Republican,0
 Cass,Judge Of The Superior Court,"Cass County, Court 1",Thomas C. Perrone,Democratic,1525
 Cass,Prosecuting Attorney,Cass 29Th Circuit,Kevin S. Enyeart,Republican,4727
-Clar,U.S. Senator,,"Don Bates, Jr.",Republican,240
-Clar,U.S. Senator,,Richard Behney,Republican,159
-Clar,U.S. Senator,,Dan Coats,Republican,3381
-Clar,U.S. Senator,,John N. Hostettler,Republican,1045
-Clar,U.S. Senator,,Marlin A. Stutzman,Republican,746
-Clar,U.S. House,9,John R. Bottorff,Democratic,2172
-Clar,U.S. House,9,Baron P. Hill,Democratic,6111
-Clar,U.S. House,9,Carol Johnson-Smith,Democratic,590
-Clar,U.S. House,9,"James R. Mcclure, Jr.",Democratic,303
-Clar,U.S. House,9,Lendall B. Terry,Democratic,262
-Clar,U.S. House,9,Travis Hankins,Republican,363
-Clar,U.S. House,9,Mike Sodrel,Republican,2945
-Clar,U.S. House,9,Rick Warren,Republican,115
-Clar,U.S. House,9,Todd Young,Republican,2507
-Clar,State Senator,45,James (Jim) Lewis,Democratic,4556
-Clar,State Senator,45,Ron Grooms,Republican,1498
-Clar,State Senator,45,Lee Ann Wiseheart,Republican,815
-Clar,State House,66,Terry Goodin,Democratic,1744
-Clar,State House,66,Jim Lucas,Republican,664
-Clar,State House,66,Brett Loyd,Republican,495
-Clar,State House,66,Rhonda J. Rhoads,Republican,980
-Clar,State House,66,Douglas C. Leatherbury,Republican,95
-Clar,State House,66,Steve Davisson,Republican,46
-Clar,State House,66,Henry H. (Hank) Taylor,Republican,173
-Clar,Prosecuting Attorney,Clark 4Th Circuit,Steven D. Stewart,Democratic,7408
+Clark,U.S. Senator,,"Don Bates, Jr.",Republican,240
+Clark,U.S. Senator,,Richard Behney,Republican,159
+Clark,U.S. Senator,,Dan Coats,Republican,3381
+Clark,U.S. Senator,,John N. Hostettler,Republican,1045
+Clark,U.S. Senator,,Marlin A. Stutzman,Republican,746
+Clark,U.S. House,9,John R. Bottorff,Democratic,2172
+Clark,U.S. House,9,Baron P. Hill,Democratic,6111
+Clark,U.S. House,9,Carol Johnson-Smith,Democratic,590
+Clark,U.S. House,9,"James R. Mcclure, Jr.",Democratic,303
+Clark,U.S. House,9,Lendall B. Terry,Democratic,262
+Clark,U.S. House,9,Travis Hankins,Republican,363
+Clark,U.S. House,9,Mike Sodrel,Republican,2945
+Clark,U.S. House,9,Rick Warren,Republican,115
+Clark,U.S. House,9,Todd Young,Republican,2507
+Clark,State Senator,45,James (Jim) Lewis,Democratic,4556
+Clark,State Senator,45,Ron Grooms,Republican,1498
+Clark,State Senator,45,Lee Ann Wiseheart,Republican,815
+Clark,State House,66,Terry Goodin,Democratic,1744
+Clark,State House,66,Jim Lucas,Republican,664
+Clark,State House,66,Brett Loyd,Republican,495
+Clark,State House,66,Rhonda J. Rhoads,Republican,980
+Clark,State House,66,Douglas C. Leatherbury,Republican,95
+Clark,State House,66,Steve Davisson,Republican,46
+Clark,State House,66,Henry H. (Hank) Taylor,Republican,173
+Clark,Prosecuting Attorney,Clark 4Th Circuit,Steven D. Stewart,Democratic,7408
 Clay,U.S. Senator,,"Don Bates, Jr.",Republican,119
 Clay,U.S. Senator,,Richard Behney,Republican,102
 Clay,U.S. Senator,,Dan Coats,Republican,813
@@ -989,32 +989,32 @@ Lake,State House,1,Daniel M. Klein,Republican,1610
 Lake,Judge Of The Circuit Court,Lake 31St Circuit,Alex Dominguez,Democratic,19310
 Lake,Judge Of The Circuit Court,Lake 31St Circuit,George C. Paras,Democratic,20462
 Lake,Prosecuting Attorney,Lake 31St Circuit,Bernard A. Carter,Democratic,34913
-LaPort,U.S. Senator,,"Don Bates, Jr.",Republican,219
-LaPort,U.S. Senator,,Richard Behney,Republican,190
-LaPort,U.S. Senator,,Dan Coats,Republican,2230
-LaPort,U.S. Senator,,John N. Hostettler,Republican,754
-LaPort,U.S. Senator,,Marlin A. Stutzman,Republican,841
-LaPort,U.S. House,1,Peter J. Visclosky,Democratic,0
-LaPort,U.S. House,1,Adam A. Dombkowski,Republican,0
-LaPort,U.S. House,1,Ric Holtz,Republican,0
-LaPort,U.S. House,1,Mark Leyva,Republican,0
-LaPort,U.S. House,1,Peter Lindemulder Iii,Republican,0
-LaPort,U.S. House,1,Eric L. Olson,Republican,0
-LaPort,U.S. House,1,Robert Pastore,Republican,0
-LaPort,U.S. House,1,Michael Petyo,Republican,0
-LaPort,U.S. House,1,Jayson Reeves,Republican,0
-LaPort,U.S. House,1,Martin A. Dolan,Republican,614
-LaPort,U.S. House,1,Jack Edward Jordan,Republican,1051
-LaPort,U.S. House,1,Jackie Walorski,Republican,2271
-LaPort,U.S. House,1,Tony Hvfvgpd Zirkle,Republican,172
-LaPort,State Senator,4,Karen Tallian,Democratic,0
-LaPort,State Senator,4,Shawn Olson,Republican,0
-LaPort,State House,8,Ryan M. Dvorak,Democratic,0
-LaPort,State House,8,Richard Pfeil,Republican,0
-LaPort,State House,8,Mark Schaeffer,Republican,0
-LaPort,State House,8,Todd Reinert,Republican,768
-LaPort,Prosecuting Attorney,Laporte 32Nd Circuit,Robert J. Beckman,Democratic,4279
-LaPort,Prosecuting Attorney,Laporte 32Nd Circuit,"Bob ""Z"" Szilagyi",Democratic,4603
+LaPorte,U.S. Senator,,"Don Bates, Jr.",Republican,219
+LaPorte,U.S. Senator,,Richard Behney,Republican,190
+LaPorte,U.S. Senator,,Dan Coats,Republican,2230
+LaPorte,U.S. Senator,,John N. Hostettler,Republican,754
+LaPorte,U.S. Senator,,Marlin A. Stutzman,Republican,841
+LaPorte,U.S. House,1,Peter J. Visclosky,Democratic,0
+LaPorte,U.S. House,1,Adam A. Dombkowski,Republican,0
+LaPorte,U.S. House,1,Ric Holtz,Republican,0
+LaPorte,U.S. House,1,Mark Leyva,Republican,0
+LaPorte,U.S. House,1,Peter Lindemulder Iii,Republican,0
+LaPorte,U.S. House,1,Eric L. Olson,Republican,0
+LaPorte,U.S. House,1,Robert Pastore,Republican,0
+LaPorte,U.S. House,1,Michael Petyo,Republican,0
+LaPorte,U.S. House,1,Jayson Reeves,Republican,0
+LaPorte,U.S. House,1,Martin A. Dolan,Republican,614
+LaPorte,U.S. House,1,Jack Edward Jordan,Republican,1051
+LaPorte,U.S. House,1,Jackie Walorski,Republican,2271
+LaPorte,U.S. House,1,Tony Hvfvgpd Zirkle,Republican,172
+LaPorte,State Senator,4,Karen Tallian,Democratic,0
+LaPorte,State Senator,4,Shawn Olson,Republican,0
+LaPorte,State House,8,Ryan M. Dvorak,Democratic,0
+LaPorte,State House,8,Richard Pfeil,Republican,0
+LaPorte,State House,8,Mark Schaeffer,Republican,0
+LaPorte,State House,8,Todd Reinert,Republican,768
+LaPorte,Prosecuting Attorney,Laporte 32Nd Circuit,Robert J. Beckman,Democratic,4279
+LaPorte,Prosecuting Attorney,Laporte 32Nd Circuit,"Bob ""Z"" Szilagyi",Democratic,4603
 Lawrence,U.S. Senator,,"Don Bates, Jr.",Republican,220
 Lawrence,U.S. Senator,,Richard Behney,Republican,135
 Lawrence,U.S. Senator,,Dan Coats,Republican,1113

--- a/2010/20101102_in_special_general_ushouse_3_county.csv
+++ b/2010/20101102_in_special_general_ushouse_3_county.csv
@@ -1,0 +1,25 @@
+﻿county,office,district,party,candidate,votes
+Allen,U.S. House,3,Democratic,Thomas Hayhurst,33664
+Allen,U.S. House,3,Republican,Marlin A. Stutzman,49971
+Allen,U.S. House,3,Libertarian,Scott Wise,3415
+DeKalb,U.S. House,3,Democratic,Thomas Hayhurst,3732
+DeKalb,U.S. House,3,Republican,Marlin A. Stutzman,7199
+DeKalb,U.S. House,3,Libertarian,Scott Wise,576
+Elkhart,U.S. House,3,Democratic,Thomas Hayhurst,7171
+Elkhart,U.S. House,3,Republican,Marlin A. Stutzman,19212
+Elkhart,U.S. House,3,Libertarian,Scott Wise,797
+Kosciusko,U.S. House,3,Democratic,Thomas Hayhurst,4223
+Kosciusko,U.S. House,3,Republican,Marlin A. Stutzman,14731
+Kosciusko,U.S. House,3,Libertarian,Scott Wise,924
+LaGrange,U.S. House,3,Democratic,Thomas Hayhurst,1688
+LaGrange,U.S. House,3,Republican,Marlin A. Stutzman,4538
+LaGrange,U.S. House,3,Libertarian,Scott Wise,317
+Noble,U.S. House,3,Democratic,Thomas Hayhurst,3474
+Noble,U.S. House,3,Republican,Marlin A. Stutzman,7211
+Noble,U.S. House,3,Libertarian,Scott Wise,592
+Steuben,U.S. House,3,Democratic,Thomas Hayhurst,3537
+Steuben,U.S. House,3,Republican,Marlin A. Stutzman,6017
+Steuben,U.S. House,3,Libertarian,Scott Wise,549
+Whitley,U.S. House,3,Democratic,Thomas Hayhurst,6536
+Whitley,U.S. House,3,Republican,Marlin A. Stutzman,3391
+Whitley,U.S. House,3,Libertarian,Scott Wise,744

--- a/2010/20101104__in__general__county.csv
+++ b/2010/20101104__in__general__county.csv
@@ -240,35 +240,35 @@ Cass,State House,25,Dan Pool,Republican,0
 Cass,State House,38,Heath Vannatter,Republican,0
 Cass,Judge Of The Superior Court,"Cass County, Court 1",Thomas C Perrone,Democratic,7244
 Cass,Prosecuting Attorney,Cass 29Th Circuit,Kevin Stacy Enyeart,Republican,8421
-Clar,U.S. Senator,,Brad Ellsworth,Democratic,13429
-Clar,U.S. Senator,,Rebecca Sink-Burris,Libertarian,1409
-Clar,U.S. Senator,,Dan Coats,Republican,17773
-Clar,U.S. Senator,,Jack Rooney,Independent,1
-Clar,U.S. Senator,,Jim Miller,Write-In,1
-Clar,Secretary Of State,,Vop Osili,Democratic,12141
-Clar,Secretary Of State,,Mike Wherry,Libertarian,1535
-Clar,Secretary Of State,,Charlie White,Republican,18124
-Clar,Auditor Of State,,Sam Locke,Democratic,13337
-Clar,Auditor Of State,,Eric Knipe,Libertarian,1408
-Clar,Auditor Of State,,Tim Berry,Republican,16940
-Clar,Treasurer Of State,,Pete Buttigieg,Democratic,13154
-Clar,Treasurer Of State,,Richard E Mourdock,Republican,18224
-Clar,U.S. House,9,Baron P Hill,Democratic,13926
-Clar,U.S. House,9,"Greg ""No Bull"" Knott",Libertarian,1544
-Clar,U.S. House,9,Todd Christopher Young,Republican,17573
-Clar,U.S. House,9,Jerry R Lucas,Independent,10
-Clar,State Senator,45,James Lewis,Democratic,8125
-Clar,State Senator,45,Jim C Smith,Republican,10332
-Clar,State Senator,46,Charles A Freiberger,Democratic,6553
-Clar,State Senator,46,Ronald T Grooms,Republican,7636
-Clar,State House,66,Terry A Goodin,Democratic,2346
-Clar,State House,66,Jim Lucas,Republican,2573
-Clar,State House,70,Paul J Robertson,Democratic,2832
-Clar,State House,70,Rhonda J Rhoads,Republican,4258
-Clar,State House,71,Steven R Stemler,Democratic,13241
-Clar,State House,73,Ryan D Bower,Democratic,390
-Clar,State House,73,Steven J Davisson,Republican,701
-Clar,Prosecuting Attorney,Clark 4Th Circuit,Steven D Stewart,Democratic,20143
+Clark,U.S. Senator,,Brad Ellsworth,Democratic,13429
+Clark,U.S. Senator,,Rebecca Sink-Burris,Libertarian,1409
+Clark,U.S. Senator,,Dan Coats,Republican,17773
+Clark,U.S. Senator,,Jack Rooney,Independent,1
+Clark,U.S. Senator,,Jim Miller,Write-In,1
+Clark,Secretary Of State,,Vop Osili,Democratic,12141
+Clark,Secretary Of State,,Mike Wherry,Libertarian,1535
+Clark,Secretary Of State,,Charlie White,Republican,18124
+Clark,Auditor Of State,,Sam Locke,Democratic,13337
+Clark,Auditor Of State,,Eric Knipe,Libertarian,1408
+Clark,Auditor Of State,,Tim Berry,Republican,16940
+Clark,Treasurer Of State,,Pete Buttigieg,Democratic,13154
+Clark,Treasurer Of State,,Richard E Mourdock,Republican,18224
+Clark,U.S. House,9,Baron P Hill,Democratic,13926
+Clark,U.S. House,9,"Greg ""No Bull"" Knott",Libertarian,1544
+Clark,U.S. House,9,Todd Christopher Young,Republican,17573
+Clark,U.S. House,9,Jerry R Lucas,Independent,10
+Clark,State Senator,45,James Lewis,Democratic,8125
+Clark,State Senator,45,Jim C Smith,Republican,10332
+Clark,State Senator,46,Charles A Freiberger,Democratic,6553
+Clark,State Senator,46,Ronald T Grooms,Republican,7636
+Clark,State House,66,Terry A Goodin,Democratic,2346
+Clark,State House,66,Jim Lucas,Republican,2573
+Clark,State House,70,Paul J Robertson,Democratic,2832
+Clark,State House,70,Rhonda J Rhoads,Republican,4258
+Clark,State House,71,Steven R Stemler,Democratic,13241
+Clark,State House,73,Ryan D Bower,Democratic,390
+Clark,State House,73,Steven J Davisson,Republican,701
+Clark,Prosecuting Attorney,Clark 4Th Circuit,Steven D Stewart,Democratic,20143
 Clay,U.S. Senator,,Brad Ellsworth,Democratic,3187
 Clay,U.S. Senator,,Rebecca Sink-Burris,Libertarian,465
 Clay,U.S. Senator,,Dan Coats,Republican,4543
@@ -1172,34 +1172,34 @@ Lake,Judge Of The Circuit Court,Lake 31St Circuit,George C Paras,Democratic,6707
 Lake,Judge Of The Circuit Court,Lake 31St Circuit,William I Fine,Republican,44376
 Lake,Prosecuting Attorney,Lake 31St Circuit,Bernard A Carter,Democratic,69175
 Lake,Prosecuting Attorney,Lake 31St Circuit,"Douglas ""Doug"" Grimes",Republican,42983
-LaPort,U.S. Senator,,Brad Ellsworth,Democratic,13627
-LaPort,U.S. Senator,,Rebecca Sink-Burris,Libertarian,1528
-LaPort,U.S. Senator,,Dan Coats,Republican,13597
-LaPort,U.S. Senator,,Jack Rooney,Independent,0
-LaPort,U.S. Senator,,Jim Miller,Write-In,0
-LaPort,Secretary Of State,,Vop Osili,Democratic,12567
-LaPort,Secretary Of State,,Mike Wherry,Libertarian,2074
-LaPort,Secretary Of State,,Charlie White,Republican,13533
-LaPort,Auditor Of State,,Sam Locke,Democratic,13094
-LaPort,Auditor Of State,,Eric Knipe,Libertarian,1544
-LaPort,Auditor Of State,,Tim Berry,Republican,12727
-LaPort,Treasurer Of State,,Pete Buttigieg,Democratic,13360
-LaPort,Treasurer Of State,,Richard E Mourdock,Republican,13986
-LaPort,U.S. House,1,Peter J Visclosky,Democratic,0
-LaPort,U.S. House,1,Jon Morris,Libertarian,0
-LaPort,U.S. House,1,Mark J Leyva,Republican,0
-LaPort,U.S. House,2,Joe Donnelly,Democratic,15709
-LaPort,U.S. House,2,Mark Vogel,Libertarian,1726
-LaPort,U.S. House,2,Jackie Walorski Swihart,Republican,11552
-LaPort,State Senator,4,Karen Tallian,Democratic,0
-LaPort,State Senator,4,Shawn Olson,Republican,0
-LaPort,State House,8,Ryan M Dvorak,Democratic,0
-LaPort,State House,8,Richard J Pfeil,Republican,0
-LaPort,State House,9,Scott D Pelath,Democratic,10995
-LaPort,State House,9,Andrew R Wolf,Libertarian,2716
-LaPort,State House,20,Tom Dermody,Republican,10275
-LaPort,Prosecuting Attorney,Laporte 32Nd Circuit,Robert C Szilagyi,Democratic,15278
-LaPort,Prosecuting Attorney,Laporte 32Nd Circuit,Alan J Sirinek,Republican,12831
+LaPorte,U.S. Senator,,Brad Ellsworth,Democratic,13627
+LaPorte,U.S. Senator,,Rebecca Sink-Burris,Libertarian,1528
+LaPorte,U.S. Senator,,Dan Coats,Republican,13597
+LaPorte,U.S. Senator,,Jack Rooney,Independent,0
+LaPorte,U.S. Senator,,Jim Miller,Write-In,0
+LaPorte,Secretary Of State,,Vop Osili,Democratic,12567
+LaPorte,Secretary Of State,,Mike Wherry,Libertarian,2074
+LaPorte,Secretary Of State,,Charlie White,Republican,13533
+LaPorte,Auditor Of State,,Sam Locke,Democratic,13094
+LaPorte,Auditor Of State,,Eric Knipe,Libertarian,1544
+LaPorte,Auditor Of State,,Tim Berry,Republican,12727
+LaPorte,Treasurer Of State,,Pete Buttigieg,Democratic,13360
+LaPorte,Treasurer Of State,,Richard E Mourdock,Republican,13986
+LaPorte,U.S. House,1,Peter J Visclosky,Democratic,0
+LaPorte,U.S. House,1,Jon Morris,Libertarian,0
+LaPorte,U.S. House,1,Mark J Leyva,Republican,0
+LaPorte,U.S. House,2,Joe Donnelly,Democratic,15709
+LaPorte,U.S. House,2,Mark Vogel,Libertarian,1726
+LaPorte,U.S. House,2,Jackie Walorski Swihart,Republican,11552
+LaPorte,State Senator,4,Karen Tallian,Democratic,0
+LaPorte,State Senator,4,Shawn Olson,Republican,0
+LaPorte,State House,8,Ryan M Dvorak,Democratic,0
+LaPorte,State House,8,Richard J Pfeil,Republican,0
+LaPorte,State House,9,Scott D Pelath,Democratic,10995
+LaPorte,State House,9,Andrew R Wolf,Libertarian,2716
+LaPorte,State House,20,Tom Dermody,Republican,10275
+LaPorte,Prosecuting Attorney,Laporte 32Nd Circuit,Robert C Szilagyi,Democratic,15278
+LaPorte,Prosecuting Attorney,Laporte 32Nd Circuit,Alan J Sirinek,Republican,12831
 Lawrence,U.S. Senator,,Brad Ellsworth,Democratic,3343
 Lawrence,U.S. Senator,,Rebecca Sink-Burris,Libertarian,748
 Lawrence,U.S. Senator,,Dan Coats,Republican,6963


### PR DESCRIPTION
Correct typos in county names - "Clar" to "Clark" and "LaPort" to "LaPorte" for 2002-10 county results