### PR TITLE
Fix values in 2018 Gibson County general file 

### DIFF
--- a/2018/counties/20181106__in__general__gibson__precinct.csv
+++ b/2018/counties/20181106__in__general__gibson__precinct.csv
@@ -620,7 +620,7 @@ Gibson,MON2,Secretary of State,,Cast Votes,,137,438,575
 Gibson,WAB1,Secretary of State,,Cast Votes,,1,11,12
 Gibson,MON3,Secretary of State,,Cast Votes,,86,311,397
 Gibson,PAT1,Secretary of State,,Cast Votes,,176,253,429
-Gibson,PAT2,Secretary of State,,Cast Votes,,0.36,77,113
+Gibson,PAT2,Secretary of State,,Cast Votes,,36,77,113
 Gibson,PAT3,Secretary of State,,Cast Votes,,162,191,353
 Gibson,PAT4,Secretary of State,,Cast Voles:,,81,112,193
 Gibson,PAT5,Secretary of State,,Cast Voles:,,54,102,156


### PR DESCRIPTION
This fixes some incorrect values in the 2018 Gibson County general file.  According to the [source file](https://github.com/openelections/openelections-sources-in/blob/daaa94b9bfa047f37a820e99bbb045ae49b4f4c4/2018/general/2018%20GE%20Gibson%20Precinct%20Report.pdf), there were `36` votes cast in the Secretary of State race in the PAT2 precinct:

![image](https://user-images.githubusercontent.com/17345532/138537044-9ee0d578-8f93-43b1-b56b-3d163427e835.png)
