### PR TITLE
Fix non-integer votes and bad candidate name

### DIFF
--- a/2018/counties/20181106__in__general__steuben__precinct.csv
+++ b/2018/counties/20181106__in__general__steuben__precinct.csv
@@ -331,7 +331,7 @@ Stueben,Jackson,Auditor of State,,JERA KLUTZ,REP,449
 Stueben,Salem,Auditor of State,,JERA KLUTZ,REP,594
 Stueben,Steuben 1,Auditor of State,,JERA KLUTZ,REP,367
 Stueben,Steuben 2,Auditor of State,,JERA KLUTZ,REP,258
-Stueben,Otsego 1,Auditor of State,,JERA KLUTZ,REP,43.5
+Stueben,Otsego 1,Auditor of State,,JERA KLUTZ,REP,435
 Stueben,Otsego 2,Auditor of State,,JERA KLUTZ,REP,413
 Stueben,Richland,Auditor of State,,JERA KLUTZ,REP,101
 Stueben,Total,Auditor of State,,JERA KLUTZ,REP,8353

--- a/2018/counties/20181106__in__general__steuben__precinct.csv
+++ b/2018/counties/20181106__in__general__steuben__precinct.csv
@@ -312,29 +312,29 @@ Stueben,Otsego 2,Secretary of State,,Write-In Votes,,2
 Stueben,Richland,Secretary of State,,Write-In Votes,,0
 Stueben,Total,Secretary of State,,Write-In Votes,,7
 Stueben,Millgrove,Auditor of State,,TERA KLUTZ,REP,440
-Stueben,Jamestown 1,Auditor of State,,JERA KLUTZ,REP,502
-Stueben,Jamestown 2,Auditor of State,,JERA KLUTZ,REP,572
-Stueben,Fremont 1,Auditor of State,,JERA KLUTZ,REP,155
-Stueben,Fremont 2,Auditor of State,,JERA KLUTZ,REP,169
-Stueben,Fremont 3,Auditor of State,,JERA KLUTZ,REP,218
-Stueben,Clear Lake,Auditor of State,,JERA KLUTZ,REP,320
-Stueben,York,Auditor of State,,JERA KLUTZ,REP,202
-Stueben,Scott,Auditor of State,,JERA KLUTZ,REP,272
-Stueben,Pleasant 1,Auditor of State,,JERA KLUTZ,REP,334
-Stueben,Pleasant 2,Auditor of State,,JERA KLUTZ,REP,422
-Stueben,Pleasant 3,Auditor of State,,JERA KLUTZ,REP,352
-Stueben,Pleasant 4,Auditor of State,,JERA KLUTZ,REP,224
-Stueben,Pleasant 5,Auditor of State,,JERA KLUTZ,REP,377
-Stueben,Pleasant 6,Auditor of State,,JERA KLUTZ,REP,497
-Stueben,Pleasant 7,Auditor of State,,JERA KLUTZ,REP,680
-Stueben,Jackson,Auditor of State,,JERA KLUTZ,REP,449
-Stueben,Salem,Auditor of State,,JERA KLUTZ,REP,594
-Stueben,Steuben 1,Auditor of State,,JERA KLUTZ,REP,367
-Stueben,Steuben 2,Auditor of State,,JERA KLUTZ,REP,258
-Stueben,Otsego 1,Auditor of State,,JERA KLUTZ,REP,435
-Stueben,Otsego 2,Auditor of State,,JERA KLUTZ,REP,413
-Stueben,Richland,Auditor of State,,JERA KLUTZ,REP,101
-Stueben,Total,Auditor of State,,JERA KLUTZ,REP,8353
+Stueben,Jamestown 1,Auditor of State,,TERA KLUTZ,REP,502
+Stueben,Jamestown 2,Auditor of State,,TERA KLUTZ,REP,572
+Stueben,Fremont 1,Auditor of State,,TERA KLUTZ,REP,155
+Stueben,Fremont 2,Auditor of State,,TERA KLUTZ,REP,169
+Stueben,Fremont 3,Auditor of State,,TERA KLUTZ,REP,218
+Stueben,Clear Lake,Auditor of State,,TERA KLUTZ,REP,320
+Stueben,York,Auditor of State,,TERA KLUTZ,REP,202
+Stueben,Scott,Auditor of State,,TERA KLUTZ,REP,272
+Stueben,Pleasant 1,Auditor of State,,TERA KLUTZ,REP,334
+Stueben,Pleasant 2,Auditor of State,,TERA KLUTZ,REP,422
+Stueben,Pleasant 3,Auditor of State,,TERA KLUTZ,REP,352
+Stueben,Pleasant 4,Auditor of State,,TERA KLUTZ,REP,224
+Stueben,Pleasant 5,Auditor of State,,TERA KLUTZ,REP,377
+Stueben,Pleasant 6,Auditor of State,,TERA KLUTZ,REP,497
+Stueben,Pleasant 7,Auditor of State,,TERA KLUTZ,REP,680
+Stueben,Jackson,Auditor of State,,TERA KLUTZ,REP,449
+Stueben,Salem,Auditor of State,,TERA KLUTZ,REP,594
+Stueben,Steuben 1,Auditor of State,,TERA KLUTZ,REP,367
+Stueben,Steuben 2,Auditor of State,,TERA KLUTZ,REP,258
+Stueben,Otsego 1,Auditor of State,,TERA KLUTZ,REP,435
+Stueben,Otsego 2,Auditor of State,,TERA KLUTZ,REP,413
+Stueben,Richland,Auditor of State,,TERA KLUTZ,REP,101
+Stueben,Total,Auditor of State,,TERA KLUTZ,REP,8353
 Stueben,Millgrove,Auditor of State,,JOSELYN WIIITTICKER,DEM,167
 Stueben,Jamestown 1,Auditor of State,,JOSELYN WIIITTICKER,DEM,205
 Stueben,Jamestown 2,Auditor of State,,JOSELYN WIIITTICKER,DEM,236


### PR DESCRIPTION
This fixes a parsing error that resulted in an incorrect candidate name, as well as some non-integer votes.  The values from the [source file](https://github.com/openelections/openelections-sources-in/blob/daaa94b9bfa047f37a820e99bbb045ae49b4f4c4/2018/general/2018%20GE%20Steuben%20Precinct%20by%20Office%20Report.pdf) are:

![image](https://user-images.githubusercontent.com/17345532/128909432-7b719cfd-b77c-4d82-ad86-d4122326663d.png)
