### PR TITLE
Update format tests

### DIFF
--- a/.github/workflows/format_tests.yml
+++ b/.github/workflows/format_tests.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/checkout@v2.3.4
       with:
         repository: openelections/openelections-format-tests
-        ref: v0.1.0
+        ref: v1.0.0
         path: format_tests
 
     - name: Run format tests


### PR DESCRIPTION
This updates the format tests to version [1.0.0](https://github.com/openelections/openelections-format-tests/releases/tag/v1.0.0).  The tests now verify that the "votes" column contains values that represent integers.  This reveals the following errors:

* 2018/20181106__in__general__precinct.csv
  ```
  * There are 1 rows with votes that aren't integers:

  	Headers: ['county', 'precinct', 'office', 'district', 'candidate', 'party', 'votes', 'absentee', 'election_day', 'provisional', 'early_voting']:
  	Row 65267: ['Steuben', 'Otsego 1', 'Auditor of State', '', 'JERA KLUTZ', 'REP', '43.5', '', '', '', '']
  ```

* 2018/counties/20181106__in__general__steuben__precinct.csv
  ```
  * There are 1 rows with votes that aren't integers:

  	Headers: ['county', 'precinct', 'office', 'district', 'candidate', 'party', 'votes']:
  	Row 334: ['Stueben', 'Otsego 1', 'Auditor of State', '', 'JERA KLUTZ', 'REP', '43.5']
  ```