### PR TITLE
Fix duplicate column header

### DIFF
--- a/2016/20161108__in__general__cass__precinct.csv
+++ b/2016/20161108__in__general__cass__precinct.csv
@@ -1,4 +1,4 @@
-county,precinct,office,district,office,party,votes
+county,precinct,office,district,candidate,party,votes
 Cass,Adams,President,,Donald Trump,REP,306
 Cass,Bethlehem,President,,Donald Trump,REP,273
 Cass,Boone,President,,Donald Trump,REP,451


### PR DESCRIPTION
The header `office` appeared twice in `2016/20161108__in__general__cass__precinct.csv`.  The second instance should be `candidate`.