### PR TITLE
Added Laporte County data

### DIFF
--- a/2024/counties/20241105__in__general__laporte__precinct.csv
+++ b/2024/counties/20241105__in__general__laporte__precinct.csv
@@ -1,0 +1,5835 @@
+county,precinct,office,district,party,candidate,election_day,absentee,early_voting,votes
+Laporte,CASS,Ballots Cast,,,,268,14,382,664
+Laporte,CASS,Registered Voters,,,,,,,908
+Laporte,CASS,Public Question-Const Amendment,,,Yes,138,6,177,321
+Laporte,CASS,Public Question-Const Amendment,,,No,116,5,158,279
+Laporte,CASS,President and Vice-President of the U.S.,,REP,Trump \ Vance,203,4,258,465
+Laporte,CASS,President and Vice-President of the U.S.,,DEM,Harris \ Walz,56,9,114,179
+Laporte,CASS,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,0,0,0,0
+Laporte,CASS,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,7,1,3,11
+Laporte,CASS,President and Vice-President of the U.S.,,,Write-In,0,0,0,0
+Laporte,CASS,United States Senator,,REP,Jim Banks,183,5,244,432
+Laporte,CASS,United States Senator,,DEM,Valerie McCray,57,9,101,167
+Laporte,CASS,United States Senator,,LIB,Andrew Horning,9,0,12,21
+Laporte,CASS,United States Senator,,,Write-In,0,0,1,1
+Laporte,CASS,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,171,4,235,410
+Laporte,CASS,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,70,10,110,190
+Laporte,CASS,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,14,0,18,32
+Laporte,CASS,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,CASS,Attorney General,,REP,Todd Rokita,194,4,258,456
+Laporte,CASS,Attorney General,,DEM,Destiny Wells,60,10,105,175
+Laporte,CASS,United States Representative,2,REP,Rudy Yakym,180,4,244,428
+Laporte,CASS,United States Representative,2,DEM,Lori A. Camp,55,10,104,169
+Laporte,CASS,United States Representative,2,LIB,William E. Henry,17,0,12,29
+Laporte,CASS,United States Representative,2,,Write-In,0,0,0,0
+Laporte,CASS,State Senator District 8,,REP,Mike Bohacek,209,4,267,480
+Laporte,CASS,State Senator District 8,,DEM,Leon P. Smith,50,10,95,155
+Laporte,CASS,State Representative,20,REP,Jim Pressel,219,5,293,517
+Laporte,CASS,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,193,5,258,456
+Laporte,CASS,Circuit Court Clerk,,REP,Heather Stevens,185,4,244,433
+Laporte,CASS,Circuit Court Clerk,,DEM,Angela Henzman,60,10,110,180
+Laporte,CASS,County Auditor,,REP,Mike Rosenbaum,218,5,295,518
+Laporte,CASS,County Recorder,,REP,Elzbieta (Ela) Bilderback,182,4,239,425
+Laporte,CASS,County Recorder,,DEM,Matthew Sikorski,63,10,117,190
+Laporte,CASS,County Treasurer,,REP,Dan Barenie,185,4,241,430
+Laporte,CASS,County Treasurer,,DEM,Joie Winski,65,10,116,191
+Laporte,CASS,County Coroner,,REP,Lynn Swanson,191,4,259,454
+Laporte,CASS,County Coroner,,DEM,Mark P. Baker,60,10,102,172
+Laporte,CASS,County Surveyor,,REP,John Matwyshyn,165,4,228,397
+Laporte,CASS,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,81,10,130,221
+Laporte,CASS,County Commissioner District 2,,REP,Steve Holifield,167,4,223,394
+Laporte,CASS,County Commissioner District 2,,DEM,Mike Kellems,87,10,138,235
+Laporte,CASS,County Commissioner District 3,,REP,Joe Haney,168,4,232,404
+Laporte,CASS,County Commissioner District 3,,DEM,Randy Novak,81,10,126,217
+Laporte,CASS,County Council Member At Large,,REP,Brett H. Kessler,167,4,211,382
+Laporte,CASS,County Council Member At Large,,REP,Adam Koronka,151,2,174,327
+Laporte,CASS,County Council Member At Large,,REP,Heather Oake,120,2,177,299
+Laporte,CASS,County Council Member At Large,,DEM,Scott (Scotty) Ford,47,5,91,143
+Laporte,CASS,County Council Member At Large,,DEM,Mike Mollenhauer,81,7,123,211
+Laporte,CASS,County Council Member At Large,,DEM,Johnny Stimley,40,6,84,130
+Laporte,CASS,IN Supreme Court-Rush,,,Yes,168,3,232,403
+Laporte,CASS,IN Supreme Court-Rush,,,No,56,5,80,141
+Laporte,CASS,IN Supreme Court-Massa,,,Yes,170,3,227,400
+Laporte,CASS,IN Supreme Court-Massa,,,No,56,5,79,140
+Laporte,CASS,IN Supreme Court-Molter,,,Yes,170,3,230,403
+Laporte,CASS,IN Supreme Court-Molter,,,No,59,5,76,140
+Laporte,CASS,Court of Appeals Dist 4-Pyle III,,,Yes,167,3,221,391
+Laporte,CASS,Court of Appeals Dist 4-Pyle III,,,No,60,5,86,151
+Laporte,CASS,Straight Party,,DEM,Democratic Party,,,,62
+Laporte,CASS,Straight Party,,REP,Republican Party,,,,164
+Laporte,CENTER 01,Ballots Cast,,,,361,55,513,929
+Laporte,CENTER 01,Registered Voters,,,,,,,1292
+Laporte,CENTER 01,Public Question-Const Amendment,,,Yes,187,20,208,415
+Laporte,CENTER 01,Public Question-Const Amendment,,,No,136,29,249,414
+Laporte,CENTER 01,President and Vice-President of the U.S.,,REP,Trump \ Vance,253,21,303,577
+Laporte,CENTER 01,President and Vice-President of the U.S.,,DEM,Harris \ Walz,95,32,199,326
+Laporte,CENTER 01,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,0,1,1,2
+Laporte,CENTER 01,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,7,0,5,12
+Laporte,CENTER 01,President and Vice-President of the U.S.,,,Write-In,3,0,0,3
+Laporte,CENTER 01,United States Senator,,REP,Jim Banks,232,21,276,529
+Laporte,CENTER 01,United States Senator,,DEM,Valerie McCray,82,33,188,303
+Laporte,CENTER 01,United States Senator,,LIB,Andrew Horning,14,1,8,23
+Laporte,CENTER 01,United States Senator,,,Write-In,0,0,0,0
+Laporte,CENTER 01,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,228,17,271,516
+Laporte,CENTER 01,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,92,33,197,322
+Laporte,CENTER 01,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,19,4,13,36
+Laporte,CENTER 01,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,CENTER 01,Attorney General,,REP,Todd Rokita,241,18,291,550
+Laporte,CENTER 01,Attorney General,,DEM,Destiny Wells,96,36,191,323
+Laporte,CENTER 01,United States Representative,1,REP,Randy Niemeyer,220,19,271,510
+Laporte,CENTER 01,United States Representative,1,DEM,Frank J. Mrvan,116,32,213,361
+Laporte,CENTER 01,United States Representative,1,LIB,Dakotah Miskus,9,2,3,14
+Laporte,CENTER 01,United States Representative,1,,Write-In,0,0,0,0
+Laporte,CENTER 01,State Senator District 8,,REP,Mike Bohacek,257,29,319,605
+Laporte,CENTER 01,State Senator District 8,,DEM,Leon P. Smith,82,25,170,277
+Laporte,CENTER 01,State Representative,20,REP,Jim Pressel,277,26,334,637
+Laporte,CENTER 01,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,257,32,333,622
+Laporte,CENTER 01,Circuit Court Clerk,,REP,Heather Stevens,239,24,281,544
+Laporte,CENTER 01,Circuit Court Clerk,,DEM,Angela Henzman,89,30,174,293
+Laporte,CENTER 01,County Auditor,,REP,Mike Rosenbaum,278,29,338,645
+Laporte,CENTER 01,County Recorder,,REP,Elzbieta (Ela) Bilderback,238,27,283,548
+Laporte,CENTER 01,County Recorder,,DEM,Matthew Sikorski,96,28,192,316
+Laporte,CENTER 01,County Treasurer,,REP,Dan Barenie,228,22,275,525
+Laporte,CENTER 01,County Treasurer,,DEM,Joie Winski,111,33,214,358
+Laporte,CENTER 01,County Coroner,,REP,Lynn Swanson,243,25,301,569
+Laporte,CENTER 01,County Coroner,,DEM,Mark P. Baker,97,26,176,299
+Laporte,CENTER 01,County Surveyor,,REP,John Matwyshyn,215,18,257,490
+Laporte,CENTER 01,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,113,37,217,367
+Laporte,CENTER 01,County Commissioner District 2,,REP,Steve Holifield,205,19,248,472
+Laporte,CENTER 01,County Commissioner District 2,,DEM,Mike Kellems,128,35,236,399
+Laporte,CENTER 01,County Commissioner District 3,,REP,Joe Haney,226,26,274,526
+Laporte,CENTER 01,County Commissioner District 3,,DEM,Randy Novak,110,29,213,352
+Laporte,CENTER 01,County Council Member At Large,,REP,Brett H. Kessler,201,14,254,469
+Laporte,CENTER 01,County Council Member At Large,,REP,Adam Koronka,165,19,208,392
+Laporte,CENTER 01,County Council Member At Large,,REP,Heather Oake,150,16,214,380
+Laporte,CENTER 01,County Council Member At Large,,DEM,Scott (Scotty) Ford,93,35,166,294
+Laporte,CENTER 01,County Council Member At Large,,DEM,Mike Mollenhauer,97,30,192,319
+Laporte,CENTER 01,County Council Member At Large,,DEM,Johnny Stimley,81,28,167,276
+Laporte,CENTER 01,Laporte Community School Board At Large,,,Jim Arnold,174,26,243,443
+Laporte,CENTER 01,Laporte Community School Board At Large,,,Monica L. Beaty,140,25,232,397
+Laporte,CENTER 01,Laporte Community School Board At Large,,,Maria L. Ria Carpenter,148,27,194,369
+Laporte,CENTER 01,Laporte Community School Board At Large,,,Ed Gilliland,127,17,203,347
+Laporte,CENTER 01,Laporte Community School Board At Large,,,Tucker King,175,21,221,417
+Laporte,CENTER 01,IN Supreme Court-Rush,,,Yes,196,27,264,487
+Laporte,CENTER 01,IN Supreme Court-Rush,,,No,87,21,134,242
+Laporte,CENTER 01,IN Supreme Court-Massa,,,Yes,198,27,260,485
+Laporte,CENTER 01,IN Supreme Court-Massa,,,No,83,20,128,231
+Laporte,CENTER 01,IN Supreme Court-Molter,,,Yes,195,24,256,475
+Laporte,CENTER 01,IN Supreme Court-Molter,,,No,89,22,131,242
+Laporte,CENTER 01,Court of Appeals Dist 4-Pyle III,,,Yes,193,27,262,482
+Laporte,CENTER 01,Court of Appeals Dist 4-Pyle III,,,No,92,21,128,241
+Laporte,CENTER 01,Straight Party,,DEM,Democratic Party,,,,108
+Laporte,CENTER 01,Straight Party,,REP,Republican Party,,,,210
+Laporte,CENTER 02,Ballots Cast,,,,336,63,636,1035
+Laporte,CENTER 02,Registered Voters,,,,,,,1424
+Laporte,CENTER 02,Public Question-Const Amendment,,,Yes,178,24,292,494
+Laporte,CENTER 02,Public Question-Const Amendment,,,No,135,23,254,412
+Laporte,CENTER 02,President and Vice-President of the U.S.,,REP,Trump \ Vance,223,30,368,621
+Laporte,CENTER 02,President and Vice-President of the U.S.,,DEM,Harris \ Walz,102,32,261,395
+Laporte,CENTER 02,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,3,0,2,5
+Laporte,CENTER 02,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,4,0,1,5
+Laporte,CENTER 02,President and Vice-President of the U.S.,,,Write-In,1,0,2,3
+Laporte,CENTER 02,United States Senator,,REP,Jim Banks,211,29,362,602
+Laporte,CENTER 02,United States Senator,,DEM,Valerie McCray,98,32,244,374
+Laporte,CENTER 02,United States Senator,,LIB,Andrew Horning,6,0,5,11
+Laporte,CENTER 02,United States Senator,,,Write-In,0,0,1,1
+Laporte,CENTER 02,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,201,29,348,578
+Laporte,CENTER 02,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,115,33,256,404
+Laporte,CENTER 02,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,5,0,11,16
+Laporte,CENTER 02,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,CENTER 02,Attorney General,,REP,Todd Rokita,222,29,367,618
+Laporte,CENTER 02,Attorney General,,DEM,Destiny Wells,101,32,248,381
+Laporte,CENTER 02,United States Representative,1,REP,Randy Niemeyer,203,32,340,575
+Laporte,CENTER 02,United States Representative,1,DEM,Frank J. Mrvan,117,30,271,418
+Laporte,CENTER 02,United States Representative,1,LIB,Dakotah Miskus,4,0,5,9
+Laporte,CENTER 02,United States Representative,1,,Write-In,0,0,0,0
+Laporte,CENTER 02,State Senator District 8,,REP,Mike Bohacek,234,29,404,667
+Laporte,CENTER 02,State Senator District 8,,DEM,Leon P. Smith,84,31,212,327
+Laporte,CENTER 02,State Representative,20,REP,Jim Pressel,261,37,427,725
+Laporte,CENTER 02,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,250,37,416,703
+Laporte,CENTER 02,Circuit Court Clerk,,REP,Heather Stevens,223,32,371,626
+Laporte,CENTER 02,Circuit Court Clerk,,DEM,Angela Henzman,84,29,226,339
+Laporte,CENTER 02,County Auditor,,REP,Mike Rosenbaum,257,37,423,717
+Laporte,CENTER 02,County Recorder,,REP,Elzbieta (Ela) Bilderback,211,33,367,611
+Laporte,CENTER 02,County Recorder,,DEM,Matthew Sikorski,100,27,235,362
+Laporte,CENTER 02,County Treasurer,,REP,Dan Barenie,209,28,340,577
+Laporte,CENTER 02,County Treasurer,,DEM,Joie Winski,110,32,274,416
+Laporte,CENTER 02,County Coroner,,REP,Lynn Swanson,217,30,384,631
+Laporte,CENTER 02,County Coroner,,DEM,Mark P. Baker,98,29,223,350
+Laporte,CENTER 02,County Surveyor,,REP,John Matwyshyn,202,27,324,553
+Laporte,CENTER 02,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,110,33,281,424
+Laporte,CENTER 02,County Commissioner District 2,,REP,Steve Holifield,199,28,333,560
+Laporte,CENTER 02,County Commissioner District 2,,DEM,Mike Kellems,114,32,277,423
+Laporte,CENTER 02,County Commissioner District 3,,REP,Joe Haney,189,27,325,541
+Laporte,CENTER 02,County Commissioner District 3,,DEM,Randy Novak,124,32,281,437
+Laporte,CENTER 02,County Council Member At Large,,REP,Brett H. Kessler,183,23,296,502
+Laporte,CENTER 02,County Council Member At Large,,REP,Adam Koronka,172,18,252,442
+Laporte,CENTER 02,County Council Member At Large,,REP,Heather Oake,139,17,244,400
+Laporte,CENTER 02,County Council Member At Large,,DEM,Scott (Scotty) Ford,80,27,210,317
+Laporte,CENTER 02,County Council Member At Large,,DEM,Mike Mollenhauer,102,31,247,380
+Laporte,CENTER 02,County Council Member At Large,,DEM,Johnny Stimley,83,29,214,326
+Laporte,CENTER 02,Laporte Community School Board At Large,,,Jim Arnold,200,24,326,550
+Laporte,CENTER 02,Laporte Community School Board At Large,,,Monica L. Beaty,119,31,262,412
+Laporte,CENTER 02,Laporte Community School Board At Large,,,Maria L. Ria Carpenter,112,36,246,394
+Laporte,CENTER 02,Laporte Community School Board At Large,,,Ed Gilliland,128,17,202,347
+Laporte,CENTER 02,Laporte Community School Board At Large,,,Tucker King,134,22,239,395
+Laporte,CENTER 02,IN Supreme Court-Rush,,,Yes,190,32,327,549
+Laporte,CENTER 02,IN Supreme Court-Rush,,,No,80,15,155,250
+Laporte,CENTER 02,IN Supreme Court-Massa,,,Yes,190,25,322,537
+Laporte,CENTER 02,IN Supreme Court-Massa,,,No,78,19,155,252
+Laporte,CENTER 02,IN Supreme Court-Molter,,,Yes,190,26,322,538
+Laporte,CENTER 02,IN Supreme Court-Molter,,,No,81,19,154,254
+Laporte,CENTER 02,Court of Appeals Dist 4-Pyle III,,,Yes,188,30,323,541
+Laporte,CENTER 02,Court of Appeals Dist 4-Pyle III,,,No,82,16,152,250
+Laporte,CENTER 02,Straight Party,,DEM,Democratic Party,,,,136
+Laporte,CENTER 02,Straight Party,,REP,Republican Party,,,,256
+Laporte,CENTER 03,Ballots Cast,,,,251,40,441,732
+Laporte,CENTER 03,Registered Voters,,,,,,,1048
+Laporte,CENTER 03,Public Question-Const Amendment,,,Yes,136,11,181,328
+Laporte,CENTER 03,Public Question-Const Amendment,,,No,96,13,199,308
+Laporte,CENTER 03,President and Vice-President of the U.S.,,REP,Trump \ Vance,146,15,263,424
+Laporte,CENTER 03,President and Vice-President of the U.S.,,DEM,Harris \ Walz,93,25,168,286
+Laporte,CENTER 03,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,3,0,2,5
+Laporte,CENTER 03,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,4,0,2,6
+Laporte,CENTER 03,President and Vice-President of the U.S.,,,Write-In,3,0,0,3
+Laporte,CENTER 03,United States Senator,,REP,Jim Banks,139,14,250,403
+Laporte,CENTER 03,United States Senator,,DEM,Valerie McCray,90,25,160,275
+Laporte,CENTER 03,United States Senator,,LIB,Andrew Horning,7,0,7,14
+Laporte,CENTER 03,United States Senator,,,Write-In,0,0,0,0
+Laporte,CENTER 03,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,128,14,239,381
+Laporte,CENTER 03,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,98,25,170,293
+Laporte,CENTER 03,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,14,0,10,24
+Laporte,CENTER 03,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,CENTER 03,Attorney General,,REP,Todd Rokita,144,18,260,422
+Laporte,CENTER 03,Attorney General,,DEM,Destiny Wells,93,21,164,278
+Laporte,CENTER 03,United States Representative,1,REP,Randy Niemeyer,135,15,243,393
+Laporte,CENTER 03,United States Representative,1,DEM,Frank J. Mrvan,97,24,179,300
+Laporte,CENTER 03,United States Representative,1,LIB,Dakotah Miskus,10,0,4,14
+Laporte,CENTER 03,United States Representative,1,,Write-In,0,0,0,0
+Laporte,CENTER 03,State Senator District 8,,REP,Mike Bohacek,159,18,283,460
+Laporte,CENTER 03,State Senator District 8,,DEM,Leon P. Smith,79,21,140,240
+Laporte,CENTER 03,State Representative,20,REP,Jim Pressel,188,22,307,517
+Laporte,CENTER 03,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,172,22,293,487
+Laporte,CENTER 03,Circuit Court Clerk,,REP,Heather Stevens,142,19,260,421
+Laporte,CENTER 03,Circuit Court Clerk,,DEM,Angela Henzman,89,20,143,252
+Laporte,CENTER 03,County Auditor,,REP,Mike Rosenbaum,191,24,313,528
+Laporte,CENTER 03,County Recorder,,REP,Elzbieta (Ela) Bilderback,141,14,261,416
+Laporte,CENTER 03,County Recorder,,DEM,Matthew Sikorski,92,25,153,270
+Laporte,CENTER 03,County Treasurer,,REP,Dan Barenie,133,11,245,389
+Laporte,CENTER 03,County Treasurer,,DEM,Joie Winski,104,29,175,308
+Laporte,CENTER 03,County Coroner,,REP,Lynn Swanson,147,16,281,444
+Laporte,CENTER 03,County Coroner,,DEM,Mark P. Baker,94,23,146,263
+Laporte,CENTER 03,County Surveyor,,REP,John Matwyshyn,128,12,235,375
+Laporte,CENTER 03,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,106,27,178,311
+Laporte,CENTER 03,County Commissioner District 2,,REP,Steve Holifield,122,11,220,353
+Laporte,CENTER 03,County Commissioner District 2,,DEM,Mike Kellems,117,29,193,339
+Laporte,CENTER 03,County Commissioner District 3,,REP,Joe Haney,133,10,225,368
+Laporte,CENTER 03,County Commissioner District 3,,DEM,Randy Novak,104,29,186,319
+Laporte,CENTER 03,County Council Member At Large,,REP,Brett H. Kessler,120,11,218,349
+Laporte,CENTER 03,County Council Member At Large,,REP,Adam Koronka,97,8,183,288
+Laporte,CENTER 03,County Council Member At Large,,REP,Heather Oake,93,7,180,280
+Laporte,CENTER 03,County Council Member At Large,,DEM,Scott (Scotty) Ford,77,16,134,227
+Laporte,CENTER 03,County Council Member At Large,,DEM,Mike Mollenhauer,98,20,153,271
+Laporte,CENTER 03,County Council Member At Large,,DEM,Johnny Stimley,91,18,141,250
+Laporte,CENTER 03,Laporte Community School Board At Large,,,Jim Arnold,144,17,249,410
+Laporte,CENTER 03,Laporte Community School Board At Large,,,Monica L. Beaty,96,12,176,284
+Laporte,CENTER 03,Laporte Community School Board At Large,,,Maria L. Ria Carpenter,107,13,174,294
+Laporte,CENTER 03,Laporte Community School Board At Large,,,Ed Gilliland,98,11,149,258
+Laporte,CENTER 03,Laporte Community School Board At Large,,,Tucker King,92,11,167,270
+Laporte,CENTER 03,IN Supreme Court-Rush,,,Yes,147,11,237,395
+Laporte,CENTER 03,IN Supreme Court-Rush,,,No,68,10,115,193
+Laporte,CENTER 03,IN Supreme Court-Massa,,,Yes,149,12,239,400
+Laporte,CENTER 03,IN Supreme Court-Massa,,,No,64,9,112,185
+Laporte,CENTER 03,IN Supreme Court-Molter,,,Yes,146,13,240,399
+Laporte,CENTER 03,IN Supreme Court-Molter,,,No,66,8,110,184
+Laporte,CENTER 03,Court of Appeals Dist 4-Pyle III,,,Yes,144,11,237,392
+Laporte,CENTER 03,Court of Appeals Dist 4-Pyle III,,,No,68,10,113,191
+Laporte,CENTER 03,Straight Party,,DEM,Democratic Party,,,,95
+Laporte,CENTER 03,Straight Party,,REP,Republican Party,,,,167
+Laporte,CENTER 04,Ballots Cast,,,,279,60,458,797
+Laporte,CENTER 04,Registered Voters,,,,,,,1075
+Laporte,CENTER 04,Public Question-Const Amendment,,,Yes,157,22,220,399
+Laporte,CENTER 04,Public Question-Const Amendment,,,No,100,22,187,309
+Laporte,CENTER 04,President and Vice-President of the U.S.,,REP,Trump \ Vance,193,28,252,473
+Laporte,CENTER 04,President and Vice-President of the U.S.,,DEM,Harris \ Walz,76,31,195,302
+Laporte,CENTER 04,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,5,0,0,5
+Laporte,CENTER 04,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,4,1,4,9
+Laporte,CENTER 04,President and Vice-President of the U.S.,,,Write-In,0,0,2,2
+Laporte,CENTER 04,United States Senator,,REP,Jim Banks,174,26,238,438
+Laporte,CENTER 04,United States Senator,,DEM,Valerie McCray,72,27,180,279
+Laporte,CENTER 04,United States Senator,,LIB,Andrew Horning,9,3,10,22
+Laporte,CENTER 04,United States Senator,,,Write-In,0,0,0,0
+Laporte,CENTER 04,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,166,27,234,427
+Laporte,CENTER 04,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,89,29,194,312
+Laporte,CENTER 04,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,8,2,7,17
+Laporte,CENTER 04,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,CENTER 04,Attorney General,,REP,Todd Rokita,185,30,250,465
+Laporte,CENTER 04,Attorney General,,DEM,Destiny Wells,71,26,183,280
+Laporte,CENTER 04,United States Representative,1,REP,Randy Niemeyer,168,25,236,429
+Laporte,CENTER 04,United States Representative,1,DEM,Frank J. Mrvan,84,31,197,312
+Laporte,CENTER 04,United States Representative,1,LIB,Dakotah Miskus,7,1,6,14
+Laporte,CENTER 04,United States Representative,1,,Write-In,0,0,0,0
+Laporte,CENTER 04,State Senator District 8,,REP,Mike Bohacek,198,31,282,511
+Laporte,CENTER 04,State Senator District 8,,DEM,Leon P. Smith,57,25,155,237
+Laporte,CENTER 04,State Representative,20,REP,Jim Pressel,209,40,302,551
+Laporte,CENTER 04,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,195,39,297,531
+Laporte,CENTER 04,Circuit Court Clerk,,REP,Heather Stevens,180,30,261,471
+Laporte,CENTER 04,Circuit Court Clerk,,DEM,Angela Henzman,61,27,161,249
+Laporte,CENTER 04,County Auditor,,REP,Mike Rosenbaum,201,38,300,539
+Laporte,CENTER 04,County Recorder,,REP,Elzbieta (Ela) Bilderback,179,27,255,461
+Laporte,CENTER 04,County Recorder,,DEM,Matthew Sikorski,69,28,177,274
+Laporte,CENTER 04,County Treasurer,,REP,Dan Barenie,160,22,239,421
+Laporte,CENTER 04,County Treasurer,,DEM,Joie Winski,89,33,196,318
+Laporte,CENTER 04,County Coroner,,REP,Lynn Swanson,179,31,261,471
+Laporte,CENTER 04,County Coroner,,DEM,Mark P. Baker,74,25,173,272
+Laporte,CENTER 04,County Surveyor,,REP,John Matwyshyn,154,24,211,389
+Laporte,CENTER 04,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,93,30,212,335
+Laporte,CENTER 04,County Commissioner District 2,,REP,Steve Holifield,152,26,202,380
+Laporte,CENTER 04,County Commissioner District 2,,DEM,Mike Kellems,106,30,229,365
+Laporte,CENTER 04,County Commissioner District 3,,REP,Joe Haney,159,23,224,406
+Laporte,CENTER 04,County Commissioner District 3,,DEM,Randy Novak,95,34,203,332
+Laporte,CENTER 04,County Council Member At Large,,REP,Brett H. Kessler,151,21,203,375
+Laporte,CENTER 04,County Council Member At Large,,REP,Adam Koronka,139,25,204,368
+Laporte,CENTER 04,County Council Member At Large,,REP,Heather Oake,118,18,190,326
+Laporte,CENTER 04,County Council Member At Large,,DEM,Scott (Scotty) Ford,66,22,165,253
+Laporte,CENTER 04,County Council Member At Large,,DEM,Mike Mollenhauer,86,28,195,309
+Laporte,CENTER 04,County Council Member At Large,,DEM,Johnny Stimley,54,21,150,225
+Laporte,CENTER 04,Laporte Community School Board At Large,,,Jim Arnold,147,30,232,409
+Laporte,CENTER 04,Laporte Community School Board At Large,,,Monica L. Beaty,102,24,193,319
+Laporte,CENTER 04,Laporte Community School Board At Large,,,Maria L. Ria Carpenter,104,25,172,301
+Laporte,CENTER 04,Laporte Community School Board At Large,,,Ed Gilliland,116,33,172,321
+Laporte,CENTER 04,Laporte Community School Board At Large,,,Tucker King,140,17,221,378
+Laporte,CENTER 04,IN Supreme Court-Rush,,,Yes,157,25,234,416
+Laporte,CENTER 04,IN Supreme Court-Rush,,,No,68,19,124,211
+Laporte,CENTER 04,IN Supreme Court-Massa,,,Yes,156,21,232,409
+Laporte,CENTER 04,IN Supreme Court-Massa,,,No,66,22,125,213
+Laporte,CENTER 04,IN Supreme Court-Molter,,,Yes,157,26,230,413
+Laporte,CENTER 04,IN Supreme Court-Molter,,,No,65,18,125,208
+Laporte,CENTER 04,Court of Appeals Dist 4-Pyle III,,,Yes,154,27,235,416
+Laporte,CENTER 04,Court of Appeals Dist 4-Pyle III,,,No,68,16,120,204
+Laporte,CENTER 04,Straight Party,,DEM,Democratic Party,,,,94
+Laporte,CENTER 04,Straight Party,,REP,Republican Party,,,,157
+Laporte,CENTER 05,Ballots Cast,,,,390,45,453,888
+Laporte,CENTER 05,Registered Voters,,,,,,,1169
+Laporte,CENTER 05,Public Question-Const Amendment,,,Yes,198,5,222,425
+Laporte,CENTER 05,Public Question-Const Amendment,,,No,161,27,187,375
+Laporte,CENTER 05,President and Vice-President of the U.S.,,REP,Trump \ Vance,235,15,252,502
+Laporte,CENTER 05,President and Vice-President of the U.S.,,DEM,Harris \ Walz,137,30,191,358
+Laporte,CENTER 05,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,3,0,4,7
+Laporte,CENTER 05,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,9,0,4,13
+Laporte,CENTER 05,President and Vice-President of the U.S.,,,Write-In,1,0,0,1
+Laporte,CENTER 05,United States Senator,,REP,Jim Banks,222,15,255,492
+Laporte,CENTER 05,United States Senator,,DEM,Valerie McCray,128,26,171,325
+Laporte,CENTER 05,United States Senator,,LIB,Andrew Horning,10,2,6,18
+Laporte,CENTER 05,United States Senator,,,Write-In,0,0,0,0
+Laporte,CENTER 05,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,208,14,229,451
+Laporte,CENTER 05,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,141,28,183,352
+Laporte,CENTER 05,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,15,0,16,31
+Laporte,CENTER 05,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,CENTER 05,Attorney General,,REP,Todd Rokita,228,14,262,504
+Laporte,CENTER 05,Attorney General,,DEM,Destiny Wells,140,29,168,337
+Laporte,CENTER 05,United States Representative,1,REP,Randy Niemeyer,211,15,252,478
+Laporte,CENTER 05,United States Representative,1,DEM,Frank J. Mrvan,149,26,184,359
+Laporte,CENTER 05,United States Representative,1,LIB,Dakotah Miskus,11,1,4,16
+Laporte,CENTER 05,United States Representative,1,,Write-In,0,0,0,0
+Laporte,CENTER 05,State Senator District 8,,REP,Mike Bohacek,255,16,268,539
+Laporte,CENTER 05,State Senator District 8,,DEM,Leon P. Smith,118,26,162,306
+Laporte,CENTER 05,State Representative,20,REP,Jim Pressel,288,28,319,635
+Laporte,CENTER 05,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,267,25,303,595
+Laporte,CENTER 05,Circuit Court Clerk,,REP,Heather Stevens,234,16,259,509
+Laporte,CENTER 05,Circuit Court Clerk,,DEM,Angela Henzman,120,27,155,302
+Laporte,CENTER 05,County Auditor,,REP,Mike Rosenbaum,303,24,317,644
+Laporte,CENTER 05,County Recorder,,REP,Elzbieta (Ela) Bilderback,244,21,250,515
+Laporte,CENTER 05,County Recorder,,DEM,Matthew Sikorski,120,22,171,313
+Laporte,CENTER 05,County Treasurer,,REP,Dan Barenie,221,16,248,485
+Laporte,CENTER 05,County Treasurer,,DEM,Joie Winski,147,27,181,355
+Laporte,CENTER 05,County Coroner,,REP,Lynn Swanson,249,18,265,532
+Laporte,CENTER 05,County Coroner,,DEM,Mark P. Baker,119,24,165,308
+Laporte,CENTER 05,County Surveyor,,REP,John Matwyshyn,202,16,224,442
+Laporte,CENTER 05,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,155,26,199,380
+Laporte,CENTER 05,County Commissioner District 2,,REP,Steve Holifield,188,16,234,438
+Laporte,CENTER 05,County Commissioner District 2,,DEM,Mike Kellems,177,27,196,400
+Laporte,CENTER 05,County Commissioner District 3,,REP,Joe Haney,212,14,239,465
+Laporte,CENTER 05,County Commissioner District 3,,DEM,Randy Novak,153,29,188,370
+Laporte,CENTER 05,County Council Member At Large,,REP,Brett H. Kessler,193,12,224,429
+Laporte,CENTER 05,County Council Member At Large,,REP,Adam Koronka,183,11,207,401
+Laporte,CENTER 05,County Council Member At Large,,REP,Heather Oake,158,7,201,366
+Laporte,CENTER 05,County Council Member At Large,,DEM,Scott (Scotty) Ford,117,27,150,294
+Laporte,CENTER 05,County Council Member At Large,,DEM,Mike Mollenhauer,143,24,185,352
+Laporte,CENTER 05,County Council Member At Large,,DEM,Johnny Stimley,90,21,133,244
+Laporte,CENTER 05,Laporte Community School Board At Large,,,Jim Arnold,218,22,237,477
+Laporte,CENTER 05,Laporte Community School Board At Large,,,Monica L. Beaty,134,18,185,337
+Laporte,CENTER 05,Laporte Community School Board At Large,,,Maria L. Ria Carpenter,131,16,175,322
+Laporte,CENTER 05,Laporte Community School Board At Large,,,Ed Gilliland,160,17,197,374
+Laporte,CENTER 05,Laporte Community School Board At Large,,,Tucker King,188,17,226,431
+Laporte,CENTER 05,IN Supreme Court-Rush,,,Yes,210,21,256,487
+Laporte,CENTER 05,IN Supreme Court-Rush,,,No,98,11,116,225
+Laporte,CENTER 05,IN Supreme Court-Massa,,,Yes,200,17,250,467
+Laporte,CENTER 05,IN Supreme Court-Massa,,,No,102,16,117,235
+Laporte,CENTER 05,IN Supreme Court-Molter,,,Yes,208,19,246,473
+Laporte,CENTER 05,IN Supreme Court-Molter,,,No,96,12,115,223
+Laporte,CENTER 05,Court of Appeals Dist 4-Pyle III,,,Yes,204,17,245,466
+Laporte,CENTER 05,Court of Appeals Dist 4-Pyle III,,,No,99,12,119,230
+Laporte,CENTER 05,Straight Party,,DEM,Democratic Party,,,,101
+Laporte,CENTER 05,Straight Party,,REP,Republican Party,,,,199
+Laporte,CLINTON,Ballots Cast,,,,257,26,345,628
+Laporte,CLINTON,Registered Voters,,,,,,,857
+Laporte,CLINTON,Public Question-Const Amendment,,,Yes,131,8,166,305
+Laporte,CLINTON,Public Question-Const Amendment,,,No,108,9,142,259
+Laporte,CLINTON,President and Vice-President of the U.S.,,REP,Trump \ Vance,199,18,242,459
+Laporte,CLINTON,President and Vice-President of the U.S.,,DEM,Harris \ Walz,46,7,97,150
+Laporte,CLINTON,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,2,0,2,4
+Laporte,CLINTON,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,6,1,1,8
+Laporte,CLINTON,President and Vice-President of the U.S.,,,Write-In,0,0,0,0
+Laporte,CLINTON,United States Senator,,REP,Jim Banks,191,18,235,444
+Laporte,CLINTON,United States Senator,,DEM,Valerie McCray,43,7,92,142
+Laporte,CLINTON,United States Senator,,LIB,Andrew Horning,9,0,3,12
+Laporte,CLINTON,United States Senator,,,Write-In,0,0,0,0
+Laporte,CLINTON,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,166,18,212,396
+Laporte,CLINTON,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,61,8,109,178
+Laporte,CLINTON,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,15,0,12,27
+Laporte,CLINTON,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,CLINTON,Attorney General,,REP,Todd Rokita,197,19,234,450
+Laporte,CLINTON,Attorney General,,DEM,Destiny Wells,50,7,94,151
+Laporte,CLINTON,United States Representative,2,REP,Rudy Yakym,189,19,225,433
+Laporte,CLINTON,United States Representative,2,DEM,Lori A. Camp,45,6,93,144
+Laporte,CLINTON,United States Representative,2,LIB,William E. Henry,9,1,8,18
+Laporte,CLINTON,United States Representative,2,,Write-In,0,0,0,0
+Laporte,CLINTON,State Senator District 8,,REP,Mike Bohacek,203,20,249,472
+Laporte,CLINTON,State Senator District 8,,DEM,Leon P. Smith,40,6,82,128
+Laporte,CLINTON,State Representative,20,REP,Jim Pressel,216,22,259,497
+Laporte,CLINTON,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,208,22,234,464
+Laporte,CLINTON,Circuit Court Clerk,,REP,Heather Stevens,190,19,231,440
+Laporte,CLINTON,Circuit Court Clerk,,DEM,Angela Henzman,47,7,91,145
+Laporte,CLINTON,County Auditor,,REP,Mike Rosenbaum,221,21,256,498
+Laporte,CLINTON,County Recorder,,REP,Elzbieta (Ela) Bilderback,193,20,222,435
+Laporte,CLINTON,County Recorder,,DEM,Matthew Sikorski,51,6,103,160
+Laporte,CLINTON,County Treasurer,,REP,Dan Barenie,184,17,228,429
+Laporte,CLINTON,County Treasurer,,DEM,Joie Winski,58,8,104,170
+Laporte,CLINTON,County Coroner,,REP,Lynn Swanson,194,19,234,447
+Laporte,CLINTON,County Coroner,,DEM,Mark P. Baker,49,7,93,149
+Laporte,CLINTON,County Surveyor,,REP,John Matwyshyn,179,18,203,400
+Laporte,CLINTON,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,60,7,123,190
+Laporte,CLINTON,County Commissioner District 2,,REP,Steve Holifield,175,17,199,391
+Laporte,CLINTON,County Commissioner District 2,,DEM,Mike Kellems,68,9,128,205
+Laporte,CLINTON,County Commissioner District 3,,REP,Joe Haney,185,16,204,405
+Laporte,CLINTON,County Commissioner District 3,,DEM,Randy Novak,57,9,124,190
+Laporte,CLINTON,County Council Member At Large,,REP,Brett H. Kessler,160,13,196,369
+Laporte,CLINTON,County Council Member At Large,,REP,Adam Koronka,136,12,164,312
+Laporte,CLINTON,County Council Member At Large,,REP,Heather Oake,124,13,158,295
+Laporte,CLINTON,County Council Member At Large,,DEM,Scott (Scotty) Ford,41,7,84,132
+Laporte,CLINTON,County Council Member At Large,,DEM,Mike Mollenhauer,62,10,117,189
+Laporte,CLINTON,County Council Member At Large,,DEM,Johnny Stimley,40,5,76,121
+Laporte,CLINTON,South Central School Board At Large,,,Jacob Wade,188,15,229,432
+Laporte,CLINTON,South Central SB Hanna Township,,,Cheryl Lynn (Sherry) Shei,127,11,168,306
+Laporte,CLINTON,South Central SB Hanna Township,,,Michael Sullivan,71,4,85,160
+Laporte,CLINTON,South Central SB Noble Township,,,Geraldine (Gerrie) Grott,172,15,222,409
+Laporte,CLINTON,IN Supreme Court-Rush,,,Yes,166,20,199,385
+Laporte,CLINTON,IN Supreme Court-Rush,,,No,45,1,81,127
+Laporte,CLINTON,IN Supreme Court-Massa,,,Yes,158,18,187,363
+Laporte,CLINTON,IN Supreme Court-Massa,,,No,51,2,89,142
+Laporte,CLINTON,IN Supreme Court-Molter,,,Yes,157,19,189,365
+Laporte,CLINTON,IN Supreme Court-Molter,,,No,52,1,85,138
+Laporte,CLINTON,Court of Appeals Dist 4-Pyle III,,,Yes,158,19,193,370
+Laporte,CLINTON,Court of Appeals Dist 4-Pyle III,,,No,50,2,80,132
+Laporte,CLINTON,Straight Party,,DEM,Democratic Party,,,,46
+Laporte,CLINTON,Straight Party,,REP,Republican Party,,,,165
+Laporte,COOLSPRING 01,Ballots Cast,,,,363,39,438,840
+Laporte,COOLSPRING 01,Registered Voters,,,,,,,1206
+Laporte,COOLSPRING 01,Public Question-Const Amendment,,,Yes,165,13,175,353
+Laporte,COOLSPRING 01,Public Question-Const Amendment,,,No,147,16,193,356
+Laporte,COOLSPRING 01,President and Vice-President of the U.S.,,REP,Trump \ Vance,220,13,230,463
+Laporte,COOLSPRING 01,President and Vice-President of the U.S.,,DEM,Harris \ Walz,132,25,195,352
+Laporte,COOLSPRING 01,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,0,1,2,3
+Laporte,COOLSPRING 01,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,3,0,7,10
+Laporte,COOLSPRING 01,President and Vice-President of the U.S.,,,Write-In,5,0,0,5
+Laporte,COOLSPRING 01,United States Senator,,REP,Jim Banks,196,14,217,427
+Laporte,COOLSPRING 01,United States Senator,,DEM,Valerie McCray,131,22,187,340
+Laporte,COOLSPRING 01,United States Senator,,LIB,Andrew Horning,6,1,5,12
+Laporte,COOLSPRING 01,United States Senator,,,Write-In,0,0,0,0
+Laporte,COOLSPRING 01,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,182,14,205,401
+Laporte,COOLSPRING 01,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,144,23,197,364
+Laporte,COOLSPRING 01,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,13,0,12,25
+Laporte,COOLSPRING 01,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,COOLSPRING 01,Attorney General,,REP,Todd Rokita,211,16,224,451
+Laporte,COOLSPRING 01,Attorney General,,DEM,Destiny Wells,130,21,192,343
+Laporte,COOLSPRING 01,United States Representative,1,REP,Randy Niemeyer,198,13,214,425
+Laporte,COOLSPRING 01,United States Representative,1,DEM,Frank J. Mrvan,143,24,203,370
+Laporte,COOLSPRING 01,United States Representative,1,LIB,Dakotah Miskus,8,0,9,17
+Laporte,COOLSPRING 01,United States Representative,1,,Write-In,0,0,0,0
+Laporte,COOLSPRING 01,State Senator District 8,,REP,Mike Bohacek,230,17,244,491
+Laporte,COOLSPRING 01,State Senator District 8,,DEM,Leon P. Smith,112,20,176,308
+Laporte,COOLSPRING 01,State Representative,09,REP,Joel Florek,205,13,220,438
+Laporte,COOLSPRING 01,State Representative,09,DEM,Patricia A. (Pat) Boy,145,24,203,372
+Laporte,COOLSPRING 01,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,237,15,266,518
+Laporte,COOLSPRING 01,Circuit Court Clerk,,REP,Heather Stevens,200,15,227,442
+Laporte,COOLSPRING 01,Circuit Court Clerk,,DEM,Angela Henzman,130,21,180,331
+Laporte,COOLSPRING 01,County Auditor,,REP,Mike Rosenbaum,240,19,274,533
+Laporte,COOLSPRING 01,County Recorder,,REP,Elzbieta (Ela) Bilderback,199,15,231,445
+Laporte,COOLSPRING 01,County Recorder,,DEM,Matthew Sikorski,137,21,187,345
+Laporte,COOLSPRING 01,County Treasurer,,REP,Dan Barenie,193,14,223,430
+Laporte,COOLSPRING 01,County Treasurer,,DEM,Joie Winski,152,21,202,375
+Laporte,COOLSPRING 01,County Coroner,,REP,Lynn Swanson,206,16,240,462
+Laporte,COOLSPRING 01,County Coroner,,DEM,Mark P. Baker,131,19,186,336
+Laporte,COOLSPRING 01,County Surveyor,,REP,John Matwyshyn,183,14,208,405
+Laporte,COOLSPRING 01,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,152,21,206,379
+Laporte,COOLSPRING 01,County Commissioner District 2,,REP,Steve Holifield,194,13,207,414
+Laporte,COOLSPRING 01,County Commissioner District 2,,DEM,Mike Kellems,141,23,212,376
+Laporte,COOLSPRING 01,County Commissioner District 3,,REP,Joe Haney,185,13,216,414
+Laporte,COOLSPRING 01,County Commissioner District 3,,DEM,Randy Novak,154,24,207,385
+Laporte,COOLSPRING 01,County Council Member At Large,,REP,Brett H. Kessler,144,14,181,339
+Laporte,COOLSPRING 01,County Council Member At Large,,REP,Adam Koronka,120,12,146,278
+Laporte,COOLSPRING 01,County Council Member At Large,,REP,Heather Oake,132,13,140,285
+Laporte,COOLSPRING 01,County Council Member At Large,,DEM,Scott (Scotty) Ford,89,19,150,258
+Laporte,COOLSPRING 01,County Council Member At Large,,DEM,Mike Mollenhauer,124,18,172,314
+Laporte,COOLSPRING 01,County Council Member At Large,,DEM,Johnny Stimley,115,18,176,309
+Laporte,COOLSPRING 01,Laporte Community School Board At Large,,,Jim Arnold,20,0,17,37
+Laporte,COOLSPRING 01,Laporte Community School Board At Large,,,Monica L. Beaty,13,1,20,34
+Laporte,COOLSPRING 01,Laporte Community School Board At Large,,,Maria L. Ria Carpenter,18,1,17,36
+Laporte,COOLSPRING 01,Laporte Community School Board At Large,,,Ed Gilliland,6,0,15,21
+Laporte,COOLSPRING 01,Laporte Community School Board At Large,,,Tucker King,11,1,17,29
+Laporte,COOLSPRING 01,MC Area SB Civil City,,,Marty M. Corley,135,13,160,308
+Laporte,COOLSPRING 01,MC Area SB Civil City,,,Rodney McCormick,93,8,101,202
+Laporte,COOLSPRING 01,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,70,4,76,150
+Laporte,COOLSPRING 01,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,21,5,31,57
+Laporte,COOLSPRING 01,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,67,5,70,142
+Laporte,COOLSPRING 01,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,49,5,73,127
+Laporte,COOLSPRING 01,MC Area SB Michigan/Springfield Twps,,,James Stewart,191,18,221,430
+Laporte,COOLSPRING 01,IN Supreme Court-Rush,,,Yes,165,15,185,365
+Laporte,COOLSPRING 01,IN Supreme Court-Rush,,,No,100,11,135,246
+Laporte,COOLSPRING 01,IN Supreme Court-Massa,,,Yes,158,11,182,351
+Laporte,COOLSPRING 01,IN Supreme Court-Massa,,,No,106,16,136,258
+Laporte,COOLSPRING 01,IN Supreme Court-Molter,,,Yes,167,12,178,357
+Laporte,COOLSPRING 01,IN Supreme Court-Molter,,,No,99,16,139,254
+Laporte,COOLSPRING 01,Court of Appeals Dist 4-Pyle III,,,Yes,160,13,173,346
+Laporte,COOLSPRING 01,Court of Appeals Dist 4-Pyle III,,,No,105,12,140,257
+Laporte,COOLSPRING 01,Straight Party,,DEM,Democratic Party,,,,141
+Laporte,COOLSPRING 01,Straight Party,,REP,Republican Party,,,,207
+Laporte,COOLSPRING 02,Ballots Cast,,,,347,39,360,746
+Laporte,COOLSPRING 02,Registered Voters,,,,,,,1089
+Laporte,COOLSPRING 02,Public Question-Const Amendment,,,Yes,171,11,165,347
+Laporte,COOLSPRING 02,Public Question-Const Amendment,,,No,133,10,143,286
+Laporte,COOLSPRING 02,President and Vice-President of the U.S.,,REP,Trump \ Vance,245,11,219,475
+Laporte,COOLSPRING 02,President and Vice-President of the U.S.,,DEM,Harris \ Walz,91,28,136,255
+Laporte,COOLSPRING 02,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,9,0,3,12
+Laporte,COOLSPRING 02,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,0,0,0,0
+Laporte,COOLSPRING 02,President and Vice-President of the U.S.,,,Write-In,0,0,0,0
+Laporte,COOLSPRING 02,United States Senator,,REP,Jim Banks,231,11,198,440
+Laporte,COOLSPRING 02,United States Senator,,DEM,Valerie McCray,86,28,132,246
+Laporte,COOLSPRING 02,United States Senator,,LIB,Andrew Horning,11,0,7,18
+Laporte,COOLSPRING 02,United States Senator,,,Write-In,1,0,0,1
+Laporte,COOLSPRING 02,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,224,10,203,437
+Laporte,COOLSPRING 02,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,89,27,134,250
+Laporte,COOLSPRING 02,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,14,1,7,22
+Laporte,COOLSPRING 02,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,COOLSPRING 02,Attorney General,,REP,Todd Rokita,242,12,220,474
+Laporte,COOLSPRING 02,Attorney General,,DEM,Destiny Wells,91,26,131,248
+Laporte,COOLSPRING 02,United States Representative,1,REP,Randy Niemeyer,225,10,196,431
+Laporte,COOLSPRING 02,United States Representative,1,DEM,Frank J. Mrvan,98,27,146,271
+Laporte,COOLSPRING 02,United States Representative,1,LIB,Dakotah Miskus,14,0,8,22
+Laporte,COOLSPRING 02,United States Representative,1,,Write-In,0,0,0,0
+Laporte,COOLSPRING 02,State Representative,09,REP,Joel Florek,236,11,199,446
+Laporte,COOLSPRING 02,State Representative,09,DEM,Patricia A. (Pat) Boy,93,27,151,271
+Laporte,COOLSPRING 02,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,258,13,243,514
+Laporte,COOLSPRING 02,Circuit Court Clerk,,REP,Heather Stevens,233,11,215,459
+Laporte,COOLSPRING 02,Circuit Court Clerk,,DEM,Angela Henzman,88,27,124,239
+Laporte,COOLSPRING 02,County Auditor,,REP,Mike Rosenbaum,277,12,256,545
+Laporte,COOLSPRING 02,County Recorder,,REP,Elzbieta (Ela) Bilderback,232,11,219,462
+Laporte,COOLSPRING 02,County Recorder,,DEM,Matthew Sikorski,98,24,129,251
+Laporte,COOLSPRING 02,County Treasurer,,REP,Dan Barenie,221,10,198,429
+Laporte,COOLSPRING 02,County Treasurer,,DEM,Joie Winski,116,27,152,295
+Laporte,COOLSPRING 02,County Coroner,,REP,Lynn Swanson,242,16,224,482
+Laporte,COOLSPRING 02,County Coroner,,DEM,Mark P. Baker,90,23,127,240
+Laporte,COOLSPRING 02,County Surveyor,,REP,John Matwyshyn,216,11,189,416
+Laporte,COOLSPRING 02,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,111,26,155,292
+Laporte,COOLSPRING 02,County Commissioner District 2,,REP,Steve Holifield,218,9,198,425
+Laporte,COOLSPRING 02,County Commissioner District 2,,DEM,Mike Kellems,111,27,146,284
+Laporte,COOLSPRING 02,County Commissioner District 3,,REP,Joe Haney,222,9,192,423
+Laporte,COOLSPRING 02,County Commissioner District 3,,DEM,Randy Novak,109,29,154,292
+Laporte,COOLSPRING 02,County Council Member At Large,,REP,Brett H. Kessler,179,9,152,340
+Laporte,COOLSPRING 02,County Council Member At Large,,REP,Adam Koronka,149,9,137,295
+Laporte,COOLSPRING 02,County Council Member At Large,,REP,Heather Oake,145,9,130,284
+Laporte,COOLSPRING 02,County Council Member At Large,,DEM,Scott (Scotty) Ford,72,15,101,188
+Laporte,COOLSPRING 02,County Council Member At Large,,DEM,Mike Mollenhauer,94,18,135,247
+Laporte,COOLSPRING 02,County Council Member At Large,,DEM,Johnny Stimley,109,18,141,268
+Laporte,COOLSPRING 02,MC Area SB Civil City,,,Marty M. Corley,144,7,178,329
+Laporte,COOLSPRING 02,MC Area SB Civil City,,,Rodney McCormick,113,8,77,198
+Laporte,COOLSPRING 02,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,93,5,69,167
+Laporte,COOLSPRING 02,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,25,1,34,60
+Laporte,COOLSPRING 02,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,61,7,56,124
+Laporte,COOLSPRING 02,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,62,7,84,153
+Laporte,COOLSPRING 02,MC Area SB Michigan/Springfield Twps,,,James Stewart,235,9,230,474
+Laporte,COOLSPRING 02,IN Supreme Court-Rush,,,Yes,169,12,167,348
+Laporte,COOLSPRING 02,IN Supreme Court-Rush,,,No,93,10,106,209
+Laporte,COOLSPRING 02,IN Supreme Court-Massa,,,Yes,174,11,166,351
+Laporte,COOLSPRING 02,IN Supreme Court-Massa,,,No,91,10,104,205
+Laporte,COOLSPRING 02,IN Supreme Court-Molter,,,Yes,175,11,172,358
+Laporte,COOLSPRING 02,IN Supreme Court-Molter,,,No,90,9,102,201
+Laporte,COOLSPRING 02,Court of Appeals Dist 4-Pyle III,,,Yes,170,11,167,348
+Laporte,COOLSPRING 02,Court of Appeals Dist 4-Pyle III,,,No,93,8,106,207
+Laporte,COOLSPRING 02,Straight Party,,DEM,Democratic Party,,,,90
+Laporte,COOLSPRING 02,Straight Party,,REP,Republican Party,,,,212
+Laporte,COOLSPRING 03,Ballots Cast,,,,293,28,328,649
+Laporte,COOLSPRING 03,Registered Voters,,,,,,,996
+Laporte,COOLSPRING 03,Public Question-Const Amendment,,,Yes,127,10,139,276
+Laporte,COOLSPRING 03,Public Question-Const Amendment,,,No,118,14,150,282
+Laporte,COOLSPRING 03,President and Vice-President of the U.S.,,REP,Trump \ Vance,168,5,176,349
+Laporte,COOLSPRING 03,President and Vice-President of the U.S.,,DEM,Harris \ Walz,119,20,142,281
+Laporte,COOLSPRING 03,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,1,1,1,3
+Laporte,COOLSPRING 03,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,3,1,4,8
+Laporte,COOLSPRING 03,President and Vice-President of the U.S.,,,Write-In,0,0,0,0
+Laporte,COOLSPRING 03,United States Senator,,REP,Jim Banks,150,7,164,321
+Laporte,COOLSPRING 03,United States Senator,,DEM,Valerie McCray,112,19,132,263
+Laporte,COOLSPRING 03,United States Senator,,LIB,Andrew Horning,7,1,1,9
+Laporte,COOLSPRING 03,United States Senator,,,Write-In,0,0,0,0
+Laporte,COOLSPRING 03,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,139,6,159,304
+Laporte,COOLSPRING 03,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,127,21,134,282
+Laporte,COOLSPRING 03,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,8,1,6,15
+Laporte,COOLSPRING 03,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,COOLSPRING 03,Attorney General,,REP,Todd Rokita,154,7,176,337
+Laporte,COOLSPRING 03,Attorney General,,DEM,Destiny Wells,110,19,134,263
+Laporte,COOLSPRING 03,United States Representative,1,REP,Randy Niemeyer,141,4,156,301
+Laporte,COOLSPRING 03,United States Representative,1,DEM,Frank J. Mrvan,124,22,154,300
+Laporte,COOLSPRING 03,United States Representative,1,LIB,Dakotah Miskus,6,1,1,8
+Laporte,COOLSPRING 03,United States Representative,1,,Write-In,0,0,0,0
+Laporte,COOLSPRING 03,State Senator District 8,,REP,Mike Bohacek,174,9,183,366
+Laporte,COOLSPRING 03,State Senator District 8,,DEM,Leon P. Smith,94,17,128,239
+Laporte,COOLSPRING 03,State Representative,09,REP,Joel Florek,151,5,167,323
+Laporte,COOLSPRING 03,State Representative,09,DEM,Patricia A. (Pat) Boy,116,21,141,278
+Laporte,COOLSPRING 03,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,188,7,205,400
+Laporte,COOLSPRING 03,Circuit Court Clerk,,REP,Heather Stevens,156,6,167,329
+Laporte,COOLSPRING 03,Circuit Court Clerk,,DEM,Angela Henzman,108,19,137,264
+Laporte,COOLSPRING 03,County Auditor,,REP,Mike Rosenbaum,197,8,207,412
+Laporte,COOLSPRING 03,County Recorder,,REP,Elzbieta (Ela) Bilderback,148,6,164,318
+Laporte,COOLSPRING 03,County Recorder,,DEM,Matthew Sikorski,116,20,139,275
+Laporte,COOLSPRING 03,County Treasurer,,REP,Dan Barenie,146,5,152,303
+Laporte,COOLSPRING 03,County Treasurer,,DEM,Joie Winski,120,21,160,301
+Laporte,COOLSPRING 03,County Coroner,,REP,Lynn Swanson,169,8,181,358
+Laporte,COOLSPRING 03,County Coroner,,DEM,Mark P. Baker,100,18,128,246
+Laporte,COOLSPRING 03,County Surveyor,,REP,John Matwyshyn,142,5,150,297
+Laporte,COOLSPRING 03,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,126,20,154,300
+Laporte,COOLSPRING 03,County Commissioner District 2,,REP,Steve Holifield,140,5,159,304
+Laporte,COOLSPRING 03,County Commissioner District 2,,DEM,Mike Kellems,124,20,146,290
+Laporte,COOLSPRING 03,County Commissioner District 3,,REP,Joe Haney,138,6,146,290
+Laporte,COOLSPRING 03,County Commissioner District 3,,DEM,Randy Novak,134,20,163,317
+Laporte,COOLSPRING 03,County Council Member At Large,,REP,Brett H. Kessler,109,7,125,241
+Laporte,COOLSPRING 03,County Council Member At Large,,REP,Adam Koronka,103,7,103,213
+Laporte,COOLSPRING 03,County Council Member At Large,,REP,Heather Oake,95,4,96,195
+Laporte,COOLSPRING 03,County Council Member At Large,,DEM,Scott (Scotty) Ford,82,14,119,215
+Laporte,COOLSPRING 03,County Council Member At Large,,DEM,Mike Mollenhauer,110,19,141,270
+Laporte,COOLSPRING 03,County Council Member At Large,,DEM,Johnny Stimley,110,18,145,273
+Laporte,COOLSPRING 03,MC Area SB Civil City,,,Marty M. Corley,137,11,155,303
+Laporte,COOLSPRING 03,MC Area SB Civil City,,,Rodney McCormick,71,2,67,140
+Laporte,COOLSPRING 03,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,65,2,71,138
+Laporte,COOLSPRING 03,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,28,0,31,59
+Laporte,COOLSPRING 03,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,39,3,47,89
+Laporte,COOLSPRING 03,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,45,10,60,115
+Laporte,COOLSPRING 03,MC Area SB Michigan/Springfield Twps,,,James Stewart,175,11,198,384
+Laporte,COOLSPRING 03,IN Supreme Court-Rush,,,Yes,134,9,153,296
+Laporte,COOLSPRING 03,IN Supreme Court-Rush,,,No,71,12,88,171
+Laporte,COOLSPRING 03,IN Supreme Court-Massa,,,Yes,136,8,142,286
+Laporte,COOLSPRING 03,IN Supreme Court-Massa,,,No,68,14,91,173
+Laporte,COOLSPRING 03,IN Supreme Court-Molter,,,Yes,136,7,149,292
+Laporte,COOLSPRING 03,IN Supreme Court-Molter,,,No,67,13,86,166
+Laporte,COOLSPRING 03,Court of Appeals Dist 4-Pyle III,,,Yes,138,12,156,306
+Laporte,COOLSPRING 03,Court of Appeals Dist 4-Pyle III,,,No,66,10,82,158
+Laporte,COOLSPRING 03,Straight Party,,DEM,Democratic Party,,,,94
+Laporte,COOLSPRING 03,Straight Party,,REP,Republican Party,,,,144
+Laporte,COOLSPRING 04,Ballots Cast,,,,434,53,523,1010
+Laporte,COOLSPRING 04,Registered Voters,,,,,,,1713
+Laporte,COOLSPRING 04,Public Question-Const Amendment,,,Yes,202,11,244,457
+Laporte,COOLSPRING 04,Public Question-Const Amendment,,,No,168,27,206,401
+Laporte,COOLSPRING 04,President and Vice-President of the U.S.,,REP,Trump \ Vance,280,13,270,563
+Laporte,COOLSPRING 04,President and Vice-President of the U.S.,,DEM,Harris \ Walz,140,39,246,425
+Laporte,COOLSPRING 04,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,3,0,2,5
+Laporte,COOLSPRING 04,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,4,0,2,6
+Laporte,COOLSPRING 04,President and Vice-President of the U.S.,,,Write-In,3,0,0,3
+Laporte,COOLSPRING 04,United States Senator,,REP,Jim Banks,242,10,244,496
+Laporte,COOLSPRING 04,United States Senator,,DEM,Valerie McCray,133,38,236,407
+Laporte,COOLSPRING 04,United States Senator,,LIB,Andrew Horning,15,1,7,23
+Laporte,COOLSPRING 04,United States Senator,,,Write-In,0,0,0,0
+Laporte,COOLSPRING 04,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,231,11,243,485
+Laporte,COOLSPRING 04,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,139,36,236,411
+Laporte,COOLSPRING 04,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,25,0,9,34
+Laporte,COOLSPRING 04,Governor And Lieutenant Governor,,,Write-In,1,0,0,1
+Laporte,COOLSPRING 04,Attorney General,,REP,Todd Rokita,262,10,263,535
+Laporte,COOLSPRING 04,Attorney General,,DEM,Destiny Wells,139,40,238,417
+Laporte,COOLSPRING 04,United States Representative,1,REP,Randy Niemeyer,231,8,241,480
+Laporte,COOLSPRING 04,United States Representative,1,DEM,Frank J. Mrvan,166,42,260,468
+Laporte,COOLSPRING 04,United States Representative,1,LIB,Dakotah Miskus,11,0,8,19
+Laporte,COOLSPRING 04,United States Representative,1,,Write-In,1,0,0,1
+Laporte,COOLSPRING 04,State Representative,09,REP,Joel Florek,254,12,256,522
+Laporte,COOLSPRING 04,State Representative,09,DEM,Patricia A. (Pat) Boy,143,39,246,428
+Laporte,COOLSPRING 04,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,289,23,311,623
+Laporte,COOLSPRING 04,Circuit Court Clerk,,REP,Heather Stevens,250,10,265,525
+Laporte,COOLSPRING 04,Circuit Court Clerk,,DEM,Angela Henzman,123,38,221,382
+Laporte,COOLSPRING 04,County Auditor,,REP,Mike Rosenbaum,317,23,325,665
+Laporte,COOLSPRING 04,County Recorder,,REP,Elzbieta (Ela) Bilderback,247,10,254,511
+Laporte,COOLSPRING 04,County Recorder,,DEM,Matthew Sikorski,148,38,240,426
+Laporte,COOLSPRING 04,County Treasurer,,REP,Dan Barenie,233,9,243,485
+Laporte,COOLSPRING 04,County Treasurer,,DEM,Joie Winski,168,40,265,473
+Laporte,COOLSPRING 04,County Coroner,,REP,Lynn Swanson,271,19,281,571
+Laporte,COOLSPRING 04,County Coroner,,DEM,Mark P. Baker,133,29,228,390
+Laporte,COOLSPRING 04,County Surveyor,,REP,John Matwyshyn,225,9,238,472
+Laporte,COOLSPRING 04,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,162,36,255,453
+Laporte,COOLSPRING 04,County Commissioner District 2,,REP,Steve Holifield,235,8,242,485
+Laporte,COOLSPRING 04,County Commissioner District 2,,DEM,Mike Kellems,149,38,246,433
+Laporte,COOLSPRING 04,County Commissioner District 3,,REP,Joe Haney,228,12,231,471
+Laporte,COOLSPRING 04,County Commissioner District 3,,DEM,Randy Novak,172,37,269,478
+Laporte,COOLSPRING 04,County Council Member At Large,,REP,Brett H. Kessler,207,6,198,411
+Laporte,COOLSPRING 04,County Council Member At Large,,REP,Adam Koronka,168,8,161,337
+Laporte,COOLSPRING 04,County Council Member At Large,,REP,Heather Oake,163,5,159,327
+Laporte,COOLSPRING 04,County Council Member At Large,,DEM,Scott (Scotty) Ford,131,34,186,351
+Laporte,COOLSPRING 04,County Council Member At Large,,DEM,Mike Mollenhauer,130,34,221,385
+Laporte,COOLSPRING 04,County Council Member At Large,,DEM,Johnny Stimley,135,32,225,392
+Laporte,COOLSPRING 04,MC Area SB Civil City,,,Marty M. Corley,198,23,233,454
+Laporte,COOLSPRING 04,MC Area SB Civil City,,,Rodney McCormick,131,13,151,295
+Laporte,COOLSPRING 04,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,106,7,135,248
+Laporte,COOLSPRING 04,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,43,6,65,114
+Laporte,COOLSPRING 04,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,71,9,86,166
+Laporte,COOLSPRING 04,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,77,8,79,164
+Laporte,COOLSPRING 04,MC Area SB Michigan/Springfield Twps,,,James Stewart,295,23,348,666
+Laporte,COOLSPRING 04,IN Supreme Court-Rush,,,Yes,208,22,241,471
+Laporte,COOLSPRING 04,IN Supreme Court-Rush,,,No,125,11,148,284
+Laporte,COOLSPRING 04,IN Supreme Court-Massa,,,Yes,207,18,224,449
+Laporte,COOLSPRING 04,IN Supreme Court-Massa,,,No,125,13,155,293
+Laporte,COOLSPRING 04,IN Supreme Court-Molter,,,Yes,214,16,234,464
+Laporte,COOLSPRING 04,IN Supreme Court-Molter,,,No,120,14,153,287
+Laporte,COOLSPRING 04,Court of Appeals Dist 4-Pyle III,,,Yes,209,17,230,456
+Laporte,COOLSPRING 04,Court of Appeals Dist 4-Pyle III,,,No,125,13,154,292
+Laporte,COOLSPRING 04,Straight Party,,DEM,Democratic Party,,,,149
+Laporte,COOLSPRING 04,Straight Party,,REP,Republican Party,,,,209
+Laporte,COOLSPRING 05,Ballots Cast,,,,220,13,188,421
+Laporte,COOLSPRING 05,Registered Voters,,,,,,,736
+Laporte,COOLSPRING 05,Public Question-Const Amendment,,,Yes,118,4,72,194
+Laporte,COOLSPRING 05,Public Question-Const Amendment,,,No,84,3,89,176
+Laporte,COOLSPRING 05,President and Vice-President of the U.S.,,REP,Trump \ Vance,113,2,84,199
+Laporte,COOLSPRING 05,President and Vice-President of the U.S.,,DEM,Harris \ Walz,100,11,101,212
+Laporte,COOLSPRING 05,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,0,0,1,1
+Laporte,COOLSPRING 05,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,4,0,2,6
+Laporte,COOLSPRING 05,President and Vice-President of the U.S.,,,Write-In,1,0,0,1
+Laporte,COOLSPRING 05,United States Senator,,REP,Jim Banks,101,2,77,180
+Laporte,COOLSPRING 05,United States Senator,,DEM,Valerie McCray,97,11,92,200
+Laporte,COOLSPRING 05,United States Senator,,LIB,Andrew Horning,3,0,3,6
+Laporte,COOLSPRING 05,United States Senator,,,Write-In,0,0,0,0
+Laporte,COOLSPRING 05,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,101,2,75,178
+Laporte,COOLSPRING 05,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,93,11,91,195
+Laporte,COOLSPRING 05,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,5,0,7,12
+Laporte,COOLSPRING 05,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,COOLSPRING 05,Attorney General,,REP,Todd Rokita,109,2,79,190
+Laporte,COOLSPRING 05,Attorney General,,DEM,Destiny Wells,96,11,101,208
+Laporte,COOLSPRING 05,United States Representative,1,REP,Randy Niemeyer,99,2,71,172
+Laporte,COOLSPRING 05,United States Representative,1,DEM,Frank J. Mrvan,104,11,107,222
+Laporte,COOLSPRING 05,United States Representative,1,LIB,Dakotah Miskus,3,0,4,7
+Laporte,COOLSPRING 05,United States Representative,1,,Write-In,0,0,0,0
+Laporte,COOLSPRING 05,State Representative,09,REP,Joel Florek,106,2,80,188
+Laporte,COOLSPRING 05,State Representative,09,DEM,Patricia A. (Pat) Boy,99,11,101,211
+Laporte,COOLSPRING 05,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,131,4,102,237
+Laporte,COOLSPRING 05,Circuit Court Clerk,,REP,Heather Stevens,114,2,77,193
+Laporte,COOLSPRING 05,Circuit Court Clerk,,DEM,Angela Henzman,84,11,93,188
+Laporte,COOLSPRING 05,County Auditor,,REP,Mike Rosenbaum,138,4,106,248
+Laporte,COOLSPRING 05,County Recorder,,REP,Elzbieta (Ela) Bilderback,109,2,84,195
+Laporte,COOLSPRING 05,County Recorder,,DEM,Matthew Sikorski,90,11,97,198
+Laporte,COOLSPRING 05,County Treasurer,,REP,Dan Barenie,91,2,75,168
+Laporte,COOLSPRING 05,County Treasurer,,DEM,Joie Winski,116,11,110,237
+Laporte,COOLSPRING 05,County Coroner,,REP,Lynn Swanson,121,2,84,207
+Laporte,COOLSPRING 05,County Coroner,,DEM,Mark P. Baker,83,11,99,193
+Laporte,COOLSPRING 05,County Surveyor,,REP,John Matwyshyn,94,2,72,168
+Laporte,COOLSPRING 05,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,102,11,103,216
+Laporte,COOLSPRING 05,County Commissioner District 2,,REP,Steve Holifield,94,2,71,167
+Laporte,COOLSPRING 05,County Commissioner District 2,,DEM,Mike Kellems,106,11,104,221
+Laporte,COOLSPRING 05,County Commissioner District 3,,REP,Joe Haney,98,2,69,169
+Laporte,COOLSPRING 05,County Commissioner District 3,,DEM,Randy Novak,103,11,110,224
+Laporte,COOLSPRING 05,County Council Member At Large,,REP,Brett H. Kessler,77,2,60,139
+Laporte,COOLSPRING 05,County Council Member At Large,,REP,Adam Koronka,60,2,48,110
+Laporte,COOLSPRING 05,County Council Member At Large,,REP,Heather Oake,64,4,50,118
+Laporte,COOLSPRING 05,County Council Member At Large,,DEM,Scott (Scotty) Ford,74,2,83,159
+Laporte,COOLSPRING 05,County Council Member At Large,,DEM,Mike Mollenhauer,80,5,86,171
+Laporte,COOLSPRING 05,County Council Member At Large,,DEM,Johnny Stimley,87,3,99,189
+Laporte,COOLSPRING 05,MC Area SB Civil City,,,Marty M. Corley,109,4,89,202
+Laporte,COOLSPRING 05,MC Area SB Civil City,,,Rodney McCormick,50,3,51,104
+Laporte,COOLSPRING 05,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,55,4,42,101
+Laporte,COOLSPRING 05,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,18,1,29,48
+Laporte,COOLSPRING 05,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,42,2,24,68
+Laporte,COOLSPRING 05,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,27,1,30,58
+Laporte,COOLSPRING 05,MC Area SB Michigan/Springfield Twps,,,James Stewart,135,7,124,266
+Laporte,COOLSPRING 05,IN Supreme Court-Rush,,,Yes,118,4,96,218
+Laporte,COOLSPRING 05,IN Supreme Court-Rush,,,No,52,3,41,96
+Laporte,COOLSPRING 05,IN Supreme Court-Massa,,,Yes,115,4,89,208
+Laporte,COOLSPRING 05,IN Supreme Court-Massa,,,No,54,3,47,104
+Laporte,COOLSPRING 05,IN Supreme Court-Molter,,,Yes,111,3,97,211
+Laporte,COOLSPRING 05,IN Supreme Court-Molter,,,No,56,4,45,105
+Laporte,COOLSPRING 05,Court of Appeals Dist 4-Pyle III,,,Yes,113,3,89,205
+Laporte,COOLSPRING 05,Court of Appeals Dist 4-Pyle III,,,No,56,4,53,113
+Laporte,COOLSPRING 05,Straight Party,,DEM,Democratic Party,,,,75
+Laporte,COOLSPRING 05,Straight Party,,REP,Republican Party,,,,88
+Laporte,DEWEY,Ballots Cast,,,,150,5,61,216
+Laporte,DEWEY,Registered Voters,,,,,,,292
+Laporte,DEWEY,Public Question-Const Amendment,,,Yes,80,1,31,112
+Laporte,DEWEY,Public Question-Const Amendment,,,No,60,2,21,83
+Laporte,DEWEY,President and Vice-President of the U.S.,,REP,Trump \ Vance,111,2,49,162
+Laporte,DEWEY,President and Vice-President of the U.S.,,DEM,Harris \ Walz,38,3,12,53
+Laporte,DEWEY,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,0,0,0,0
+Laporte,DEWEY,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,0,0,0,0
+Laporte,DEWEY,President and Vice-President of the U.S.,,,Write-In,0,0,0,0
+Laporte,DEWEY,United States Senator,,REP,Jim Banks,105,3,45,153
+Laporte,DEWEY,United States Senator,,DEM,Valerie McCray,36,2,11,49
+Laporte,DEWEY,United States Senator,,LIB,Andrew Horning,2,0,1,3
+Laporte,DEWEY,United States Senator,,,Write-In,0,0,0,0
+Laporte,DEWEY,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,96,2,42,140
+Laporte,DEWEY,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,41,3,14,58
+Laporte,DEWEY,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,7,0,2,9
+Laporte,DEWEY,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,DEWEY,Attorney General,,REP,Todd Rokita,104,3,47,154
+Laporte,DEWEY,Attorney General,,DEM,Destiny Wells,40,2,11,53
+Laporte,DEWEY,United States Representative,2,REP,Rudy Yakym,105,3,44,152
+Laporte,DEWEY,United States Representative,2,DEM,Lori A. Camp,35,2,14,51
+Laporte,DEWEY,United States Representative,2,LIB,William E. Henry,4,0,0,4
+Laporte,DEWEY,United States Representative,2,,Write-In,0,0,0,0
+Laporte,DEWEY,State Senator District 8,,REP,Mike Bohacek,115,3,49,167
+Laporte,DEWEY,State Senator District 8,,DEM,Leon P. Smith,31,2,8,41
+Laporte,DEWEY,State Representative,20,REP,Jim Pressel,131,3,49,183
+Laporte,DEWEY,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,116,3,45,164
+Laporte,DEWEY,Circuit Court Clerk,,REP,Heather Stevens,100,3,44,147
+Laporte,DEWEY,Circuit Court Clerk,,DEM,Angela Henzman,40,2,11,53
+Laporte,DEWEY,County Auditor,,REP,Mike Rosenbaum,128,3,51,182
+Laporte,DEWEY,County Recorder,,REP,Elzbieta (Ela) Bilderback,94,3,47,144
+Laporte,DEWEY,County Recorder,,DEM,Matthew Sikorski,44,2,10,56
+Laporte,DEWEY,County Treasurer,,REP,Dan Barenie,93,3,49,145
+Laporte,DEWEY,County Treasurer,,DEM,Joie Winski,43,2,7,52
+Laporte,DEWEY,County Coroner,,REP,Lynn Swanson,110,3,48,161
+Laporte,DEWEY,County Coroner,,DEM,Mark P. Baker,32,2,8,42
+Laporte,DEWEY,County Surveyor,,REP,John Matwyshyn,89,3,43,135
+Laporte,DEWEY,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,52,2,12,66
+Laporte,DEWEY,County Commissioner District 2,,REP,Steve Holifield,81,3,40,124
+Laporte,DEWEY,County Commissioner District 2,,DEM,Mike Kellems,62,2,17,81
+Laporte,DEWEY,County Commissioner District 3,,REP,Joe Haney,87,3,44,134
+Laporte,DEWEY,County Commissioner District 3,,DEM,Randy Novak,57,2,12,71
+Laporte,DEWEY,County Council Member At Large,,REP,Brett H. Kessler,90,1,39,130
+Laporte,DEWEY,County Council Member At Large,,REP,Adam Koronka,88,1,39,128
+Laporte,DEWEY,County Council Member At Large,,REP,Heather Oake,70,1,34,105
+Laporte,DEWEY,County Council Member At Large,,DEM,Scott (Scotty) Ford,29,2,6,37
+Laporte,DEWEY,County Council Member At Large,,DEM,Mike Mollenhauer,54,2,11,67
+Laporte,DEWEY,County Council Member At Large,,DEM,Johnny Stimley,30,2,6,38
+Laporte,DEWEY,IN Supreme Court-Rush,,,Yes,90,3,37,130
+Laporte,DEWEY,IN Supreme Court-Rush,,,No,36,0,12,48
+Laporte,DEWEY,IN Supreme Court-Massa,,,Yes,85,3,38,126
+Laporte,DEWEY,IN Supreme Court-Massa,,,No,39,0,11,50
+Laporte,DEWEY,IN Supreme Court-Molter,,,Yes,88,3,38,129
+Laporte,DEWEY,IN Supreme Court-Molter,,,No,38,0,12,50
+Laporte,DEWEY,Court of Appeals Dist 4-Pyle III,,,Yes,85,3,38,126
+Laporte,DEWEY,Court of Appeals Dist 4-Pyle III,,,No,40,0,12,52
+Laporte,DEWEY,Straight Party,,DEM,Democratic Party,,,,10
+Laporte,DEWEY,Straight Party,,REP,Republican Party,,,,51
+Laporte,DUNELAND BEACH,Ballots Cast,,,,42,14,89,145
+Laporte,DUNELAND BEACH,Registered Voters,,,,,,,213
+Laporte,DUNELAND BEACH,Public Question-Const Amendment,,,Yes,30,5,46,81
+Laporte,DUNELAND BEACH,Public Question-Const Amendment,,,No,9,5,39,53
+Laporte,DUNELAND BEACH,President and Vice-President of the U.S.,,REP,Trump \ Vance,16,7,37,60
+Laporte,DUNELAND BEACH,President and Vice-President of the U.S.,,DEM,Harris \ Walz,24,7,51,82
+Laporte,DUNELAND BEACH,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,0,0,0,0
+Laporte,DUNELAND BEACH,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,0,0,0,0
+Laporte,DUNELAND BEACH,President and Vice-President of the U.S.,,,Write-In,0,0,0,0
+Laporte,DUNELAND BEACH,United States Senator,,REP,Jim Banks,18,7,37,62
+Laporte,DUNELAND BEACH,United States Senator,,DEM,Valerie McCray,21,7,45,73
+Laporte,DUNELAND BEACH,United States Senator,,LIB,Andrew Horning,1,0,0,1
+Laporte,DUNELAND BEACH,United States Senator,,,Write-In,0,0,0,0
+Laporte,DUNELAND BEACH,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,19,7,38,64
+Laporte,DUNELAND BEACH,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,21,7,46,74
+Laporte,DUNELAND BEACH,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,1,0,0,1
+Laporte,DUNELAND BEACH,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,DUNELAND BEACH,Attorney General,,REP,Todd Rokita,18,7,39,64
+Laporte,DUNELAND BEACH,Attorney General,,DEM,Destiny Wells,23,6,47,76
+Laporte,DUNELAND BEACH,United States Representative,1,REP,Randy Niemeyer,17,7,38,62
+Laporte,DUNELAND BEACH,United States Representative,1,DEM,Frank J. Mrvan,24,7,48,79
+Laporte,DUNELAND BEACH,United States Representative,1,LIB,Dakotah Miskus,0,0,2,2
+Laporte,DUNELAND BEACH,United States Representative,1,,Write-In,0,0,0,0
+Laporte,DUNELAND BEACH,State Representative,09,REP,Joel Florek,19,7,39,65
+Laporte,DUNELAND BEACH,State Representative,09,DEM,Patricia A. (Pat) Boy,22,7,45,74
+Laporte,DUNELAND BEACH,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,27,9,42,78
+Laporte,DUNELAND BEACH,Circuit Court Clerk,,REP,Heather Stevens,19,7,36,62
+Laporte,DUNELAND BEACH,Circuit Court Clerk,,DEM,Angela Henzman,20,6,45,71
+Laporte,DUNELAND BEACH,County Auditor,,REP,Mike Rosenbaum,28,9,46,83
+Laporte,DUNELAND BEACH,County Recorder,,REP,Elzbieta (Ela) Bilderback,19,7,40,66
+Laporte,DUNELAND BEACH,County Recorder,,DEM,Matthew Sikorski,21,6,47,74
+Laporte,DUNELAND BEACH,County Treasurer,,REP,Dan Barenie,17,8,34,59
+Laporte,DUNELAND BEACH,County Treasurer,,DEM,Joie Winski,24,5,54,83
+Laporte,DUNELAND BEACH,County Coroner,,REP,Lynn Swanson,21,7,39,67
+Laporte,DUNELAND BEACH,County Coroner,,DEM,Mark P. Baker,19,6,48,73
+Laporte,DUNELAND BEACH,County Surveyor,,REP,John Matwyshyn,16,8,37,61
+Laporte,DUNELAND BEACH,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,23,5,47,75
+Laporte,DUNELAND BEACH,County Commissioner District 2,,REP,Steve Holifield,19,7,37,63
+Laporte,DUNELAND BEACH,County Commissioner District 2,,DEM,Mike Kellems,21,6,46,73
+Laporte,DUNELAND BEACH,County Commissioner District 3,,REP,Joe Haney,17,7,35,59
+Laporte,DUNELAND BEACH,County Commissioner District 3,,DEM,Randy Novak,24,6,48,78
+Laporte,DUNELAND BEACH,County Council Member At Large,,REP,Brett H. Kessler,15,4,31,50
+Laporte,DUNELAND BEACH,County Council Member At Large,,REP,Adam Koronka,13,3,28,44
+Laporte,DUNELAND BEACH,County Council Member At Large,,REP,Heather Oake,16,3,27,46
+Laporte,DUNELAND BEACH,County Council Member At Large,,DEM,Scott (Scotty) Ford,17,3,38,58
+Laporte,DUNELAND BEACH,County Council Member At Large,,DEM,Mike Mollenhauer,22,3,43,68
+Laporte,DUNELAND BEACH,County Council Member At Large,,DEM,Johnny Stimley,23,3,41,67
+Laporte,DUNELAND BEACH,MC Area SB Civil City,,,Marty M. Corley,23,5,42,70
+Laporte,DUNELAND BEACH,MC Area SB Civil City,,,Rodney McCormick,7,1,16,24
+Laporte,DUNELAND BEACH,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,8,1,13,22
+Laporte,DUNELAND BEACH,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,5,1,7,13
+Laporte,DUNELAND BEACH,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,7,2,18,27
+Laporte,DUNELAND BEACH,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,7,2,16,25
+Laporte,DUNELAND BEACH,MC Area SB Michigan/Springfield Twps,,,James Stewart,28,6,55,89
+Laporte,DUNELAND BEACH,IN Supreme Court-Rush,,,Yes,30,5,51,86
+Laporte,DUNELAND BEACH,IN Supreme Court-Rush,,,No,5,2,21,28
+Laporte,DUNELAND BEACH,IN Supreme Court-Massa,,,Yes,29,5,52,86
+Laporte,DUNELAND BEACH,IN Supreme Court-Massa,,,No,5,2,21,28
+Laporte,DUNELAND BEACH,IN Supreme Court-Molter,,,Yes,28,4,48,80
+Laporte,DUNELAND BEACH,IN Supreme Court-Molter,,,No,6,3,24,33
+Laporte,DUNELAND BEACH,Court of Appeals Dist 4-Pyle III,,,Yes,28,5,48,81
+Laporte,DUNELAND BEACH,Court of Appeals Dist 4-Pyle III,,,No,6,2,24,32
+Laporte,DUNELAND BEACH,Straight Party,,DEM,Democratic Party,,,,31
+Laporte,DUNELAND BEACH,Straight Party,,REP,Republican Party,,,,33
+Laporte,GALENA 01,Ballots Cast,,,,261,23,245,529
+Laporte,GALENA 01,Registered Voters,,,,,,,723
+Laporte,GALENA 01,Public Question-Const Amendment,,,Yes,112,6,104,222
+Laporte,GALENA 01,Public Question-Const Amendment,,,No,105,12,114,231
+Laporte,GALENA 01,President and Vice-President of the U.S.,,REP,Trump \ Vance,185,11,118,314
+Laporte,GALENA 01,President and Vice-President of the U.S.,,DEM,Harris \ Walz,67,11,126,204
+Laporte,GALENA 01,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,2,0,0,2
+Laporte,GALENA 01,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,2,0,0,2
+Laporte,GALENA 01,President and Vice-President of the U.S.,,,Write-In,2,0,1,3
+Laporte,GALENA 01,United States Senator,,REP,Jim Banks,171,9,109,289
+Laporte,GALENA 01,United States Senator,,DEM,Valerie McCray,65,12,122,199
+Laporte,GALENA 01,United States Senator,,LIB,Andrew Horning,6,0,3,9
+Laporte,GALENA 01,United States Senator,,,Write-In,0,0,1,1
+Laporte,GALENA 01,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,160,9,109,278
+Laporte,GALENA 01,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,71,12,121,204
+Laporte,GALENA 01,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,14,0,4,18
+Laporte,GALENA 01,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,GALENA 01,Attorney General,,REP,Todd Rokita,176,10,116,302
+Laporte,GALENA 01,Attorney General,,DEM,Destiny Wells,67,12,126,205
+Laporte,GALENA 01,United States Representative,2,REP,Rudy Yakym,164,10,115,289
+Laporte,GALENA 01,United States Representative,2,DEM,Lori A. Camp,65,12,121,198
+Laporte,GALENA 01,United States Representative,2,LIB,William E. Henry,12,0,4,16
+Laporte,GALENA 01,United States Representative,2,,Write-In,0,0,0,0
+Laporte,GALENA 01,State Senator District 8,,REP,Mike Bohacek,194,11,123,328
+Laporte,GALENA 01,State Senator District 8,,DEM,Leon P. Smith,50,10,117,177
+Laporte,GALENA 01,State Representative,09,REP,Joel Florek,176,10,112,298
+Laporte,GALENA 01,State Representative,09,DEM,Patricia A. (Pat) Boy,68,10,123,201
+Laporte,GALENA 01,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,190,13,137,340
+Laporte,GALENA 01,Circuit Court Clerk,,REP,Heather Stevens,173,11,116,300
+Laporte,GALENA 01,Circuit Court Clerk,,DEM,Angela Henzman,53,10,117,180
+Laporte,GALENA 01,County Auditor,,REP,Mike Rosenbaum,205,15,156,376
+Laporte,GALENA 01,County Recorder,,REP,Elzbieta (Ela) Bilderback,166,10,109,285
+Laporte,GALENA 01,County Recorder,,DEM,Matthew Sikorski,64,11,124,199
+Laporte,GALENA 01,County Treasurer,,REP,Dan Barenie,162,12,101,275
+Laporte,GALENA 01,County Treasurer,,DEM,Joie Winski,73,9,138,220
+Laporte,GALENA 01,County Coroner,,REP,Lynn Swanson,187,11,122,320
+Laporte,GALENA 01,County Coroner,,DEM,Mark P. Baker,49,10,117,176
+Laporte,GALENA 01,County Surveyor,,REP,John Matwyshyn,153,10,101,264
+Laporte,GALENA 01,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,73,11,133,217
+Laporte,GALENA 01,County Commissioner District 2,,REP,Steve Holifield,169,9,106,284
+Laporte,GALENA 01,County Commissioner District 2,,DEM,Mike Kellems,62,12,126,200
+Laporte,GALENA 01,County Commissioner District 3,,REP,Joe Haney,162,9,99,270
+Laporte,GALENA 01,County Commissioner District 3,,DEM,Randy Novak,74,12,137,223
+Laporte,GALENA 01,County Council Member At Large,,REP,Brett H. Kessler,156,12,90,258
+Laporte,GALENA 01,County Council Member At Large,,REP,Adam Koronka,125,6,74,205
+Laporte,GALENA 01,County Council Member At Large,,REP,Heather Oake,126,8,70,204
+Laporte,GALENA 01,County Council Member At Large,,DEM,Scott (Scotty) Ford,56,11,100,167
+Laporte,GALENA 01,County Council Member At Large,,DEM,Mike Mollenhauer,81,7,126,214
+Laporte,GALENA 01,County Council Member At Large,,DEM,Johnny Stimley,52,9,103,164
+Laporte,GALENA 01,New Prairie United School Corp At Lg,,,Jill Smith,128,13,127,268
+Laporte,GALENA 01,New Prairie United School Corp At Lg,,,Mike Yacullo,68,1,53,122
+Laporte,GALENA 01,New Prairie United School Corp Dist 1,,,Rich Shail,164,11,153,328
+Laporte,GALENA 01,New Prairie United School Corp Dist 3,,,Phillip J. King,107,10,104,221
+Laporte,GALENA 01,New Prairie United School Corp Dist 3,,,Andrew Oake,77,3,71,151
+Laporte,GALENA 01,IN Supreme Court-Rush,,,Yes,122,12,133,267
+Laporte,GALENA 01,IN Supreme Court-Rush,,,No,69,3,61,133
+Laporte,GALENA 01,IN Supreme Court-Massa,,,Yes,118,6,123,247
+Laporte,GALENA 01,IN Supreme Court-Massa,,,No,73,8,70,151
+Laporte,GALENA 01,IN Supreme Court-Molter,,,Yes,120,6,128,254
+Laporte,GALENA 01,IN Supreme Court-Molter,,,No,69,9,66,144
+Laporte,GALENA 01,Court of Appeals Dist 4-Pyle III,,,Yes,120,6,128,254
+Laporte,GALENA 01,Court of Appeals Dist 4-Pyle III,,,No,71,9,65,145
+Laporte,GALENA 01,Straight Party,,DEM,Democratic Party,,,,74
+Laporte,GALENA 01,Straight Party,,REP,Republican Party,,,,119
+Laporte,GALENA 02,Ballots Cast,,,,286,25,295,606
+Laporte,GALENA 02,Registered Voters,,,,,,,849
+Laporte,GALENA 02,Public Question-Const Amendment,,,Yes,135,12,121,268
+Laporte,GALENA 02,Public Question-Const Amendment,,,No,101,6,138,245
+Laporte,GALENA 02,President and Vice-President of the U.S.,,REP,Trump \ Vance,201,11,161,373
+Laporte,GALENA 02,President and Vice-President of the U.S.,,DEM,Harris \ Walz,78,13,125,216
+Laporte,GALENA 02,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,1,0,5,6
+Laporte,GALENA 02,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,3,0,0,3
+Laporte,GALENA 02,President and Vice-President of the U.S.,,,Write-In,0,0,0,0
+Laporte,GALENA 02,United States Senator,,REP,Jim Banks,174,11,158,343
+Laporte,GALENA 02,United States Senator,,DEM,Valerie McCray,76,14,116,206
+Laporte,GALENA 02,United States Senator,,LIB,Andrew Horning,10,0,5,15
+Laporte,GALENA 02,United States Senator,,,Write-In,0,0,0,0
+Laporte,GALENA 02,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,173,11,152,336
+Laporte,GALENA 02,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,80,14,121,215
+Laporte,GALENA 02,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,13,0,6,19
+Laporte,GALENA 02,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,GALENA 02,Attorney General,,REP,Todd Rokita,179,13,162,354
+Laporte,GALENA 02,Attorney General,,DEM,Destiny Wells,81,12,120,213
+Laporte,GALENA 02,United States Representative,2,REP,Rudy Yakym,178,11,164,353
+Laporte,GALENA 02,United States Representative,2,DEM,Lori A. Camp,74,14,118,206
+Laporte,GALENA 02,United States Representative,2,LIB,William E. Henry,8,0,4,12
+Laporte,GALENA 02,United States Representative,2,,Write-In,0,0,0,0
+Laporte,GALENA 02,State Senator District 8,,REP,Mike Bohacek,192,13,180,385
+Laporte,GALENA 02,State Senator District 8,,DEM,Leon P. Smith,71,11,104,186
+Laporte,GALENA 02,State Representative,09,REP,Joel Florek,187,12,159,358
+Laporte,GALENA 02,State Representative,09,DEM,Patricia A. (Pat) Boy,75,12,124,211
+Laporte,GALENA 02,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,186,17,192,395
+Laporte,GALENA 02,Circuit Court Clerk,,REP,Heather Stevens,179,13,162,354
+Laporte,GALENA 02,Circuit Court Clerk,,DEM,Angela Henzman,70,12,115,197
+Laporte,GALENA 02,County Auditor,,REP,Mike Rosenbaum,205,17,210,432
+Laporte,GALENA 02,County Recorder,,REP,Elzbieta (Ela) Bilderback,174,13,158,345
+Laporte,GALENA 02,County Recorder,,DEM,Matthew Sikorski,79,12,124,215
+Laporte,GALENA 02,County Treasurer,,REP,Dan Barenie,177,10,156,343
+Laporte,GALENA 02,County Treasurer,,DEM,Joie Winski,80,15,129,224
+Laporte,GALENA 02,County Coroner,,REP,Lynn Swanson,185,15,177,377
+Laporte,GALENA 02,County Coroner,,DEM,Mark P. Baker,77,10,107,194
+Laporte,GALENA 02,County Surveyor,,REP,John Matwyshyn,170,10,150,330
+Laporte,GALENA 02,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,88,15,128,231
+Laporte,GALENA 02,County Commissioner District 2,,REP,Steve Holifield,173,11,161,345
+Laporte,GALENA 02,County Commissioner District 2,,DEM,Mike Kellems,85,14,118,217
+Laporte,GALENA 02,County Commissioner District 3,,REP,Joe Haney,163,10,148,321
+Laporte,GALENA 02,County Commissioner District 3,,DEM,Randy Novak,95,15,134,244
+Laporte,GALENA 02,County Council Member At Large,,REP,Brett H. Kessler,158,8,151,317
+Laporte,GALENA 02,County Council Member At Large,,REP,Adam Koronka,126,8,120,254
+Laporte,GALENA 02,County Council Member At Large,,REP,Heather Oake,130,9,117,256
+Laporte,GALENA 02,County Council Member At Large,,DEM,Scott (Scotty) Ford,57,12,97,166
+Laporte,GALENA 02,County Council Member At Large,,DEM,Mike Mollenhauer,71,13,117,201
+Laporte,GALENA 02,County Council Member At Large,,DEM,Johnny Stimley,57,13,96,166
+Laporte,GALENA 02,New Prairie United School Corp At Lg,,,Jill Smith,113,16,155,284
+Laporte,GALENA 02,New Prairie United School Corp At Lg,,,Mike Yacullo,83,2,67,152
+Laporte,GALENA 02,New Prairie United School Corp Dist 1,,,Rich Shail,171,18,186,375
+Laporte,GALENA 02,New Prairie United School Corp Dist 3,,,Phillip J. King,111,9,123,243
+Laporte,GALENA 02,New Prairie United School Corp Dist 3,,,Andrew Oake,71,9,89,169
+Laporte,GALENA 02,IN Supreme Court-Rush,,,Yes,136,9,149,294
+Laporte,GALENA 02,IN Supreme Court-Rush,,,No,54,10,82,146
+Laporte,GALENA 02,IN Supreme Court-Massa,,,Yes,131,7,147,285
+Laporte,GALENA 02,IN Supreme Court-Massa,,,No,56,12,80,148
+Laporte,GALENA 02,IN Supreme Court-Molter,,,Yes,129,7,139,275
+Laporte,GALENA 02,IN Supreme Court-Molter,,,No,61,12,88,161
+Laporte,GALENA 02,Court of Appeals Dist 4-Pyle III,,,Yes,133,9,147,289
+Laporte,GALENA 02,Court of Appeals Dist 4-Pyle III,,,No,57,10,83,150
+Laporte,GALENA 02,Straight Party,,DEM,Democratic Party,,,,78
+Laporte,GALENA 02,Straight Party,,REP,Republican Party,,,,152
+Laporte,HANNA,Ballots Cast,,,,343,12,212,567
+Laporte,HANNA,Registered Voters,,,,,,,787
+Laporte,HANNA,Public Question-Const Amendment,,,Yes,192,3,101,296
+Laporte,HANNA,Public Question-Const Amendment,,,No,104,6,89,199
+Laporte,HANNA,President and Vice-President of the U.S.,,REP,Trump \ Vance,248,9,133,390
+Laporte,HANNA,President and Vice-President of the U.S.,,DEM,Harris \ Walz,84,2,73,159
+Laporte,HANNA,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,1,0,1,2
+Laporte,HANNA,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,6,1,4,11
+Laporte,HANNA,President and Vice-President of the U.S.,,,Write-In,0,0,0,0
+Laporte,HANNA,United States Senator,,REP,Jim Banks,225,10,121,356
+Laporte,HANNA,United States Senator,,DEM,Valerie McCray,73,2,67,142
+Laporte,HANNA,United States Senator,,LIB,Andrew Horning,17,0,6,23
+Laporte,HANNA,United States Senator,,,Write-In,0,0,0,0
+Laporte,HANNA,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,215,9,114,338
+Laporte,HANNA,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,86,2,75,163
+Laporte,HANNA,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,19,1,9,29
+Laporte,HANNA,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,HANNA,Attorney General,,REP,Todd Rokita,232,9,129,370
+Laporte,HANNA,Attorney General,,DEM,Destiny Wells,85,3,78,166
+Laporte,HANNA,United States Representative,2,REP,Rudy Yakym,225,9,126,360
+Laporte,HANNA,United States Representative,2,DEM,Lori A. Camp,75,3,71,149
+Laporte,HANNA,United States Representative,2,LIB,William E. Henry,19,0,8,27
+Laporte,HANNA,United States Representative,2,,Write-In,0,0,0,0
+Laporte,HANNA,State Senator District 8,,REP,Mike Bohacek,251,8,142,401
+Laporte,HANNA,State Senator District 8,,DEM,Leon P. Smith,69,3,62,134
+Laporte,HANNA,State Representative,20,REP,Jim Pressel,273,10,175,458
+Laporte,HANNA,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,251,10,156,417
+Laporte,HANNA,Circuit Court Clerk,,REP,Heather Stevens,251,8,143,402
+Laporte,HANNA,Circuit Court Clerk,,DEM,Angela Henzman,71,3,55,129
+Laporte,HANNA,County Auditor,,REP,Mike Rosenbaum,279,11,174,464
+Laporte,HANNA,County Recorder,,REP,Elzbieta (Ela) Bilderback,227,7,135,369
+Laporte,HANNA,County Recorder,,DEM,Matthew Sikorski,82,3,70,155
+Laporte,HANNA,County Treasurer,,REP,Dan Barenie,222,8,129,359
+Laporte,HANNA,County Treasurer,,DEM,Joie Winski,92,2,76,170
+Laporte,HANNA,County Coroner,,REP,Lynn Swanson,243,8,138,389
+Laporte,HANNA,County Coroner,,DEM,Mark P. Baker,79,2,68,149
+Laporte,HANNA,County Surveyor,,REP,John Matwyshyn,206,7,113,326
+Laporte,HANNA,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,107,3,89,199
+Laporte,HANNA,County Commissioner District 2,,REP,Steve Holifield,195,9,112,316
+Laporte,HANNA,County Commissioner District 2,,DEM,Mike Kellems,124,2,88,214
+Laporte,HANNA,County Commissioner District 3,,REP,Joe Haney,204,9,133,346
+Laporte,HANNA,County Commissioner District 3,,DEM,Randy Novak,116,2,70,188
+Laporte,HANNA,County Council Member At Large,,REP,Brett H. Kessler,184,7,104,295
+Laporte,HANNA,County Council Member At Large,,REP,Adam Koronka,174,9,95,278
+Laporte,HANNA,County Council Member At Large,,REP,Heather Oake,152,9,83,244
+Laporte,HANNA,County Council Member At Large,,DEM,Scott (Scotty) Ford,77,1,81,159
+Laporte,HANNA,County Council Member At Large,,DEM,Mike Mollenhauer,112,3,85,200
+Laporte,HANNA,County Council Member At Large,,DEM,Johnny Stimley,58,0,62,120
+Laporte,HANNA,South Central School Board At Large,,,Jacob Wade,224,10,128,362
+Laporte,HANNA,South Central SB Hanna Township,,,Cheryl Lynn (Sherry) Shei,163,8,112,283
+Laporte,HANNA,South Central SB Hanna Township,,,Michael Sullivan,125,2,60,187
+Laporte,HANNA,South Central SB Noble Township,,,Geraldine (Gerrie) Grott,219,9,133,361
+Laporte,HANNA,IN Supreme Court-Rush,,,Yes,186,11,112,309
+Laporte,HANNA,IN Supreme Court-Rush,,,No,84,0,52,136
+Laporte,HANNA,IN Supreme Court-Massa,,,Yes,181,10,107,298
+Laporte,HANNA,IN Supreme Court-Massa,,,No,80,1,53,134
+Laporte,HANNA,IN Supreme Court-Molter,,,Yes,190,11,112,313
+Laporte,HANNA,IN Supreme Court-Molter,,,No,75,0,50,125
+Laporte,HANNA,Court of Appeals Dist 4-Pyle III,,,Yes,178,10,107,295
+Laporte,HANNA,Court of Appeals Dist 4-Pyle III,,,No,86,1,53,140
+Laporte,HANNA,Straight Party,,DEM,Democratic Party,,,,35
+Laporte,HANNA,Straight Party,,REP,Republican Party,,,,147
+Laporte,HUDSON,Ballots Cast,,,,536,60,324,920
+Laporte,HUDSON,Registered Voters,,,,,,,1372
+Laporte,HUDSON,Public Question-Const Amendment,,,Yes,269,18,125,412
+Laporte,HUDSON,Public Question-Const Amendment,,,No,193,29,153,375
+Laporte,HUDSON,President and Vice-President of the U.S.,,REP,Trump \ Vance,359,24,210,593
+Laporte,HUDSON,President and Vice-President of the U.S.,,DEM,Harris \ Walz,164,34,108,306
+Laporte,HUDSON,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,5,1,0,6
+Laporte,HUDSON,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,4,0,1,5
+Laporte,HUDSON,President and Vice-President of the U.S.,,,Write-In,0,1,2,3
+Laporte,HUDSON,United States Senator,,REP,Jim Banks,338,24,199,561
+Laporte,HUDSON,United States Senator,,DEM,Valerie McCray,140,29,101,270
+Laporte,HUDSON,United States Senator,,LIB,Andrew Horning,21,1,7,29
+Laporte,HUDSON,United States Senator,,,Write-In,0,0,0,0
+Laporte,HUDSON,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,300,24,190,514
+Laporte,HUDSON,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,160,31,108,299
+Laporte,HUDSON,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,40,2,16,58
+Laporte,HUDSON,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,HUDSON,Attorney General,,REP,Todd Rokita,347,25,209,581
+Laporte,HUDSON,Attorney General,,DEM,Destiny Wells,161,31,106,298
+Laporte,HUDSON,United States Representative,2,REP,Rudy Yakym,345,24,208,577
+Laporte,HUDSON,United States Representative,2,DEM,Lori A. Camp,147,30,100,277
+Laporte,HUDSON,United States Representative,2,LIB,William E. Henry,21,2,6,29
+Laporte,HUDSON,United States Representative,2,,Write-In,0,0,0,0
+Laporte,HUDSON,State Senator District 8,,REP,Mike Bohacek,375,26,211,612
+Laporte,HUDSON,State Senator District 8,,DEM,Leon P. Smith,139,28,102,269
+Laporte,HUDSON,State Representative,07,REP,Jake Teshka,385,30,223,638
+Laporte,HUDSON,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,374,30,215,619
+Laporte,HUDSON,Circuit Court Clerk,,REP,Heather Stevens,338,26,203,567
+Laporte,HUDSON,Circuit Court Clerk,,DEM,Angela Henzman,148,28,101,277
+Laporte,HUDSON,County Auditor,,REP,Mike Rosenbaum,404,32,224,660
+Laporte,HUDSON,County Recorder,,REP,Elzbieta (Ela) Bilderback,347,21,196,564
+Laporte,HUDSON,County Recorder,,DEM,Matthew Sikorski,159,34,110,303
+Laporte,HUDSON,County Treasurer,,REP,Dan Barenie,342,24,195,561
+Laporte,HUDSON,County Treasurer,,DEM,Joie Winski,167,30,114,311
+Laporte,HUDSON,County Coroner,,REP,Lynn Swanson,369,25,208,602
+Laporte,HUDSON,County Coroner,,DEM,Mark P. Baker,142,28,102,272
+Laporte,HUDSON,County Surveyor,,REP,John Matwyshyn,337,24,196,557
+Laporte,HUDSON,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,163,30,113,306
+Laporte,HUDSON,County Commissioner District 2,,REP,Steve Holifield,346,28,198,572
+Laporte,HUDSON,County Commissioner District 2,,DEM,Mike Kellems,158,27,110,295
+Laporte,HUDSON,County Commissioner District 3,,REP,Joe Haney,332,24,190,546
+Laporte,HUDSON,County Commissioner District 3,,DEM,Randy Novak,165,29,118,312
+Laporte,HUDSON,County Council Member At Large,,REP,Brett H. Kessler,289,19,164,472
+Laporte,HUDSON,County Council Member At Large,,REP,Adam Koronka,223,13,138,374
+Laporte,HUDSON,County Council Member At Large,,REP,Heather Oake,253,16,150,419
+Laporte,HUDSON,County Council Member At Large,,DEM,Scott (Scotty) Ford,126,22,88,236
+Laporte,HUDSON,County Council Member At Large,,DEM,Mike Mollenhauer,171,24,103,298
+Laporte,HUDSON,County Council Member At Large,,DEM,Johnny Stimley,112,24,71,207
+Laporte,HUDSON,New Prairie United School Corp At Lg,,,Jill Smith,246,27,151,424
+Laporte,HUDSON,New Prairie United School Corp At Lg,,,Mike Yacullo,195,18,98,311
+Laporte,HUDSON,New Prairie United School Corp Dist 1,,,Rich Shail,362,27,212,601
+Laporte,HUDSON,New Prairie United School Corp Dist 3,,,Phillip J. King,205,18,125,348
+Laporte,HUDSON,New Prairie United School Corp Dist 3,,,Andrew Oake,197,21,109,327
+Laporte,HUDSON,IN Supreme Court-Rush,,,Yes,296,31,172,499
+Laporte,HUDSON,IN Supreme Court-Rush,,,No,132,14,76,222
+Laporte,HUDSON,IN Supreme Court-Massa,,,Yes,282,26,173,481
+Laporte,HUDSON,IN Supreme Court-Massa,,,No,143,18,71,232
+Laporte,HUDSON,IN Supreme Court-Molter,,,Yes,291,29,166,486
+Laporte,HUDSON,IN Supreme Court-Molter,,,No,135,16,75,226
+Laporte,HUDSON,Court of Appeals Dist 4-Pyle III,,,Yes,280,28,162,470
+Laporte,HUDSON,Court of Appeals Dist 4-Pyle III,,,No,145,15,81,241
+Laporte,HUDSON,Straight Party,,DEM,Democratic Party,,,,118
+Laporte,HUDSON,Straight Party,,REP,Republican Party,,,,265
+Laporte,JOHNSON,Ballots Cast,,,,97,1,9,107
+Laporte,JOHNSON,Registered Voters,,,,,,,148
+Laporte,JOHNSON,Public Question-Const Amendment,,,Yes,55,0,4,59
+Laporte,JOHNSON,Public Question-Const Amendment,,,No,35,1,5,41
+Laporte,JOHNSON,President and Vice-President of the U.S.,,REP,Trump \ Vance,62,0,5,67
+Laporte,JOHNSON,President and Vice-President of the U.S.,,DEM,Harris \ Walz,28,1,2,31
+Laporte,JOHNSON,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,2,0,0,2
+Laporte,JOHNSON,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,2,0,2,4
+Laporte,JOHNSON,President and Vice-President of the U.S.,,,Write-In,0,0,0,0
+Laporte,JOHNSON,United States Senator,,REP,Jim Banks,60,0,6,66
+Laporte,JOHNSON,United States Senator,,DEM,Valerie McCray,27,1,2,30
+Laporte,JOHNSON,United States Senator,,LIB,Andrew Horning,7,0,1,8
+Laporte,JOHNSON,United States Senator,,,Write-In,0,0,0,0
+Laporte,JOHNSON,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,49,0,4,53
+Laporte,JOHNSON,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,34,1,2,37
+Laporte,JOHNSON,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,10,0,3,13
+Laporte,JOHNSON,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,JOHNSON,Attorney General,,REP,Todd Rokita,63,0,6,69
+Laporte,JOHNSON,Attorney General,,DEM,Destiny Wells,31,1,3,35
+Laporte,JOHNSON,United States Representative,2,REP,Rudy Yakym,60,0,6,66
+Laporte,JOHNSON,United States Representative,2,DEM,Lori A. Camp,28,1,2,31
+Laporte,JOHNSON,United States Representative,2,LIB,William E. Henry,8,0,1,9
+Laporte,JOHNSON,United States Representative,2,,Write-In,0,0,0,0
+Laporte,JOHNSON,State Senator District 8,,REP,Mike Bohacek,67,0,6,73
+Laporte,JOHNSON,State Senator District 8,,DEM,Leon P. Smith,26,1,3,30
+Laporte,JOHNSON,State Representative,20,REP,Jim Pressel,75,1,7,83
+Laporte,JOHNSON,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,73,1,5,79
+Laporte,JOHNSON,Circuit Court Clerk,,REP,Heather Stevens,62,0,6,68
+Laporte,JOHNSON,Circuit Court Clerk,,DEM,Angela Henzman,32,1,3,36
+Laporte,JOHNSON,County Auditor,,REP,Mike Rosenbaum,76,1,6,83
+Laporte,JOHNSON,County Recorder,,REP,Elzbieta (Ela) Bilderback,65,0,7,72
+Laporte,JOHNSON,County Recorder,,DEM,Matthew Sikorski,31,1,2,34
+Laporte,JOHNSON,County Treasurer,,REP,Dan Barenie,61,0,6,67
+Laporte,JOHNSON,County Treasurer,,DEM,Joie Winski,33,1,3,37
+Laporte,JOHNSON,County Coroner,,REP,Lynn Swanson,65,0,6,71
+Laporte,JOHNSON,County Coroner,,DEM,Mark P. Baker,28,1,3,32
+Laporte,JOHNSON,County Surveyor,,REP,John Matwyshyn,59,0,7,66
+Laporte,JOHNSON,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,35,1,2,38
+Laporte,JOHNSON,County Commissioner District 2,,REP,Steve Holifield,69,0,5,74
+Laporte,JOHNSON,County Commissioner District 2,,DEM,Mike Kellems,25,1,3,29
+Laporte,JOHNSON,County Commissioner District 3,,REP,Joe Haney,57,0,6,63
+Laporte,JOHNSON,County Commissioner District 3,,DEM,Randy Novak,37,1,3,41
+Laporte,JOHNSON,County Council Member At Large,,REP,Brett H. Kessler,63,0,6,69
+Laporte,JOHNSON,County Council Member At Large,,REP,Adam Koronka,45,0,4,49
+Laporte,JOHNSON,County Council Member At Large,,REP,Heather Oake,46,0,4,50
+Laporte,JOHNSON,County Council Member At Large,,DEM,Scott (Scotty) Ford,22,1,3,26
+Laporte,JOHNSON,County Council Member At Large,,DEM,Mike Mollenhauer,36,1,3,40
+Laporte,JOHNSON,County Council Member At Large,,DEM,Johnny Stimley,14,1,3,18
+Laporte,JOHNSON,John Glenn School Board Johnson Township,,,Ryan Knowlton,76,1,6,83
+Laporte,JOHNSON,John Glenn School Board Liberty Township,,,Christian L. Mattix,64,1,6,71
+Laporte,JOHNSON,John Glenn School Board Polk Township,,,Jared Egger,71,1,5,77
+Laporte,JOHNSON,IN Supreme Court-Rush,,,Yes,54,0,5,59
+Laporte,JOHNSON,IN Supreme Court-Rush,,,No,31,1,4,36
+Laporte,JOHNSON,IN Supreme Court-Massa,,,Yes,58,0,5,63
+Laporte,JOHNSON,IN Supreme Court-Massa,,,No,27,1,4,32
+Laporte,JOHNSON,IN Supreme Court-Molter,,,Yes,54,0,4,58
+Laporte,JOHNSON,IN Supreme Court-Molter,,,No,30,1,4,35
+Laporte,JOHNSON,Court of Appeals Dist 4-Pyle III,,,Yes,52,1,4,57
+Laporte,JOHNSON,Court of Appeals Dist 4-Pyle III,,,No,31,0,4,35
+Laporte,JOHNSON,Straight Party,,DEM,Democratic Party,,,,14
+Laporte,JOHNSON,Straight Party,,REP,Republican Party,,,,29
+Laporte,KANKAKEE 01,Ballots Cast,,,,511,46,523,1080
+Laporte,KANKAKEE 01,Registered Voters,,,,,,,1554
+Laporte,KANKAKEE 01,Public Question-Const Amendment,,,Yes,250,17,239,506
+Laporte,KANKAKEE 01,Public Question-Const Amendment,,,No,193,21,230,444
+Laporte,KANKAKEE 01,President and Vice-President of the U.S.,,REP,Trump \ Vance,355,14,314,683
+Laporte,KANKAKEE 01,President and Vice-President of the U.S.,,DEM,Harris \ Walz,144,27,192,363
+Laporte,KANKAKEE 01,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,3,1,1,5
+Laporte,KANKAKEE 01,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,7,2,7,16
+Laporte,KANKAKEE 01,President and Vice-President of the U.S.,,,Write-In,0,0,3,3
+Laporte,KANKAKEE 01,United States Senator,,REP,Jim Banks,323,17,308,648
+Laporte,KANKAKEE 01,United States Senator,,DEM,Valerie McCray,132,27,178,337
+Laporte,KANKAKEE 01,United States Senator,,LIB,Andrew Horning,14,1,9,24
+Laporte,KANKAKEE 01,United States Senator,,,Write-In,0,0,0,0
+Laporte,KANKAKEE 01,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,289,13,295,597
+Laporte,KANKAKEE 01,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,161,28,189,378
+Laporte,KANKAKEE 01,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,29,2,16,47
+Laporte,KANKAKEE 01,Governor And Lieutenant Governor,,,Write-In,1,0,0,1
+Laporte,KANKAKEE 01,Attorney General,,REP,Todd Rokita,337,14,320,671
+Laporte,KANKAKEE 01,Attorney General,,DEM,Destiny Wells,145,30,188,363
+Laporte,KANKAKEE 01,United States Representative,2,REP,Rudy Yakym,322,16,307,645
+Laporte,KANKAKEE 01,United States Representative,2,DEM,Lori A. Camp,135,27,185,347
+Laporte,KANKAKEE 01,United States Representative,2,LIB,William E. Henry,24,2,14,40
+Laporte,KANKAKEE 01,United States Representative,2,,Write-In,0,0,0,0
+Laporte,KANKAKEE 01,State Senator District 8,,REP,Mike Bohacek,363,21,339,723
+Laporte,KANKAKEE 01,State Senator District 8,,DEM,Leon P. Smith,121,23,166,310
+Laporte,KANKAKEE 01,State Representative,20,REP,Jim Pressel,388,31,365,784
+Laporte,KANKAKEE 01,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,371,33,348,752
+Laporte,KANKAKEE 01,Circuit Court Clerk,,REP,Heather Stevens,320,19,312,651
+Laporte,KANKAKEE 01,Circuit Court Clerk,,DEM,Angela Henzman,145,27,182,354
+Laporte,KANKAKEE 01,County Auditor,,REP,Mike Rosenbaum,393,32,364,789
+Laporte,KANKAKEE 01,County Recorder,,REP,Elzbieta (Ela) Bilderback,316,15,302,633
+Laporte,KANKAKEE 01,County Recorder,,DEM,Matthew Sikorski,152,29,201,382
+Laporte,KANKAKEE 01,County Treasurer,,REP,Dan Barenie,319,14,306,639
+Laporte,KANKAKEE 01,County Treasurer,,DEM,Joie Winski,158,30,204,392
+Laporte,KANKAKEE 01,County Coroner,,REP,Lynn Swanson,341,16,322,679
+Laporte,KANKAKEE 01,County Coroner,,DEM,Mark P. Baker,135,28,188,351
+Laporte,KANKAKEE 01,County Surveyor,,REP,John Matwyshyn,288,15,279,582
+Laporte,KANKAKEE 01,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,179,28,223,430
+Laporte,KANKAKEE 01,County Commissioner District 2,,REP,Steve Holifield,313,18,296,627
+Laporte,KANKAKEE 01,County Commissioner District 2,,DEM,Mike Kellems,170,26,211,407
+Laporte,KANKAKEE 01,County Commissioner District 3,,REP,Joe Haney,291,15,295,601
+Laporte,KANKAKEE 01,County Commissioner District 3,,DEM,Randy Novak,190,29,206,425
+Laporte,KANKAKEE 01,County Council Member At Large,,REP,Brett H. Kessler,285,17,264,566
+Laporte,KANKAKEE 01,County Council Member At Large,,REP,Adam Koronka,237,14,223,474
+Laporte,KANKAKEE 01,County Council Member At Large,,REP,Heather Oake,224,13,225,462
+Laporte,KANKAKEE 01,County Council Member At Large,,DEM,Scott (Scotty) Ford,131,20,146,297
+Laporte,KANKAKEE 01,County Council Member At Large,,DEM,Mike Mollenhauer,157,26,197,380
+Laporte,KANKAKEE 01,County Council Member At Large,,DEM,Johnny Stimley,105,18,149,272
+Laporte,KANKAKEE 01,New Prairie United School Corp At Lg,,,Jill Smith,275,21,275,571
+Laporte,KANKAKEE 01,New Prairie United School Corp At Lg,,,Mike Yacullo,124,11,92,227
+Laporte,KANKAKEE 01,New Prairie United School Corp Dist 1,,,Rich Shail,341,30,332,703
+Laporte,KANKAKEE 01,New Prairie United School Corp Dist 3,,,Phillip J. King,211,12,195,418
+Laporte,KANKAKEE 01,New Prairie United School Corp Dist 3,,,Andrew Oake,170,18,165,353
+Laporte,KANKAKEE 01,IN Supreme Court-Rush,,,Yes,290,17,270,577
+Laporte,KANKAKEE 01,IN Supreme Court-Rush,,,No,119,20,146,285
+Laporte,KANKAKEE 01,IN Supreme Court-Massa,,,Yes,283,15,257,555
+Laporte,KANKAKEE 01,IN Supreme Court-Massa,,,No,121,22,150,293
+Laporte,KANKAKEE 01,IN Supreme Court-Molter,,,Yes,289,14,252,555
+Laporte,KANKAKEE 01,IN Supreme Court-Molter,,,No,117,23,157,297
+Laporte,KANKAKEE 01,Court of Appeals Dist 4-Pyle III,,,Yes,287,19,257,563
+Laporte,KANKAKEE 01,Court of Appeals Dist 4-Pyle III,,,No,116,18,153,287
+Laporte,KANKAKEE 01,Straight Party,,DEM,Democratic Party,,,,113
+Laporte,KANKAKEE 01,Straight Party,,REP,Republican Party,,,,250
+Laporte,KANKAKEE 02,Ballots Cast,,,,482,23,446,951
+Laporte,KANKAKEE 02,Registered Voters,,,,,,,1413
+Laporte,KANKAKEE 02,Public Question-Const Amendment,,,Yes,260,8,199,467
+Laporte,KANKAKEE 02,Public Question-Const Amendment,,,No,179,7,192,378
+Laporte,KANKAKEE 02,President and Vice-President of the U.S.,,REP,Trump \ Vance,344,13,303,660
+Laporte,KANKAKEE 02,President and Vice-President of the U.S.,,DEM,Harris \ Walz,115,8,137,260
+Laporte,KANKAKEE 02,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,8,0,1,9
+Laporte,KANKAKEE 02,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,10,0,3,13
+Laporte,KANKAKEE 02,President and Vice-President of the U.S.,,,Write-In,1,0,0,1
+Laporte,KANKAKEE 02,United States Senator,,REP,Jim Banks,318,15,283,616
+Laporte,KANKAKEE 02,United States Senator,,DEM,Valerie McCray,110,7,128,245
+Laporte,KANKAKEE 02,United States Senator,,LIB,Andrew Horning,21,0,9,30
+Laporte,KANKAKEE 02,United States Senator,,,Write-In,0,0,0,0
+Laporte,KANKAKEE 02,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,284,10,257,551
+Laporte,KANKAKEE 02,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,138,11,146,295
+Laporte,KANKAKEE 02,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,40,1,20,61
+Laporte,KANKAKEE 02,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,KANKAKEE 02,Attorney General,,REP,Todd Rokita,341,12,298,651
+Laporte,KANKAKEE 02,Attorney General,,DEM,Destiny Wells,119,10,135,264
+Laporte,KANKAKEE 02,United States Representative,2,REP,Rudy Yakym,306,13,282,601
+Laporte,KANKAKEE 02,United States Representative,2,DEM,Lori A. Camp,114,9,136,259
+Laporte,KANKAKEE 02,United States Representative,2,LIB,William E. Henry,31,0,8,39
+Laporte,KANKAKEE 02,United States Representative,2,,Write-In,1,0,0,1
+Laporte,KANKAKEE 02,State Senator District 8,,REP,Mike Bohacek,358,15,305,678
+Laporte,KANKAKEE 02,State Senator District 8,,DEM,Leon P. Smith,99,7,124,230
+Laporte,KANKAKEE 02,State Representative,20,REP,Jim Pressel,387,20,328,735
+Laporte,KANKAKEE 02,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,372,20,311,703
+Laporte,KANKAKEE 02,Circuit Court Clerk,,REP,Heather Stevens,335,12,285,632
+Laporte,KANKAKEE 02,Circuit Court Clerk,,DEM,Angela Henzman,111,9,137,257
+Laporte,KANKAKEE 02,County Auditor,,REP,Mike Rosenbaum,392,19,333,744
+Laporte,KANKAKEE 02,County Recorder,,REP,Elzbieta (Ela) Bilderback,305,13,280,598
+Laporte,KANKAKEE 02,County Recorder,,DEM,Matthew Sikorski,144,9,141,294
+Laporte,KANKAKEE 02,County Treasurer,,REP,Dan Barenie,312,11,278,601
+Laporte,KANKAKEE 02,County Treasurer,,DEM,Joie Winski,147,11,146,304
+Laporte,KANKAKEE 02,County Coroner,,REP,Lynn Swanson,337,10,288,635
+Laporte,KANKAKEE 02,County Coroner,,DEM,Mark P. Baker,119,12,142,273
+Laporte,KANKAKEE 02,County Surveyor,,REP,John Matwyshyn,293,13,257,563
+Laporte,KANKAKEE 02,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,149,8,158,315
+Laporte,KANKAKEE 02,County Commissioner District 2,,REP,Steve Holifield,312,12,273,597
+Laporte,KANKAKEE 02,County Commissioner District 2,,DEM,Mike Kellems,145,10,153,308
+Laporte,KANKAKEE 02,County Commissioner District 3,,REP,Joe Haney,302,9,255,566
+Laporte,KANKAKEE 02,County Commissioner District 3,,DEM,Randy Novak,151,13,175,339
+Laporte,KANKAKEE 02,County Council Member At Large,,REP,Brett H. Kessler,275,12,240,527
+Laporte,KANKAKEE 02,County Council Member At Large,,REP,Adam Koronka,241,11,218,470
+Laporte,KANKAKEE 02,County Council Member At Large,,REP,Heather Oake,226,9,191,426
+Laporte,KANKAKEE 02,County Council Member At Large,,DEM,Scott (Scotty) Ford,98,7,112,217
+Laporte,KANKAKEE 02,County Council Member At Large,,DEM,Mike Mollenhauer,146,11,150,307
+Laporte,KANKAKEE 02,County Council Member At Large,,DEM,Johnny Stimley,96,7,98,201
+Laporte,KANKAKEE 02,New Prairie United School Corp At Lg,,,Jill Smith,275,15,225,515
+Laporte,KANKAKEE 02,New Prairie United School Corp At Lg,,,Mike Yacullo,136,4,119,259
+Laporte,KANKAKEE 02,New Prairie United School Corp Dist 1,,,Rich Shail,359,16,288,663
+Laporte,KANKAKEE 02,New Prairie United School Corp Dist 3,,,Phillip J. King,231,13,188,432
+Laporte,KANKAKEE 02,New Prairie United School Corp Dist 3,,,Andrew Oake,162,5,140,307
+Laporte,KANKAKEE 02,IN Supreme Court-Rush,,,Yes,273,15,227,515
+Laporte,KANKAKEE 02,IN Supreme Court-Rush,,,No,128,2,120,250
+Laporte,KANKAKEE 02,IN Supreme Court-Massa,,,Yes,267,14,219,500
+Laporte,KANKAKEE 02,IN Supreme Court-Massa,,,No,131,4,124,259
+Laporte,KANKAKEE 02,IN Supreme Court-Molter,,,Yes,270,15,219,504
+Laporte,KANKAKEE 02,IN Supreme Court-Molter,,,No,129,3,123,255
+Laporte,KANKAKEE 02,Court of Appeals Dist 4-Pyle III,,,Yes,272,14,224,510
+Laporte,KANKAKEE 02,Court of Appeals Dist 4-Pyle III,,,No,125,4,116,245
+Laporte,KANKAKEE 02,Straight Party,,DEM,Democratic Party,,,,83
+Laporte,KANKAKEE 02,Straight Party,,REP,Republican Party,,,,220
+Laporte,KINGSBURY,Ballots Cast,,,,352,7,31,390
+Laporte,KINGSBURY,Registered Voters,,,,,,,153
+Laporte,KINGSBURY,Public Question-Const Amendment,,,Yes,162,0,12,174
+Laporte,KINGSBURY,Public Question-Const Amendment,,,No,118,6,12,136
+Laporte,KINGSBURY,President and Vice-President of the U.S.,,REP,Trump \ Vance,260,5,16,281
+Laporte,KINGSBURY,President and Vice-President of the U.S.,,DEM,Harris \ Walz,77,1,14,92
+Laporte,KINGSBURY,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,3,0,0,3
+Laporte,KINGSBURY,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,6,0,0,6
+Laporte,KINGSBURY,President and Vice-President of the U.S.,,,Write-In,0,0,0,0
+Laporte,KINGSBURY,United States Senator,,REP,Jim Banks,244,6,16,266
+Laporte,KINGSBURY,United States Senator,,DEM,Valerie McCray,74,0,13,87
+Laporte,KINGSBURY,United States Senator,,LIB,Andrew Horning,12,0,0,12
+Laporte,KINGSBURY,United States Senator,,,Write-In,0,0,0,0
+Laporte,KINGSBURY,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,222,4,15,241
+Laporte,KINGSBURY,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,89,0,13,102
+Laporte,KINGSBURY,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,20,1,1,22
+Laporte,KINGSBURY,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,KINGSBURY,Attorney General,,REP,Todd Rokita,247,5,19,271
+Laporte,KINGSBURY,Attorney General,,DEM,Destiny Wells,91,0,11,102
+Laporte,KINGSBURY,United States Representative,2,REP,Rudy Yakym,249,5,16,270
+Laporte,KINGSBURY,United States Representative,2,DEM,Lori A. Camp,72,2,12,86
+Laporte,KINGSBURY,United States Representative,2,LIB,William E. Henry,15,0,2,17
+Laporte,KINGSBURY,United States Representative,2,,Write-In,0,0,0,0
+Laporte,KINGSBURY,State Senator District 8,,REP,Mike Bohacek,268,6,19,293
+Laporte,KINGSBURY,State Senator District 8,,DEM,Leon P. Smith,70,0,11,81
+Laporte,KINGSBURY,State Representative,20,REP,Jim Pressel,292,7,23,322
+Laporte,KINGSBURY,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,278,6,23,307
+Laporte,KINGSBURY,Circuit Court Clerk,,REP,Heather Stevens,250,5,16,271
+Laporte,KINGSBURY,Circuit Court Clerk,,DEM,Angela Henzman,76,1,13,90
+Laporte,KINGSBURY,County Auditor,,REP,Mike Rosenbaum,297,7,24,328
+Laporte,KINGSBURY,County Recorder,,REP,Elzbieta (Ela) Bilderback,240,6,13,259
+Laporte,KINGSBURY,County Recorder,,DEM,Matthew Sikorski,94,0,16,110
+Laporte,KINGSBURY,County Treasurer,,REP,Dan Barenie,234,3,15,252
+Laporte,KINGSBURY,County Treasurer,,DEM,Joie Winski,97,3,14,114
+Laporte,KINGSBURY,County Coroner,,REP,Lynn Swanson,252,3,15,270
+Laporte,KINGSBURY,County Coroner,,DEM,Mark P. Baker,85,2,14,101
+Laporte,KINGSBURY,County Surveyor,,REP,John Matwyshyn,224,4,14,242
+Laporte,KINGSBURY,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,105,1,14,120
+Laporte,KINGSBURY,County Commissioner District 2,,REP,Steve Holifield,233,1,16,250
+Laporte,KINGSBURY,County Commissioner District 2,,DEM,Mike Kellems,100,4,14,118
+Laporte,KINGSBURY,County Commissioner District 3,,REP,Joe Haney,233,4,15,252
+Laporte,KINGSBURY,County Commissioner District 3,,DEM,Randy Novak,98,2,13,113
+Laporte,KINGSBURY,County Council Member At Large,,REP,Brett H. Kessler,203,5,9,217
+Laporte,KINGSBURY,County Council Member At Large,,REP,Adam Koronka,167,2,10,179
+Laporte,KINGSBURY,County Council Member At Large,,REP,Heather Oake,157,5,10,172
+Laporte,KINGSBURY,County Council Member At Large,,DEM,Scott (Scotty) Ford,73,0,17,90
+Laporte,KINGSBURY,County Council Member At Large,,DEM,Mike Mollenhauer,91,4,18,113
+Laporte,KINGSBURY,County Council Member At Large,,DEM,Johnny Stimley,66,0,12,78
+Laporte,KINGSBURY,Laporte Community School Board At Large,,,Jim Arnold,172,4,18,194
+Laporte,KINGSBURY,Laporte Community School Board At Large,,,Monica L. Beaty,142,0,12,154
+Laporte,KINGSBURY,Laporte Community School Board At Large,,,Maria L. Ria Carpenter,118,1,10,129
+Laporte,KINGSBURY,Laporte Community School Board At Large,,,Ed Gilliland,110,5,17,132
+Laporte,KINGSBURY,Laporte Community School Board At Large,,,Tucker King,152,3,10,165
+Laporte,KINGSBURY,IN Supreme Court-Rush,,,Yes,205,7,18,230
+Laporte,KINGSBURY,IN Supreme Court-Rush,,,No,66,0,3,69
+Laporte,KINGSBURY,IN Supreme Court-Massa,,,Yes,197,7,17,221
+Laporte,KINGSBURY,IN Supreme Court-Massa,,,No,72,0,4,76
+Laporte,KINGSBURY,IN Supreme Court-Molter,,,Yes,197,7,16,220
+Laporte,KINGSBURY,IN Supreme Court-Molter,,,No,74,0,5,79
+Laporte,KINGSBURY,Court of Appeals Dist 4-Pyle III,,,Yes,201,7,16,224
+Laporte,KINGSBURY,Court of Appeals Dist 4-Pyle III,,,No,67,0,5,72
+Laporte,KINGSBURY,Straight Party,,DEM,Democratic Party,,,,24
+Laporte,KINGSBURY,Straight Party,,REP,Republican Party,,,,110
+Laporte,KINGSFORD HEIGHTS,Ballots Cast,,,,345,13,139,497
+Laporte,KINGSFORD HEIGHTS,Registered Voters,,,,,,,902
+Laporte,KINGSFORD HEIGHTS,Public Question-Const Amendment,,,Yes,168,4,58,230
+Laporte,KINGSFORD HEIGHTS,Public Question-Const Amendment,,,No,157,7,63,227
+Laporte,KINGSFORD HEIGHTS,President and Vice-President of the U.S.,,REP,Trump \ Vance,220,7,70,297
+Laporte,KINGSFORD HEIGHTS,President and Vice-President of the U.S.,,DEM,Harris \ Walz,119,5,65,189
+Laporte,KINGSFORD HEIGHTS,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,3,0,0,3
+Laporte,KINGSFORD HEIGHTS,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,3,0,2,5
+Laporte,KINGSFORD HEIGHTS,President and Vice-President of the U.S.,,,Write-In,0,0,0,0
+Laporte,KINGSFORD HEIGHTS,United States Senator,,REP,Jim Banks,201,6,61,268
+Laporte,KINGSFORD HEIGHTS,United States Senator,,DEM,Valerie McCray,113,6,63,182
+Laporte,KINGSFORD HEIGHTS,United States Senator,,LIB,Andrew Horning,8,1,2,11
+Laporte,KINGSFORD HEIGHTS,United States Senator,,,Write-In,0,0,0,0
+Laporte,KINGSFORD HEIGHTS,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,180,7,63,250
+Laporte,KINGSFORD HEIGHTS,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,120,6,65,191
+Laporte,KINGSFORD HEIGHTS,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,21,0,3,24
+Laporte,KINGSFORD HEIGHTS,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,KINGSFORD HEIGHTS,Attorney General,,REP,Todd Rokita,206,7,66,279
+Laporte,KINGSFORD HEIGHTS,Attorney General,,DEM,Destiny Wells,123,6,63,192
+Laporte,KINGSFORD HEIGHTS,United States Representative,2,REP,Rudy Yakym,205,7,62,274
+Laporte,KINGSFORD HEIGHTS,United States Representative,2,DEM,Lori A. Camp,123,5,64,192
+Laporte,KINGSFORD HEIGHTS,United States Representative,2,LIB,William E. Henry,8,1,3,12
+Laporte,KINGSFORD HEIGHTS,United States Representative,2,,Write-In,0,0,0,0
+Laporte,KINGSFORD HEIGHTS,State Senator District 8,,REP,Mike Bohacek,224,8,65,297
+Laporte,KINGSFORD HEIGHTS,State Senator District 8,,DEM,Leon P. Smith,107,5,65,177
+Laporte,KINGSFORD HEIGHTS,State Representative,20,REP,Jim Pressel,243,7,80,330
+Laporte,KINGSFORD HEIGHTS,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,232,9,75,316
+Laporte,KINGSFORD HEIGHTS,Circuit Court Clerk,,REP,Heather Stevens,205,7,63,275
+Laporte,KINGSFORD HEIGHTS,Circuit Court Clerk,,DEM,Angela Henzman,115,6,66,187
+Laporte,KINGSFORD HEIGHTS,County Auditor,,REP,Mike Rosenbaum,242,8,84,334
+Laporte,KINGSFORD HEIGHTS,County Recorder,,REP,Elzbieta (Ela) Bilderback,206,7,63,276
+Laporte,KINGSFORD HEIGHTS,County Recorder,,DEM,Matthew Sikorski,121,6,68,195
+Laporte,KINGSFORD HEIGHTS,County Treasurer,,REP,Dan Barenie,203,7,58,268
+Laporte,KINGSFORD HEIGHTS,County Treasurer,,DEM,Joie Winski,127,6,73,206
+Laporte,KINGSFORD HEIGHTS,County Coroner,,REP,Lynn Swanson,216,7,62,285
+Laporte,KINGSFORD HEIGHTS,County Coroner,,DEM,Mark P. Baker,115,6,68,189
+Laporte,KINGSFORD HEIGHTS,County Surveyor,,REP,John Matwyshyn,190,7,61,258
+Laporte,KINGSFORD HEIGHTS,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,131,6,69,206
+Laporte,KINGSFORD HEIGHTS,County Commissioner District 2,,REP,Steve Holifield,198,7,56,261
+Laporte,KINGSFORD HEIGHTS,County Commissioner District 2,,DEM,Mike Kellems,131,6,76,213
+Laporte,KINGSFORD HEIGHTS,County Commissioner District 3,,REP,Joe Haney,205,8,67,280
+Laporte,KINGSFORD HEIGHTS,County Commissioner District 3,,DEM,Randy Novak,121,5,63,189
+Laporte,KINGSFORD HEIGHTS,County Council Member At Large,,REP,Brett H. Kessler,151,7,46,204
+Laporte,KINGSFORD HEIGHTS,County Council Member At Large,,REP,Adam Koronka,150,7,46,203
+Laporte,KINGSFORD HEIGHTS,County Council Member At Large,,REP,Heather Oake,142,7,41,190
+Laporte,KINGSFORD HEIGHTS,County Council Member At Large,,DEM,Scott (Scotty) Ford,88,4,57,149
+Laporte,KINGSFORD HEIGHTS,County Council Member At Large,,DEM,Mike Mollenhauer,131,6,63,200
+Laporte,KINGSFORD HEIGHTS,County Council Member At Large,,DEM,Johnny Stimley,81,5,48,134
+Laporte,KINGSFORD HEIGHTS,Laporte Community School Board At Large,,,Jim Arnold,142,8,56,206
+Laporte,KINGSFORD HEIGHTS,Laporte Community School Board At Large,,,Monica L. Beaty,221,11,95,327
+Laporte,KINGSFORD HEIGHTS,Laporte Community School Board At Large,,,Maria L. Ria Carpenter,116,3,57,176
+Laporte,KINGSFORD HEIGHTS,Laporte Community School Board At Large,,,Ed Gilliland,107,3,39,149
+Laporte,KINGSFORD HEIGHTS,Laporte Community School Board At Large,,,Tucker King,152,6,66,224
+Laporte,KINGSFORD HEIGHTS,IN Supreme Court-Rush,,,Yes,197,9,74,280
+Laporte,KINGSFORD HEIGHTS,IN Supreme Court-Rush,,,No,98,3,47,148
+Laporte,KINGSFORD HEIGHTS,IN Supreme Court-Massa,,,Yes,183,9,68,260
+Laporte,KINGSFORD HEIGHTS,IN Supreme Court-Massa,,,No,110,2,47,159
+Laporte,KINGSFORD HEIGHTS,IN Supreme Court-Molter,,,Yes,182,9,72,263
+Laporte,KINGSFORD HEIGHTS,IN Supreme Court-Molter,,,No,109,3,46,158
+Laporte,KINGSFORD HEIGHTS,Court of Appeals Dist 4-Pyle III,,,Yes,179,9,69,257
+Laporte,KINGSFORD HEIGHTS,Court of Appeals Dist 4-Pyle III,,,No,112,3,49,164
+Laporte,KINGSFORD HEIGHTS,Straight Party,,DEM,Democratic Party,,,,67
+Laporte,KINGSFORD HEIGHTS,Straight Party,,REP,Republican Party,,,,119
+Laporte,La CROSSE,Ballots Cast,,,,175,7,67,249
+Laporte,La CROSSE,Registered Voters,,,,,,,399
+Laporte,La CROSSE,Public Question-Const Amendment,,,Yes,88,1,24,113
+Laporte,La CROSSE,Public Question-Const Amendment,,,No,76,3,27,106
+Laporte,La CROSSE,President and Vice-President of the U.S.,,REP,Trump \ Vance,127,2,43,172
+Laporte,La CROSSE,President and Vice-President of the U.S.,,DEM,Harris \ Walz,44,5,23,72
+Laporte,La CROSSE,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,0,0,0,0
+Laporte,La CROSSE,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,1,0,0,1
+Laporte,La CROSSE,President and Vice-President of the U.S.,,,Write-In,0,0,0,0
+Laporte,La CROSSE,United States Senator,,REP,Jim Banks,122,2,36,160
+Laporte,La CROSSE,United States Senator,,DEM,Valerie McCray,39,5,24,68
+Laporte,La CROSSE,United States Senator,,LIB,Andrew Horning,2,0,0,2
+Laporte,La CROSSE,United States Senator,,,Write-In,0,0,0,0
+Laporte,La CROSSE,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,117,2,34,153
+Laporte,La CROSSE,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,48,4,25,77
+Laporte,La CROSSE,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,1,1,3,5
+Laporte,La CROSSE,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,La CROSSE,Attorney General,,REP,Todd Rokita,122,3,38,163
+Laporte,La CROSSE,Attorney General,,DEM,Destiny Wells,44,4,24,72
+Laporte,La CROSSE,United States Representative,2,REP,Rudy Yakym,124,2,38,164
+Laporte,La CROSSE,United States Representative,2,DEM,Lori A. Camp,41,4,25,70
+Laporte,La CROSSE,United States Representative,2,LIB,William E. Henry,1,1,0,2
+Laporte,La CROSSE,United States Representative,2,,Write-In,0,0,0,0
+Laporte,La CROSSE,State Senator District 8,,REP,Mike Bohacek,125,3,38,166
+Laporte,La CROSSE,State Senator District 8,,DEM,Leon P. Smith,39,4,22,65
+Laporte,La CROSSE,State Representative,20,REP,Jim Pressel,140,4,44,188
+Laporte,La CROSSE,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,131,4,46,181
+Laporte,La CROSSE,Circuit Court Clerk,,REP,Heather Stevens,122,3,34,159
+Laporte,La CROSSE,Circuit Court Clerk,,DEM,Angela Henzman,41,4,27,72
+Laporte,La CROSSE,County Auditor,,REP,Mike Rosenbaum,139,4,46,189
+Laporte,La CROSSE,County Recorder,,REP,Elzbieta (Ela) Bilderback,120,3,35,158
+Laporte,La CROSSE,County Recorder,,DEM,Matthew Sikorski,44,4,26,74
+Laporte,La CROSSE,County Treasurer,,REP,Dan Barenie,122,3,36,161
+Laporte,La CROSSE,County Treasurer,,DEM,Joie Winski,42,4,25,71
+Laporte,La CROSSE,County Coroner,,REP,Lynn Swanson,126,4,40,170
+Laporte,La CROSSE,County Coroner,,DEM,Mark P. Baker,40,3,21,64
+Laporte,La CROSSE,County Surveyor,,REP,John Matwyshyn,114,3,35,152
+Laporte,La CROSSE,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,47,4,25,76
+Laporte,La CROSSE,County Commissioner District 2,,REP,Steve Holifield,104,2,34,140
+Laporte,La CROSSE,County Commissioner District 2,,DEM,Mike Kellems,63,5,27,95
+Laporte,La CROSSE,County Commissioner District 3,,REP,Joe Haney,115,3,35,153
+Laporte,La CROSSE,County Commissioner District 3,,DEM,Randy Novak,50,4,26,80
+Laporte,La CROSSE,County Council Member At Large,,REP,Brett H. Kessler,97,3,31,131
+Laporte,La CROSSE,County Council Member At Large,,REP,Adam Koronka,93,2,28,123
+Laporte,La CROSSE,County Council Member At Large,,REP,Heather Oake,80,2,26,108
+Laporte,La CROSSE,County Council Member At Large,,DEM,Scott (Scotty) Ford,32,4,21,57
+Laporte,La CROSSE,County Council Member At Large,,DEM,Mike Mollenhauer,45,5,19,69
+Laporte,La CROSSE,County Council Member At Large,,DEM,Johnny Stimley,30,3,17,50
+Laporte,La CROSSE,IN Supreme Court-Rush,,,Yes,99,2,30,131
+Laporte,La CROSSE,IN Supreme Court-Rush,,,No,39,5,17,61
+Laporte,La CROSSE,IN Supreme Court-Massa,,,Yes,101,1,29,131
+Laporte,La CROSSE,IN Supreme Court-Massa,,,No,35,5,18,58
+Laporte,La CROSSE,IN Supreme Court-Molter,,,Yes,100,1,28,129
+Laporte,La CROSSE,IN Supreme Court-Molter,,,No,38,5,18,61
+Laporte,La CROSSE,Court of Appeals Dist 4-Pyle III,,,Yes,97,1,27,125
+Laporte,La CROSSE,Court of Appeals Dist 4-Pyle III,,,No,42,5,19,66
+Laporte,La CROSSE,Straight Party,,DEM,Democratic Party,,,,25
+Laporte,La CROSSE,Straight Party,,REP,Republican Party,,,,68
+Laporte,LINCOLN,Ballots Cast,,,,487,33,311,831
+Laporte,LINCOLN,Registered Voters,,,,,,,1270
+Laporte,LINCOLN,Public Question-Const Amendment,,,Yes,250,13,135,398
+Laporte,LINCOLN,Public Question-Const Amendment,,,No,208,16,130,354
+Laporte,LINCOLN,President and Vice-President of the U.S.,,REP,Trump \ Vance,352,16,189,557
+Laporte,LINCOLN,President and Vice-President of the U.S.,,DEM,Harris \ Walz,119,15,117,251
+Laporte,LINCOLN,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,3,1,0,4
+Laporte,LINCOLN,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,7,0,4,11
+Laporte,LINCOLN,President and Vice-President of the U.S.,,,Write-In,1,0,0,1
+Laporte,LINCOLN,United States Senator,,REP,Jim Banks,321,16,178,515
+Laporte,LINCOLN,United States Senator,,DEM,Valerie McCray,117,16,107,240
+Laporte,LINCOLN,United States Senator,,LIB,Andrew Horning,17,1,4,22
+Laporte,LINCOLN,United States Senator,,,Write-In,0,0,0,0
+Laporte,LINCOLN,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,287,17,167,471
+Laporte,LINCOLN,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,139,15,113,267
+Laporte,LINCOLN,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,38,1,9,48
+Laporte,LINCOLN,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,LINCOLN,Attorney General,,REP,Todd Rokita,329,17,183,529
+Laporte,LINCOLN,Attorney General,,DEM,Destiny Wells,136,14,110,260
+Laporte,LINCOLN,United States Representative,2,REP,Rudy Yakym,324,18,179,521
+Laporte,LINCOLN,United States Representative,2,DEM,Lori A. Camp,123,14,113,250
+Laporte,LINCOLN,United States Representative,2,LIB,William E. Henry,17,1,3,21
+Laporte,LINCOLN,United States Representative,2,,Write-In,0,0,0,0
+Laporte,LINCOLN,State Senator District 8,,REP,Mike Bohacek,360,19,197,576
+Laporte,LINCOLN,State Senator District 8,,DEM,Leon P. Smith,107,12,99,218
+Laporte,LINCOLN,State Representative,20,REP,Jim Pressel,387,20,221,628
+Laporte,LINCOLN,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,364,19,197,580
+Laporte,LINCOLN,Circuit Court Clerk,,REP,Heather Stevens,336,18,190,544
+Laporte,LINCOLN,Circuit Court Clerk,,DEM,Angela Henzman,111,13,96,220
+Laporte,LINCOLN,County Auditor,,REP,Mike Rosenbaum,394,19,211,624
+Laporte,LINCOLN,County Recorder,,REP,Elzbieta (Ela) Bilderback,323,18,174,515
+Laporte,LINCOLN,County Recorder,,DEM,Matthew Sikorski,133,13,112,258
+Laporte,LINCOLN,County Treasurer,,REP,Dan Barenie,311,16,177,504
+Laporte,LINCOLN,County Treasurer,,DEM,Joie Winski,152,14,115,281
+Laporte,LINCOLN,County Coroner,,REP,Lynn Swanson,339,15,201,555
+Laporte,LINCOLN,County Coroner,,DEM,Mark P. Baker,124,15,93,232
+Laporte,LINCOLN,County Surveyor,,REP,John Matwyshyn,290,15,171,476
+Laporte,LINCOLN,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,162,16,122,300
+Laporte,LINCOLN,County Commissioner District 2,,REP,Steve Holifield,318,16,184,518
+Laporte,LINCOLN,County Commissioner District 2,,DEM,Mike Kellems,141,15,114,270
+Laporte,LINCOLN,County Commissioner District 3,,REP,Joe Haney,310,15,175,500
+Laporte,LINCOLN,County Commissioner District 3,,DEM,Randy Novak,149,16,120,285
+Laporte,LINCOLN,County Council Member At Large,,REP,Brett H. Kessler,281,15,139,435
+Laporte,LINCOLN,County Council Member At Large,,REP,Adam Koronka,259,14,128,401
+Laporte,LINCOLN,County Council Member At Large,,REP,Heather Oake,243,15,126,384
+Laporte,LINCOLN,County Council Member At Large,,DEM,Scott (Scotty) Ford,140,12,92,244
+Laporte,LINCOLN,County Council Member At Large,,DEM,Mike Mollenhauer,159,10,110,279
+Laporte,LINCOLN,County Council Member At Large,,DEM,Johnny Stimley,88,11,89,188
+Laporte,LINCOLN,Laporte Community School Board At Large,,,Jim Arnold,270,14,156,440
+Laporte,LINCOLN,Laporte Community School Board At Large,,,Monica L. Beaty,210,16,127,353
+Laporte,LINCOLN,Laporte Community School Board At Large,,,Maria L. Ria Carpenter,211,12,105,328
+Laporte,LINCOLN,Laporte Community School Board At Large,,,Ed Gilliland,166,18,91,275
+Laporte,LINCOLN,Laporte Community School Board At Large,,,Tucker King,226,10,118,354
+Laporte,LINCOLN,IN Supreme Court-Rush,,,Yes,298,20,133,451
+Laporte,LINCOLN,IN Supreme Court-Rush,,,No,119,6,93,218
+Laporte,LINCOLN,IN Supreme Court-Massa,,,Yes,297,18,124,439
+Laporte,LINCOLN,IN Supreme Court-Massa,,,No,115,9,103,227
+Laporte,LINCOLN,IN Supreme Court-Molter,,,Yes,303,18,124,445
+Laporte,LINCOLN,IN Supreme Court-Molter,,,No,113,9,99,221
+Laporte,LINCOLN,Court of Appeals Dist 4-Pyle III,,,Yes,295,14,128,437
+Laporte,LINCOLN,Court of Appeals Dist 4-Pyle III,,,No,114,11,97,222
+Laporte,LINCOLN,Straight Party,,DEM,Democratic Party,,,,72
+Laporte,LINCOLN,Straight Party,,LIB,Libertarian Party,,,,1
+Laporte,LINCOLN,Straight Party,,REP,Republican Party,,,,216
+Laporte,LONG BEACH,Ballots Cast,,,,307,75,526,908
+Laporte,LONG BEACH,Registered Voters,,,,,,,1394
+Laporte,LONG BEACH,Public Question-Const Amendment,,,Yes,154,33,273,460
+Laporte,LONG BEACH,Public Question-Const Amendment,,,No,126,22,192,340
+Laporte,LONG BEACH,President and Vice-President of the U.S.,,REP,Trump \ Vance,143,25,232,400
+Laporte,LONG BEACH,President and Vice-President of the U.S.,,DEM,Harris \ Walz,150,49,283,482
+Laporte,LONG BEACH,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,1,0,2,3
+Laporte,LONG BEACH,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,4,0,3,7
+Laporte,LONG BEACH,President and Vice-President of the U.S.,,,Write-In,3,0,1,4
+Laporte,LONG BEACH,United States Senator,,REP,Jim Banks,149,25,234,408
+Laporte,LONG BEACH,United States Senator,,DEM,Valerie McCray,133,47,239,419
+Laporte,LONG BEACH,United States Senator,,LIB,Andrew Horning,5,0,6,11
+Laporte,LONG BEACH,United States Senator,,,Write-In,0,0,0,0
+Laporte,LONG BEACH,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,152,25,236,413
+Laporte,LONG BEACH,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,128,47,247,422
+Laporte,LONG BEACH,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,8,0,5,13
+Laporte,LONG BEACH,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,LONG BEACH,Attorney General,,REP,Todd Rokita,164,24,243,431
+Laporte,LONG BEACH,Attorney General,,DEM,Destiny Wells,123,47,240,410
+Laporte,LONG BEACH,United States Representative,1,REP,Randy Niemeyer,142,25,232,399
+Laporte,LONG BEACH,United States Representative,1,DEM,Frank J. Mrvan,149,44,270,463
+Laporte,LONG BEACH,United States Representative,1,LIB,Dakotah Miskus,7,1,4,12
+Laporte,LONG BEACH,United States Representative,1,,Write-In,1,0,0,1
+Laporte,LONG BEACH,State Representative,09,REP,Joel Florek,152,23,232,407
+Laporte,LONG BEACH,State Representative,09,DEM,Patricia A. (Pat) Boy,138,46,264,448
+Laporte,LONG BEACH,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,188,36,269,493
+Laporte,LONG BEACH,Circuit Court Clerk,,REP,Heather Stevens,158,27,250,435
+Laporte,LONG BEACH,Circuit Court Clerk,,DEM,Angela Henzman,116,43,226,385
+Laporte,LONG BEACH,County Auditor,,REP,Mike Rosenbaum,201,39,290,530
+Laporte,LONG BEACH,County Recorder,,REP,Elzbieta (Ela) Bilderback,157,27,242,426
+Laporte,LONG BEACH,County Recorder,,DEM,Matthew Sikorski,127,43,236,406
+Laporte,LONG BEACH,County Treasurer,,REP,Dan Barenie,132,25,226,383
+Laporte,LONG BEACH,County Treasurer,,DEM,Joie Winski,155,45,272,472
+Laporte,LONG BEACH,County Coroner,,REP,Lynn Swanson,173,28,255,456
+Laporte,LONG BEACH,County Coroner,,DEM,Mark P. Baker,113,41,230,384
+Laporte,LONG BEACH,County Surveyor,,REP,John Matwyshyn,143,24,221,388
+Laporte,LONG BEACH,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,135,45,254,434
+Laporte,LONG BEACH,County Commissioner District 2,,REP,Steve Holifield,144,24,230,398
+Laporte,LONG BEACH,County Commissioner District 2,,DEM,Mike Kellems,134,45,244,423
+Laporte,LONG BEACH,County Commissioner District 3,,REP,Joe Haney,132,24,209,365
+Laporte,LONG BEACH,County Commissioner District 3,,DEM,Randy Novak,151,44,277,472
+Laporte,LONG BEACH,County Council Member At Large,,REP,Brett H. Kessler,132,15,194,341
+Laporte,LONG BEACH,County Council Member At Large,,REP,Adam Koronka,121,17,177,315
+Laporte,LONG BEACH,County Council Member At Large,,REP,Heather Oake,109,17,175,301
+Laporte,LONG BEACH,County Council Member At Large,,DEM,Scott (Scotty) Ford,115,34,187,336
+Laporte,LONG BEACH,County Council Member At Large,,DEM,Mike Mollenhauer,128,34,213,375
+Laporte,LONG BEACH,County Council Member At Large,,DEM,Johnny Stimley,132,33,212,377
+Laporte,LONG BEACH,Long Beach Town Clerk-Treasurer,,IND,Meg Collins,222,36,371,629
+Laporte,LONG BEACH,Long Beach Town Council Member At Large,,IND,Kendra Bartlett,188,37,319,544
+Laporte,LONG BEACH,Long Beach Town Council Member At Large,,IND,Colleen Marie Lane,169,31,286,486
+Laporte,LONG BEACH,Long Beach Town Council Member At Large,,IND,Cindy Levy,189,36,321,546
+Laporte,LONG BEACH,Long Beach Town Council Member At Large,,IND,Anita Remijas,180,32,284,496
+Laporte,LONG BEACH,Long Beach Town Council Member At Large,,IND,Joy Schmitt,201,36,322,559
+Laporte,LONG BEACH,MC Area SB Civil City,,,Marty M. Corley,136,22,202,360
+Laporte,LONG BEACH,MC Area SB Civil City,,,Rodney McCormick,79,13,105,197
+Laporte,LONG BEACH,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,45,8,55,108
+Laporte,LONG BEACH,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,26,6,55,87
+Laporte,LONG BEACH,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,63,9,82,154
+Laporte,LONG BEACH,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,48,7,90,145
+Laporte,LONG BEACH,MC Area SB Michigan/Springfield Twps,,,James Stewart,185,24,274,483
+Laporte,LONG BEACH,IN Supreme Court-Rush,,,Yes,146,31,224,401
+Laporte,LONG BEACH,IN Supreme Court-Rush,,,No,74,14,126,214
+Laporte,LONG BEACH,IN Supreme Court-Massa,,,Yes,149,27,217,393
+Laporte,LONG BEACH,IN Supreme Court-Massa,,,No,67,16,131,214
+Laporte,LONG BEACH,IN Supreme Court-Molter,,,Yes,146,26,213,385
+Laporte,LONG BEACH,IN Supreme Court-Molter,,,No,71,16,130,217
+Laporte,LONG BEACH,Court of Appeals Dist 4-Pyle III,,,Yes,144,27,223,394
+Laporte,LONG BEACH,Court of Appeals Dist 4-Pyle III,,,No,70,16,119,205
+Laporte,LONG BEACH,Straight Party,,DEM,Democratic Party,,,,143
+Laporte,LONG BEACH,Straight Party,,REP,Republican Party,,,,162
+Laporte,LP 25,Ballots Cast,,,,299,66,239,604
+Laporte,LP 25,Registered Voters,,,,,,,1141
+Laporte,LP 25,Public Question-Const Amendment,,,Yes,168,8,105,281
+Laporte,LP 25,Public Question-Const Amendment,,,No,93,3,96,192
+Laporte,LP 25,President and Vice-President of the U.S.,,REP,Trump \ Vance,178,10,130,318
+Laporte,LP 25,President and Vice-President of the U.S.,,DEM,Harris \ Walz,104,53,103,260
+Laporte,LP 25,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,4,1,0,5
+Laporte,LP 25,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,9,1,1,11
+Laporte,LP 25,President and Vice-President of the U.S.,,,Write-In,2,0,1,3
+Laporte,LP 25,United States Senator,,REP,Jim Banks,161,8,122,291
+Laporte,LP 25,United States Senator,,DEM,Valerie McCray,101,52,95,248
+Laporte,LP 25,United States Senator,,LIB,Andrew Horning,13,0,2,15
+Laporte,LP 25,United States Senator,,,Write-In,0,0,0,0
+Laporte,LP 25,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,149,4,116,269
+Laporte,LP 25,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,110,10,98,218
+Laporte,LP 25,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,17,0,9,26
+Laporte,LP 25,Governor And Lieutenant Governor,,,Write-In,1,0,0,1
+Laporte,LP 25,Attorney General,,REP,Todd Rokita,163,4,125,292
+Laporte,LP 25,Attorney General,,DEM,Destiny Wells,112,10,100,222
+Laporte,LP 25,United States Representative,1,REP,Randy Niemeyer,159,9,122,290
+Laporte,LP 25,United States Representative,1,DEM,Frank J. Mrvan,109,48,100,257
+Laporte,LP 25,United States Representative,1,LIB,Dakotah Miskus,15,3,6,24
+Laporte,LP 25,United States Representative,1,,Write-In,0,0,0,0
+Laporte,LP 25,State Senator District 8,,REP,Mike Bohacek,180,2,133,315
+Laporte,LP 25,State Senator District 8,,DEM,Leon P. Smith,99,12,93,204
+Laporte,LP 25,State Representative,20,REP,Jim Pressel,211,7,149,367
+Laporte,LP 25,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,189,8,140,337
+Laporte,LP 25,Circuit Court Clerk,,REP,Heather Stevens,163,4,124,291
+Laporte,LP 25,Circuit Court Clerk,,DEM,Angela Henzman,102,10,93,205
+Laporte,LP 25,County Auditor,,REP,Mike Rosenbaum,203,6,155,364
+Laporte,LP 25,County Recorder,,REP,Elzbieta (Ela) Bilderback,165,3,123,291
+Laporte,LP 25,County Recorder,,DEM,Matthew Sikorski,113,12,99,224
+Laporte,LP 25,County Treasurer,,REP,Dan Barenie,168,4,122,294
+Laporte,LP 25,County Treasurer,,DEM,Joie Winski,109,11,99,219
+Laporte,LP 25,County Coroner,,REP,Lynn Swanson,173,5,127,305
+Laporte,LP 25,County Coroner,,DEM,Mark P. Baker,105,9,97,211
+Laporte,LP 25,County Surveyor,,REP,John Matwyshyn,160,3,118,281
+Laporte,LP 25,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,116,12,102,230
+Laporte,LP 25,County Commissioner District 2,,REP,Steve Holifield,155,3,111,269
+Laporte,LP 25,County Commissioner District 2,,DEM,Mike Kellems,118,12,112,242
+Laporte,LP 25,County Commissioner District 3,,REP,Joe Haney,164,3,118,285
+Laporte,LP 25,County Commissioner District 3,,DEM,Randy Novak,111,12,103,226
+Laporte,LP 25,County Council Member At Large,,REP,Brett H. Kessler,125,3,98,226
+Laporte,LP 25,County Council Member At Large,,REP,Adam Koronka,100,2,82,184
+Laporte,LP 25,County Council Member At Large,,REP,Heather Oake,102,1,81,184
+Laporte,LP 25,County Council Member At Large,,DEM,Scott (Scotty) Ford,96,10,81,187
+Laporte,LP 25,County Council Member At Large,,DEM,Mike Mollenhauer,106,10,90,206
+Laporte,LP 25,County Council Member At Large,,DEM,Johnny Stimley,83,10,75,168
+Laporte,LP 25,Laporte Community School Board At Large,,,Jim Arnold,138,10,111,259
+Laporte,LP 25,Laporte Community School Board At Large,,,Monica L. Beaty,119,9,90,218
+Laporte,LP 25,Laporte Community School Board At Large,,,Maria L. Ria Carpenter,112,10,101,223
+Laporte,LP 25,Laporte Community School Board At Large,,,Ed Gilliland,91,4,78,173
+Laporte,LP 25,Laporte Community School Board At Large,,,Tucker King,121,3,86,210
+Laporte,LP 25,IN Supreme Court-Rush,,,Yes,156,8,127,291
+Laporte,LP 25,IN Supreme Court-Rush,,,No,75,1,52,128
+Laporte,LP 25,IN Supreme Court-Massa,,,Yes,148,4,121,273
+Laporte,LP 25,IN Supreme Court-Massa,,,No,82,2,55,139
+Laporte,LP 25,IN Supreme Court-Molter,,,Yes,156,6,126,288
+Laporte,LP 25,IN Supreme Court-Molter,,,No,76,2,51,129
+Laporte,LP 25,Court of Appeals Dist 4-Pyle III,,,Yes,156,7,124,287
+Laporte,LP 25,Court of Appeals Dist 4-Pyle III,,,No,76,2,50,128
+Laporte,LP 25,Straight Party,,DEM,Democratic Party,,,,93
+Laporte,LP 25,Straight Party,,REP,Republican Party,,,,131
+Laporte,LP 26,Ballots Cast,,,,125,7,48,180
+Laporte,LP 26,Registered Voters,,,,,,,483
+Laporte,LP 26,Public Question-Const Amendment,,,Yes,62,2,24,88
+Laporte,LP 26,Public Question-Const Amendment,,,No,40,3,14,57
+Laporte,LP 26,President and Vice-President of the U.S.,,REP,Trump \ Vance,67,2,28,97
+Laporte,LP 26,President and Vice-President of the U.S.,,DEM,Harris \ Walz,49,5,20,74
+Laporte,LP 26,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,0,0,0,0
+Laporte,LP 26,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,2,0,0,2
+Laporte,LP 26,President and Vice-President of the U.S.,,,Write-In,1,0,0,1
+Laporte,LP 26,United States Senator,,REP,Jim Banks,61,2,27,90
+Laporte,LP 26,United States Senator,,DEM,Valerie McCray,46,5,17,68
+Laporte,LP 26,United States Senator,,LIB,Andrew Horning,4,0,1,5
+Laporte,LP 26,United States Senator,,,Write-In,0,0,0,0
+Laporte,LP 26,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,57,2,25,84
+Laporte,LP 26,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,48,5,20,73
+Laporte,LP 26,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,8,0,1,9
+Laporte,LP 26,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,LP 26,Attorney General,,REP,Todd Rokita,64,2,27,93
+Laporte,LP 26,Attorney General,,DEM,Destiny Wells,48,5,20,73
+Laporte,LP 26,United States Representative,1,REP,Randy Niemeyer,60,2,25,87
+Laporte,LP 26,United States Representative,1,DEM,Frank J. Mrvan,48,5,20,73
+Laporte,LP 26,United States Representative,1,LIB,Dakotah Miskus,8,0,2,10
+Laporte,LP 26,United States Representative,1,,Write-In,0,0,0,0
+Laporte,LP 26,State Senator District 8,,REP,Mike Bohacek,72,2,30,104
+Laporte,LP 26,State Senator District 8,,DEM,Leon P. Smith,44,5,17,66
+Laporte,LP 26,State Representative,20,REP,Jim Pressel,76,2,29,107
+Laporte,LP 26,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,74,2,27,103
+Laporte,LP 26,Circuit Court Clerk,,REP,Heather Stevens,60,2,27,89
+Laporte,LP 26,Circuit Court Clerk,,DEM,Angela Henzman,46,5,19,70
+Laporte,LP 26,County Auditor,,REP,Mike Rosenbaum,79,2,28,109
+Laporte,LP 26,County Recorder,,REP,Elzbieta (Ela) Bilderback,69,2,26,97
+Laporte,LP 26,County Recorder,,DEM,Matthew Sikorski,43,5,21,69
+Laporte,LP 26,County Treasurer,,REP,Dan Barenie,60,2,28,90
+Laporte,LP 26,County Treasurer,,DEM,Joie Winski,55,5,18,78
+Laporte,LP 26,County Coroner,,REP,Lynn Swanson,63,2,29,94
+Laporte,LP 26,County Coroner,,DEM,Mark P. Baker,50,4,18,72
+Laporte,LP 26,County Surveyor,,REP,John Matwyshyn,62,2,20,84
+Laporte,LP 26,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,49,5,26,80
+Laporte,LP 26,County Commissioner District 2,,REP,Steve Holifield,60,2,26,88
+Laporte,LP 26,County Commissioner District 2,,DEM,Mike Kellems,51,5,21,77
+Laporte,LP 26,County Commissioner District 3,,REP,Joe Haney,61,2,24,87
+Laporte,LP 26,County Commissioner District 3,,DEM,Randy Novak,51,5,22,78
+Laporte,LP 26,County Council Member At Large,,REP,Brett H. Kessler,53,2,16,71
+Laporte,LP 26,County Council Member At Large,,REP,Adam Koronka,40,2,19,61
+Laporte,LP 26,County Council Member At Large,,REP,Heather Oake,42,2,16,60
+Laporte,LP 26,County Council Member At Large,,DEM,Scott (Scotty) Ford,30,3,14,47
+Laporte,LP 26,County Council Member At Large,,DEM,Mike Mollenhauer,35,1,16,52
+Laporte,LP 26,County Council Member At Large,,DEM,Johnny Stimley,29,3,15,47
+Laporte,LP 26,Laporte Community School Board At Large,,,Jim Arnold,69,3,22,94
+Laporte,LP 26,Laporte Community School Board At Large,,,Monica L. Beaty,52,1,19,72
+Laporte,LP 26,Laporte Community School Board At Large,,,Maria L. Ria Carpenter,53,2,21,76
+Laporte,LP 26,Laporte Community School Board At Large,,,Ed Gilliland,32,1,10,43
+Laporte,LP 26,Laporte Community School Board At Large,,,Tucker King,54,2,19,75
+Laporte,LP 26,IN Supreme Court-Rush,,,Yes,64,3,25,92
+Laporte,LP 26,IN Supreme Court-Rush,,,No,33,1,10,44
+Laporte,LP 26,IN Supreme Court-Massa,,,Yes,59,1,24,84
+Laporte,LP 26,IN Supreme Court-Massa,,,No,37,2,10,49
+Laporte,LP 26,IN Supreme Court-Molter,,,Yes,60,1,24,85
+Laporte,LP 26,IN Supreme Court-Molter,,,No,36,2,10,48
+Laporte,LP 26,Court of Appeals Dist 4-Pyle III,,,Yes,63,2,26,91
+Laporte,LP 26,Court of Appeals Dist 4-Pyle III,,,No,35,1,8,44
+Laporte,LP 26,Straight Party,,DEM,Democratic Party,,,,40
+Laporte,LP 26,Straight Party,,REP,Republican Party,,,,46
+Laporte,LP 27,Ballots Cast,,,,160,15,154,329
+Laporte,LP 27,Registered Voters,,,,,,,702
+Laporte,LP 27,Public Question-Const Amendment,,,Yes,93,3,72,168
+Laporte,LP 27,Public Question-Const Amendment,,,No,54,6,60,120
+Laporte,LP 27,President and Vice-President of the U.S.,,REP,Trump \ Vance,81,3,75,159
+Laporte,LP 27,President and Vice-President of the U.S.,,DEM,Harris \ Walz,74,11,74,159
+Laporte,LP 27,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,0,0,0,0
+Laporte,LP 27,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,3,1,2,6
+Laporte,LP 27,President and Vice-President of the U.S.,,,Write-In,1,0,0,1
+Laporte,LP 27,United States Senator,,REP,Jim Banks,70,2,75,147
+Laporte,LP 27,United States Senator,,DEM,Valerie McCray,76,12,69,157
+Laporte,LP 27,United States Senator,,LIB,Andrew Horning,2,1,2,5
+Laporte,LP 27,United States Senator,,,Write-In,0,0,0,0
+Laporte,LP 27,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,64,2,69,135
+Laporte,LP 27,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,83,12,73,168
+Laporte,LP 27,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,4,0,6,10
+Laporte,LP 27,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,LP 27,Attorney General,,REP,Todd Rokita,74,2,76,152
+Laporte,LP 27,Attorney General,,DEM,Destiny Wells,79,12,69,160
+Laporte,LP 27,United States Representative,2,REP,Rudy Yakym,75,2,71,148
+Laporte,LP 27,United States Representative,2,DEM,Lori A. Camp,72,11,72,155
+Laporte,LP 27,United States Representative,2,LIB,William E. Henry,4,1,1,6
+Laporte,LP 27,United States Representative,2,,Write-In,0,0,0,0
+Laporte,LP 27,State Senator District 8,,REP,Mike Bohacek,88,2,84,174
+Laporte,LP 27,State Senator District 8,,DEM,Leon P. Smith,63,11,61,135
+Laporte,LP 27,State Representative,20,REP,Jim Pressel,101,5,98,204
+Laporte,LP 27,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,95,5,95,195
+Laporte,LP 27,Circuit Court Clerk,,REP,Heather Stevens,83,2,80,165
+Laporte,LP 27,Circuit Court Clerk,,DEM,Angela Henzman,66,12,65,143
+Laporte,LP 27,County Auditor,,REP,Mike Rosenbaum,110,4,100,214
+Laporte,LP 27,County Recorder,,REP,Elzbieta (Ela) Bilderback,75,4,80,159
+Laporte,LP 27,County Recorder,,DEM,Matthew Sikorski,75,10,67,152
+Laporte,LP 27,County Treasurer,,REP,Dan Barenie,71,3,75,149
+Laporte,LP 27,County Treasurer,,DEM,Joie Winski,78,11,71,160
+Laporte,LP 27,County Coroner,,REP,Lynn Swanson,84,3,82,169
+Laporte,LP 27,County Coroner,,DEM,Mark P. Baker,67,11,64,142
+Laporte,LP 27,County Surveyor,,REP,John Matwyshyn,72,2,73,147
+Laporte,LP 27,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,77,12,69,158
+Laporte,LP 27,County Commissioner District 2,,REP,Steve Holifield,69,2,70,141
+Laporte,LP 27,County Commissioner District 2,,DEM,Mike Kellems,79,12,74,165
+Laporte,LP 27,County Commissioner District 3,,REP,Joe Haney,76,3,78,157
+Laporte,LP 27,County Commissioner District 3,,DEM,Randy Novak,74,11,69,154
+Laporte,LP 27,County Council Member At Large,,REP,Brett H. Kessler,65,4,68,137
+Laporte,LP 27,County Council Member At Large,,REP,Adam Koronka,63,1,60,124
+Laporte,LP 27,County Council Member At Large,,REP,Heather Oake,51,2,59,112
+Laporte,LP 27,County Council Member At Large,,DEM,Scott (Scotty) Ford,57,8,57,122
+Laporte,LP 27,County Council Member At Large,,DEM,Mike Mollenhauer,61,8,55,124
+Laporte,LP 27,County Council Member At Large,,DEM,Johnny Stimley,52,6,54,112
+Laporte,LP 27,Laporte Community School Board At Large,,,Jim Arnold,64,7,63,134
+Laporte,LP 27,Laporte Community School Board At Large,,,Monica L. Beaty,70,7,79,156
+Laporte,LP 27,Laporte Community School Board At Large,,,Maria L. Ria Carpenter,69,3,67,139
+Laporte,LP 27,Laporte Community School Board At Large,,,Ed Gilliland,40,6,55,101
+Laporte,LP 27,Laporte Community School Board At Large,,,Tucker King,74,2,65,141
+Laporte,LP 27,IN Supreme Court-Rush,,,Yes,81,6,76,163
+Laporte,LP 27,IN Supreme Court-Rush,,,No,46,2,43,91
+Laporte,LP 27,IN Supreme Court-Massa,,,Yes,82,7,82,171
+Laporte,LP 27,IN Supreme Court-Massa,,,No,44,2,43,89
+Laporte,LP 27,IN Supreme Court-Molter,,,Yes,80,6,75,161
+Laporte,LP 27,IN Supreme Court-Molter,,,No,47,3,43,93
+Laporte,LP 27,Court of Appeals Dist 4-Pyle III,,,Yes,81,6,81,168
+Laporte,LP 27,Court of Appeals Dist 4-Pyle III,,,No,45,2,36,83
+Laporte,LP 27,Straight Party,,DEM,Democratic Party,,,,55
+Laporte,LP 27,Straight Party,,REP,Republican Party,,,,68
+Laporte,LP 28,Ballots Cast,,,,52,6,40,98
+Laporte,LP 28,Registered Voters,,,,,,,236
+Laporte,LP 28,Public Question-Const Amendment,,,Yes,29,0,21,50
+Laporte,LP 28,Public Question-Const Amendment,,,No,14,4,13,31
+Laporte,LP 28,President and Vice-President of the U.S.,,REP,Trump \ Vance,31,0,17,48
+Laporte,LP 28,President and Vice-President of the U.S.,,DEM,Harris \ Walz,20,5,21,46
+Laporte,LP 28,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,0,0,1,1
+Laporte,LP 28,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,0,0,0,0
+Laporte,LP 28,President and Vice-President of the U.S.,,,Write-In,0,0,0,0
+Laporte,LP 28,United States Senator,,REP,Jim Banks,27,0,17,44
+Laporte,LP 28,United States Senator,,DEM,Valerie McCray,21,5,19,45
+Laporte,LP 28,United States Senator,,LIB,Andrew Horning,1,0,2,3
+Laporte,LP 28,United States Senator,,,Write-In,0,0,0,0
+Laporte,LP 28,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,24,0,17,41
+Laporte,LP 28,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,17,5,19,41
+Laporte,LP 28,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,8,0,2,10
+Laporte,LP 28,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,LP 28,Attorney General,,REP,Todd Rokita,28,0,18,46
+Laporte,LP 28,Attorney General,,DEM,Destiny Wells,21,5,20,46
+Laporte,LP 28,United States Representative,2,REP,Rudy Yakym,31,0,15,46
+Laporte,LP 28,United States Representative,2,DEM,Lori A. Camp,18,5,18,41
+Laporte,LP 28,United States Representative,2,LIB,William E. Henry,1,0,5,6
+Laporte,LP 28,United States Representative,2,,Write-In,0,0,0,0
+Laporte,LP 28,State Senator District 8,,REP,Mike Bohacek,31,0,18,49
+Laporte,LP 28,State Senator District 8,,DEM,Leon P. Smith,18,5,20,43
+Laporte,LP 28,State Representative,20,REP,Jim Pressel,36,0,28,64
+Laporte,LP 28,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,32,1,24,57
+Laporte,LP 28,Circuit Court Clerk,,REP,Heather Stevens,26,0,18,44
+Laporte,LP 28,Circuit Court Clerk,,DEM,Angela Henzman,19,5,20,44
+Laporte,LP 28,County Auditor,,REP,Mike Rosenbaum,34,1,30,65
+Laporte,LP 28,County Recorder,,REP,Elzbieta (Ela) Bilderback,30,0,19,49
+Laporte,LP 28,County Recorder,,DEM,Matthew Sikorski,17,4,19,40
+Laporte,LP 28,County Treasurer,,REP,Dan Barenie,29,0,14,43
+Laporte,LP 28,County Treasurer,,DEM,Joie Winski,18,4,24,46
+Laporte,LP 28,County Coroner,,REP,Lynn Swanson,29,0,22,51
+Laporte,LP 28,County Coroner,,DEM,Mark P. Baker,17,4,17,38
+Laporte,LP 28,County Surveyor,,REP,John Matwyshyn,26,0,16,42
+Laporte,LP 28,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,19,4,22,45
+Laporte,LP 28,County Commissioner District 2,,REP,Steve Holifield,25,0,15,40
+Laporte,LP 28,County Commissioner District 2,,DEM,Mike Kellems,20,4,24,48
+Laporte,LP 28,County Commissioner District 3,,REP,Joe Haney,25,0,13,38
+Laporte,LP 28,County Commissioner District 3,,DEM,Randy Novak,21,4,25,50
+Laporte,LP 28,County Council Member At Large,,REP,Brett H. Kessler,22,0,13,35
+Laporte,LP 28,County Council Member At Large,,REP,Adam Koronka,16,0,9,25
+Laporte,LP 28,County Council Member At Large,,REP,Heather Oake,15,0,12,27
+Laporte,LP 28,County Council Member At Large,,DEM,Scott (Scotty) Ford,15,1,18,34
+Laporte,LP 28,County Council Member At Large,,DEM,Mike Mollenhauer,17,1,21,39
+Laporte,LP 28,County Council Member At Large,,DEM,Johnny Stimley,15,1,14,30
+Laporte,LP 28,Laporte Community School Board At Large,,,Jim Arnold,22,0,22,44
+Laporte,LP 28,Laporte Community School Board At Large,,,Monica L. Beaty,20,0,10,30
+Laporte,LP 28,Laporte Community School Board At Large,,,Maria L. Ria Carpenter,18,0,14,32
+Laporte,LP 28,Laporte Community School Board At Large,,,Ed Gilliland,9,0,6,15
+Laporte,LP 28,Laporte Community School Board At Large,,,Tucker King,8,0,17,25
+Laporte,LP 28,New Prairie United School Corp At Lg,,,Jill Smith,4,0,6,10
+Laporte,LP 28,New Prairie United School Corp At Lg,,,Mike Yacullo,2,0,0,2
+Laporte,LP 28,New Prairie United School Corp Dist 1,,,Rich Shail,6,0,5,11
+Laporte,LP 28,New Prairie United School Corp Dist 3,,,Phillip J. King,4,0,5,9
+Laporte,LP 28,New Prairie United School Corp Dist 3,,,Andrew Oake,2,0,3,5
+Laporte,LP 28,IN Supreme Court-Rush,,,Yes,25,0,26,51
+Laporte,LP 28,IN Supreme Court-Rush,,,No,12,0,6,18
+Laporte,LP 28,IN Supreme Court-Massa,,,Yes,23,0,20,43
+Laporte,LP 28,IN Supreme Court-Massa,,,No,14,0,10,24
+Laporte,LP 28,IN Supreme Court-Molter,,,Yes,22,0,23,45
+Laporte,LP 28,IN Supreme Court-Molter,,,No,16,0,8,24
+Laporte,LP 28,Court of Appeals Dist 4-Pyle III,,,Yes,24,0,23,47
+Laporte,LP 28,Court of Appeals Dist 4-Pyle III,,,No,14,0,9,23
+Laporte,LP 28,Straight Party,,DEM,Democratic Party,,,,16
+Laporte,LP 28,Straight Party,,REP,Republican Party,,,,19
+Laporte,LP 29,Ballots Cast,,,,116,17,170,303
+Laporte,LP 29,Registered Voters,,,,,,,545
+Laporte,LP 29,Public Question-Const Amendment,,,Yes,62,6,86,154
+Laporte,LP 29,Public Question-Const Amendment,,,No,49,11,64,124
+Laporte,LP 29,President and Vice-President of the U.S.,,REP,Trump \ Vance,81,8,104,193
+Laporte,LP 29,President and Vice-President of the U.S.,,DEM,Harris \ Walz,32,9,63,104
+Laporte,LP 29,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,2,0,0,2
+Laporte,LP 29,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,1,0,1,2
+Laporte,LP 29,President and Vice-President of the U.S.,,,Write-In,0,0,0,0
+Laporte,LP 29,United States Senator,,REP,Jim Banks,73,7,100,180
+Laporte,LP 29,United States Senator,,DEM,Valerie McCray,31,9,54,94
+Laporte,LP 29,United States Senator,,LIB,Andrew Horning,4,0,5,9
+Laporte,LP 29,United States Senator,,,Write-In,0,0,0,0
+Laporte,LP 29,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,68,5,93,166
+Laporte,LP 29,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,34,11,61,106
+Laporte,LP 29,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,7,0,7,14
+Laporte,LP 29,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,LP 29,Attorney General,,REP,Todd Rokita,75,8,103,186
+Laporte,LP 29,Attorney General,,DEM,Destiny Wells,33,8,58,99
+Laporte,LP 29,United States Representative,1,REP,Randy Niemeyer,66,7,98,171
+Laporte,LP 29,United States Representative,1,DEM,Frank J. Mrvan,37,9,62,108
+Laporte,LP 29,United States Representative,1,LIB,Dakotah Miskus,7,0,3,10
+Laporte,LP 29,United States Representative,1,,Write-In,0,0,0,0
+Laporte,LP 29,State Senator District 8,,REP,Mike Bohacek,82,9,122,213
+Laporte,LP 29,State Senator District 8,,DEM,Leon P. Smith,26,7,44,77
+Laporte,LP 29,State Representative,20,REP,Jim Pressel,89,9,126,224
+Laporte,LP 29,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,84,10,120,214
+Laporte,LP 29,Circuit Court Clerk,,REP,Heather Stevens,80,7,106,193
+Laporte,LP 29,Circuit Court Clerk,,DEM,Angela Henzman,29,8,52,89
+Laporte,LP 29,County Auditor,,REP,Mike Rosenbaum,93,10,131,234
+Laporte,LP 29,County Recorder,,REP,Elzbieta (Ela) Bilderback,77,5,105,187
+Laporte,LP 29,County Recorder,,DEM,Matthew Sikorski,31,10,59,100
+Laporte,LP 29,County Treasurer,,REP,Dan Barenie,74,7,103,184
+Laporte,LP 29,County Treasurer,,DEM,Joie Winski,36,8,62,106
+Laporte,LP 29,County Coroner,,REP,Lynn Swanson,84,7,110,201
+Laporte,LP 29,County Coroner,,DEM,Mark P. Baker,28,7,54,89
+Laporte,LP 29,County Surveyor,,REP,John Matwyshyn,73,5,88,166
+Laporte,LP 29,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,34,10,70,114
+Laporte,LP 29,County Commissioner District 2,,REP,Steve Holifield,59,6,91,156
+Laporte,LP 29,County Commissioner District 2,,DEM,Mike Kellems,47,9,70,126
+Laporte,LP 29,County Commissioner District 3,,REP,Joe Haney,72,4,100,176
+Laporte,LP 29,County Commissioner District 3,,DEM,Randy Novak,39,11,63,113
+Laporte,LP 29,County Council Member At Large,,REP,Brett H. Kessler,65,4,90,159
+Laporte,LP 29,County Council Member At Large,,REP,Adam Koronka,53,6,72,131
+Laporte,LP 29,County Council Member At Large,,REP,Heather Oake,54,5,68,127
+Laporte,LP 29,County Council Member At Large,,DEM,Scott (Scotty) Ford,21,7,61,89
+Laporte,LP 29,County Council Member At Large,,DEM,Mike Mollenhauer,39,9,61,109
+Laporte,LP 29,County Council Member At Large,,DEM,Johnny Stimley,19,6,49,74
+Laporte,LP 29,Laporte Community School Board At Large,,,Jim Arnold,57,7,85,149
+Laporte,LP 29,Laporte Community School Board At Large,,,Monica L. Beaty,39,10,81,130
+Laporte,LP 29,Laporte Community School Board At Large,,,Maria L. Ria Carpenter,45,11,57,113
+Laporte,LP 29,Laporte Community School Board At Large,,,Ed Gilliland,30,6,63,99
+Laporte,LP 29,Laporte Community School Board At Large,,,Tucker King,56,7,86,149
+Laporte,LP 29,IN Supreme Court-Rush,,,Yes,63,12,96,171
+Laporte,LP 29,IN Supreme Court-Rush,,,No,36,1,42,79
+Laporte,LP 29,IN Supreme Court-Massa,,,Yes,59,13,91,163
+Laporte,LP 29,IN Supreme Court-Massa,,,No,36,2,44,82
+Laporte,LP 29,IN Supreme Court-Molter,,,Yes,61,12,93,166
+Laporte,LP 29,IN Supreme Court-Molter,,,No,37,3,42,82
+Laporte,LP 29,Court of Appeals Dist 4-Pyle III,,,Yes,65,12,89,166
+Laporte,LP 29,Court of Appeals Dist 4-Pyle III,,,No,33,3,45,81
+Laporte,LP 29,Straight Party,,DEM,Democratic Party,,,,26
+Laporte,LP 29,Straight Party,,REP,Republican Party,,,,74
+Laporte,LP 30,Ballots Cast,,,,212,19,262,493
+Laporte,LP 30,Registered Voters,,,,,,,884
+Laporte,LP 30,Public Question-Const Amendment,,,Yes,106,7,119,232
+Laporte,LP 30,Public Question-Const Amendment,,,No,90,7,109,206
+Laporte,LP 30,President and Vice-President of the U.S.,,REP,Trump \ Vance,134,6,157,297
+Laporte,LP 30,President and Vice-President of the U.S.,,DEM,Harris \ Walz,76,13,101,190
+Laporte,LP 30,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,0,0,2,2
+Laporte,LP 30,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,1,0,1,2
+Laporte,LP 30,President and Vice-President of the U.S.,,,Write-In,0,0,0,0
+Laporte,LP 30,United States Senator,,REP,Jim Banks,120,6,144,270
+Laporte,LP 30,United States Senator,,DEM,Valerie McCray,70,12,101,183
+Laporte,LP 30,United States Senator,,LIB,Andrew Horning,6,0,4,10
+Laporte,LP 30,United States Senator,,,Write-In,0,0,0,0
+Laporte,LP 30,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,101,6,143,250
+Laporte,LP 30,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,83,12,101,196
+Laporte,LP 30,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,13,0,5,18
+Laporte,LP 30,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,LP 30,Attorney General,,REP,Todd Rokita,118,6,157,281
+Laporte,LP 30,Attorney General,,DEM,Destiny Wells,78,12,97,187
+Laporte,LP 30,United States Representative,1,REP,Randy Niemeyer,110,6,152,268
+Laporte,LP 30,United States Representative,1,DEM,Frank J. Mrvan,75,12,100,187
+Laporte,LP 30,United States Representative,1,LIB,Dakotah Miskus,15,0,3,18
+Laporte,LP 30,United States Representative,1,,Write-In,0,0,0,0
+Laporte,LP 30,State Senator District 8,,REP,Mike Bohacek,132,8,173,313
+Laporte,LP 30,State Senator District 8,,DEM,Leon P. Smith,66,11,79,156
+Laporte,LP 30,State Representative,20,REP,Jim Pressel,152,8,184,344
+Laporte,LP 30,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,143,10,178,331
+Laporte,LP 30,Circuit Court Clerk,,REP,Heather Stevens,118,8,158,284
+Laporte,LP 30,Circuit Court Clerk,,DEM,Angela Henzman,69,10,86,165
+Laporte,LP 30,County Auditor,,REP,Mike Rosenbaum,156,8,198,362
+Laporte,LP 30,County Recorder,,REP,Elzbieta (Ela) Bilderback,121,9,161,291
+Laporte,LP 30,County Recorder,,DEM,Matthew Sikorski,74,9,87,170
+Laporte,LP 30,County Treasurer,,REP,Dan Barenie,122,10,150,282
+Laporte,LP 30,County Treasurer,,DEM,Joie Winski,75,8,102,185
+Laporte,LP 30,County Coroner,,REP,Lynn Swanson,132,6,164,302
+Laporte,LP 30,County Coroner,,DEM,Mark P. Baker,68,12,88,168
+Laporte,LP 30,County Surveyor,,REP,John Matwyshyn,113,6,134,253
+Laporte,LP 30,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,78,12,112,202
+Laporte,LP 30,County Commissioner District 2,,REP,Steve Holifield,109,6,129,244
+Laporte,LP 30,County Commissioner District 2,,DEM,Mike Kellems,86,12,118,216
+Laporte,LP 30,County Commissioner District 3,,REP,Joe Haney,114,10,142,266
+Laporte,LP 30,County Commissioner District 3,,DEM,Randy Novak,79,8,105,192
+Laporte,LP 30,County Council Member At Large,,REP,Brett H. Kessler,95,5,124,224
+Laporte,LP 30,County Council Member At Large,,REP,Adam Koronka,88,5,108,201
+Laporte,LP 30,County Council Member At Large,,REP,Heather Oake,91,3,104,198
+Laporte,LP 30,County Council Member At Large,,DEM,Scott (Scotty) Ford,72,7,89,168
+Laporte,LP 30,County Council Member At Large,,DEM,Mike Mollenhauer,75,7,104,186
+Laporte,LP 30,County Council Member At Large,,DEM,Johnny Stimley,59,8,76,143
+Laporte,LP 30,Laporte Community School Board At Large,,,Jim Arnold,106,4,123,233
+Laporte,LP 30,Laporte Community School Board At Large,,,Monica L. Beaty,87,12,107,206
+Laporte,LP 30,Laporte Community School Board At Large,,,Maria L. Ria Carpenter,81,9,93,183
+Laporte,LP 30,Laporte Community School Board At Large,,,Ed Gilliland,82,3,87,172
+Laporte,LP 30,Laporte Community School Board At Large,,,Tucker King,98,8,142,248
+Laporte,LP 30,IN Supreme Court-Rush,,,Yes,123,5,146,274
+Laporte,LP 30,IN Supreme Court-Rush,,,No,51,4,73,128
+Laporte,LP 30,IN Supreme Court-Massa,,,Yes,122,3,144,269
+Laporte,LP 30,IN Supreme Court-Massa,,,No,52,6,73,131
+Laporte,LP 30,IN Supreme Court-Molter,,,Yes,121,4,147,272
+Laporte,LP 30,IN Supreme Court-Molter,,,No,55,5,70,130
+Laporte,LP 30,Court of Appeals Dist 4-Pyle III,,,Yes,118,3,146,267
+Laporte,LP 30,Court of Appeals Dist 4-Pyle III,,,No,59,5,72,136
+Laporte,LP 30,Straight Party,,DEM,Democratic Party,,,,50
+Laporte,LP 30,Straight Party,,REP,Republican Party,,,,110
+Laporte,LP 31,Ballots Cast,,,,306,39,374,719
+Laporte,LP 31,Registered Voters,,,,,,,1409
+Laporte,LP 31,Public Question-Const Amendment,,,Yes,147,16,149,312
+Laporte,LP 31,Public Question-Const Amendment,,,No,122,15,134,271
+Laporte,LP 31,President and Vice-President of the U.S.,,REP,Trump \ Vance,173,8,181,362
+Laporte,LP 31,President and Vice-President of the U.S.,,DEM,Harris \ Walz,122,30,174,326
+Laporte,LP 31,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,1,0,1,2
+Laporte,LP 31,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,4,1,6,11
+Laporte,LP 31,President and Vice-President of the U.S.,,,Write-In,1,0,1,2
+Laporte,LP 31,United States Senator,,REP,Jim Banks,167,9,169,345
+Laporte,LP 31,United States Senator,,DEM,Valerie McCray,108,30,172,310
+Laporte,LP 31,United States Senator,,LIB,Andrew Horning,9,0,11,20
+Laporte,LP 31,United States Senator,,,Write-In,0,0,0,0
+Laporte,LP 31,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,149,10,165,324
+Laporte,LP 31,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,121,28,180,329
+Laporte,LP 31,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,14,0,13,27
+Laporte,LP 31,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,LP 31,Attorney General,,REP,Todd Rokita,163,11,179,353
+Laporte,LP 31,Attorney General,,DEM,Destiny Wells,124,28,180,332
+Laporte,LP 31,United States Representative,1,REP,Randy Niemeyer,156,9,169,334
+Laporte,LP 31,United States Representative,1,DEM,Frank J. Mrvan,130,29,176,335
+Laporte,LP 31,United States Representative,1,LIB,Dakotah Miskus,9,1,12,22
+Laporte,LP 31,United States Representative,1,,Write-In,0,0,0,0
+Laporte,LP 31,State Senator District 8,,REP,Mike Bohacek,184,10,195,389
+Laporte,LP 31,State Senator District 8,,DEM,Leon P. Smith,102,29,162,293
+Laporte,LP 31,State Representative,20,REP,Jim Pressel,224,16,228,468
+Laporte,LP 31,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,208,19,213,440
+Laporte,LP 31,Circuit Court Clerk,,REP,Heather Stevens,172,11,184,367
+Laporte,LP 31,Circuit Court Clerk,,DEM,Angela Henzman,113,28,170,311
+Laporte,LP 31,County Auditor,,REP,Mike Rosenbaum,219,20,234,473
+Laporte,LP 31,County Recorder,,REP,Elzbieta (Ela) Bilderback,170,14,185,369
+Laporte,LP 31,County Recorder,,DEM,Matthew Sikorski,116,25,169,310
+Laporte,LP 31,County Treasurer,,REP,Dan Barenie,159,10,168,337
+Laporte,LP 31,County Treasurer,,DEM,Joie Winski,129,29,187,345
+Laporte,LP 31,County Coroner,,REP,Lynn Swanson,180,9,204,393
+Laporte,LP 31,County Coroner,,DEM,Mark P. Baker,111,30,158,299
+Laporte,LP 31,County Surveyor,,REP,John Matwyshyn,156,13,167,336
+Laporte,LP 31,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,124,26,184,334
+Laporte,LP 31,County Commissioner District 2,,REP,Steve Holifield,150,11,166,327
+Laporte,LP 31,County Commissioner District 2,,DEM,Mike Kellems,135,28,192,355
+Laporte,LP 31,County Commissioner District 3,,REP,Joe Haney,159,7,178,344
+Laporte,LP 31,County Commissioner District 3,,DEM,Randy Novak,127,32,183,342
+Laporte,LP 31,County Council Member At Large,,REP,Brett H. Kessler,130,8,133,271
+Laporte,LP 31,County Council Member At Large,,REP,Adam Koronka,109,7,121,237
+Laporte,LP 31,County Council Member At Large,,REP,Heather Oake,111,8,128,247
+Laporte,LP 31,County Council Member At Large,,DEM,Scott (Scotty) Ford,95,22,133,250
+Laporte,LP 31,County Council Member At Large,,DEM,Mike Mollenhauer,116,24,154,294
+Laporte,LP 31,County Council Member At Large,,DEM,Johnny Stimley,90,21,121,232
+Laporte,LP 31,Laporte Community School Board At Large,,,Jim Arnold,156,19,181,356
+Laporte,LP 31,Laporte Community School Board At Large,,,Monica L. Beaty,131,19,136,286
+Laporte,LP 31,Laporte Community School Board At Large,,,Maria L. Ria Carpenter,105,18,139,262
+Laporte,LP 31,Laporte Community School Board At Large,,,Ed Gilliland,83,11,106,200
+Laporte,LP 31,Laporte Community School Board At Large,,,Tucker King,125,11,136,272
+Laporte,LP 31,IN Supreme Court-Rush,,,Yes,163,24,166,353
+Laporte,LP 31,IN Supreme Court-Rush,,,No,85,3,104,192
+Laporte,LP 31,IN Supreme Court-Massa,,,Yes,155,22,156,333
+Laporte,LP 31,IN Supreme Court-Massa,,,No,91,6,109,206
+Laporte,LP 31,IN Supreme Court-Molter,,,Yes,160,22,161,343
+Laporte,LP 31,IN Supreme Court-Molter,,,No,87,6,109,202
+Laporte,LP 31,Court of Appeals Dist 4-Pyle III,,,Yes,145,23,161,329
+Laporte,LP 31,Court of Appeals Dist 4-Pyle III,,,No,101,6,106,213
+Laporte,LP 31,Straight Party,,DEM,Democratic Party,,,,117
+Laporte,LP 31,Straight Party,,REP,Republican Party,,,,154
+Laporte,LP 32,Ballots Cast,,,,276,24,278,578
+Laporte,LP 32,Registered Voters,,,,,,,1240
+Laporte,LP 32,Public Question-Const Amendment,,,Yes,135,7,123,265
+Laporte,LP 32,Public Question-Const Amendment,,,No,116,10,117,243
+Laporte,LP 32,President and Vice-President of the U.S.,,REP,Trump \ Vance,151,11,130,292
+Laporte,LP 32,President and Vice-President of the U.S.,,DEM,Harris \ Walz,115,11,139,265
+Laporte,LP 32,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,4,0,4,8
+Laporte,LP 32,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,5,0,2,7
+Laporte,LP 32,President and Vice-President of the U.S.,,,Write-In,0,0,1,1
+Laporte,LP 32,United States Senator,,REP,Jim Banks,135,13,125,273
+Laporte,LP 32,United States Senator,,DEM,Valerie McCray,107,10,130,247
+Laporte,LP 32,United States Senator,,LIB,Andrew Horning,16,0,6,22
+Laporte,LP 32,United States Senator,,,Write-In,0,0,0,0
+Laporte,LP 32,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,132,13,115,260
+Laporte,LP 32,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,112,10,140,262
+Laporte,LP 32,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,14,0,9,23
+Laporte,LP 32,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,LP 32,Attorney General,,REP,Todd Rokita,151,15,134,300
+Laporte,LP 32,Attorney General,,DEM,Destiny Wells,115,8,134,257
+Laporte,LP 32,United States Representative,1,REP,Randy Niemeyer,136,13,117,266
+Laporte,LP 32,United States Representative,1,DEM,Frank J. Mrvan,116,11,141,268
+Laporte,LP 32,United States Representative,1,LIB,Dakotah Miskus,16,0,9,25
+Laporte,LP 32,United States Representative,1,,Write-In,0,0,0,0
+Laporte,LP 32,State Senator District 8,,REP,Mike Bohacek,159,13,150,322
+Laporte,LP 32,State Senator District 8,,DEM,Leon P. Smith,103,9,117,229
+Laporte,LP 32,State Representative,20,REP,Jim Pressel,184,19,182,385
+Laporte,LP 32,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,172,17,174,363
+Laporte,LP 32,Circuit Court Clerk,,REP,Heather Stevens,144,13,141,298
+Laporte,LP 32,Circuit Court Clerk,,DEM,Angela Henzman,102,10,119,231
+Laporte,LP 32,County Auditor,,REP,Mike Rosenbaum,190,17,175,382
+Laporte,LP 32,County Recorder,,REP,Elzbieta (Ela) Bilderback,153,14,136,303
+Laporte,LP 32,County Recorder,,DEM,Matthew Sikorski,108,10,131,249
+Laporte,LP 32,County Treasurer,,REP,Dan Barenie,140,13,130,283
+Laporte,LP 32,County Treasurer,,DEM,Joie Winski,121,11,139,271
+Laporte,LP 32,County Coroner,,REP,Lynn Swanson,150,11,143,304
+Laporte,LP 32,County Coroner,,DEM,Mark P. Baker,112,13,123,248
+Laporte,LP 32,County Surveyor,,REP,John Matwyshyn,134,12,128,274
+Laporte,LP 32,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,121,10,138,269
+Laporte,LP 32,County Commissioner District 2,,REP,Steve Holifield,139,14,120,273
+Laporte,LP 32,County Commissioner District 2,,DEM,Mike Kellems,119,10,145,274
+Laporte,LP 32,County Commissioner District 3,,REP,Joe Haney,151,14,129,294
+Laporte,LP 32,County Commissioner District 3,,DEM,Randy Novak,109,10,139,258
+Laporte,LP 32,County Council Member At Large,,REP,Brett H. Kessler,126,10,114,250
+Laporte,LP 32,County Council Member At Large,,REP,Adam Koronka,106,6,110,222
+Laporte,LP 32,County Council Member At Large,,REP,Heather Oake,102,6,90,198
+Laporte,LP 32,County Council Member At Large,,DEM,Scott (Scotty) Ford,85,12,102,199
+Laporte,LP 32,County Council Member At Large,,DEM,Mike Mollenhauer,98,13,122,233
+Laporte,LP 32,County Council Member At Large,,DEM,Johnny Stimley,79,9,98,186
+Laporte,LP 32,Laporte Community School Board At Large,,,Jim Arnold,137,14,123,274
+Laporte,LP 32,Laporte Community School Board At Large,,,Monica L. Beaty,108,9,127,244
+Laporte,LP 32,Laporte Community School Board At Large,,,Maria L. Ria Carpenter,112,7,114,233
+Laporte,LP 32,Laporte Community School Board At Large,,,Ed Gilliland,80,12,88,180
+Laporte,LP 32,Laporte Community School Board At Large,,,Tucker King,124,3,105,232
+Laporte,LP 32,IN Supreme Court-Rush,,,Yes,156,7,137,300
+Laporte,LP 32,IN Supreme Court-Rush,,,No,80,10,80,170
+Laporte,LP 32,IN Supreme Court-Massa,,,Yes,150,9,130,289
+Laporte,LP 32,IN Supreme Court-Massa,,,No,84,9,85,178
+Laporte,LP 32,IN Supreme Court-Molter,,,Yes,143,7,134,284
+Laporte,LP 32,IN Supreme Court-Molter,,,No,85,10,83,178
+Laporte,LP 32,Court of Appeals Dist 4-Pyle III,,,Yes,146,8,141,295
+Laporte,LP 32,Court of Appeals Dist 4-Pyle III,,,No,87,10,76,173
+Laporte,LP 32,Straight Party,,DEM,Democratic Party,,,,87
+Laporte,LP 32,Straight Party,,REP,Republican Party,,,,110
+Laporte,LP 33,Ballots Cast,,,,300,20,246,566
+Laporte,LP 33,Registered Voters,,,,,,,895
+Laporte,LP 33,Public Question-Const Amendment,,,Yes,162,10,98,270
+Laporte,LP 33,Public Question-Const Amendment,,,No,108,9,114,231
+Laporte,LP 33,President and Vice-President of the U.S.,,REP,Trump \ Vance,189,2,127,318
+Laporte,LP 33,President and Vice-President of the U.S.,,DEM,Harris \ Walz,102,18,114,234
+Laporte,LP 33,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,2,0,2,4
+Laporte,LP 33,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,5,0,0,5
+Laporte,LP 33,President and Vice-President of the U.S.,,,Write-In,1,0,0,1
+Laporte,LP 33,United States Senator,,REP,Jim Banks,176,3,123,302
+Laporte,LP 33,United States Senator,,DEM,Valerie McCray,91,16,100,207
+Laporte,LP 33,United States Senator,,LIB,Andrew Horning,8,1,9,18
+Laporte,LP 33,United States Senator,,,Write-In,0,0,0,0
+Laporte,LP 33,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,169,3,113,285
+Laporte,LP 33,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,102,17,107,226
+Laporte,LP 33,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,12,0,13,25
+Laporte,LP 33,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,LP 33,Attorney General,,REP,Todd Rokita,182,4,129,315
+Laporte,LP 33,Attorney General,,DEM,Destiny Wells,101,16,111,228
+Laporte,LP 33,United States Representative,1,REP,Randy Niemeyer,170,2,123,295
+Laporte,LP 33,United States Representative,1,DEM,Frank J. Mrvan,108,18,111,237
+Laporte,LP 33,United States Representative,1,LIB,Dakotah Miskus,7,0,4,11
+Laporte,LP 33,United States Representative,1,,Write-In,0,0,0,0
+Laporte,LP 33,State Senator District 8,,REP,Mike Bohacek,197,6,149,352
+Laporte,LP 33,State Senator District 8,,DEM,Leon P. Smith,89,14,87,190
+Laporte,LP 33,State Representative,20,REP,Jim Pressel,226,13,174,413
+Laporte,LP 33,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,218,13,160,391
+Laporte,LP 33,Circuit Court Clerk,,REP,Heather Stevens,186,8,133,327
+Laporte,LP 33,Circuit Court Clerk,,DEM,Angela Henzman,89,11,95,195
+Laporte,LP 33,County Auditor,,REP,Mike Rosenbaum,228,13,173,414
+Laporte,LP 33,County Recorder,,REP,Elzbieta (Ela) Bilderback,175,4,135,314
+Laporte,LP 33,County Recorder,,DEM,Matthew Sikorski,98,16,97,211
+Laporte,LP 33,County Treasurer,,REP,Dan Barenie,175,5,127,307
+Laporte,LP 33,County Treasurer,,DEM,Joie Winski,106,14,108,228
+Laporte,LP 33,County Coroner,,REP,Lynn Swanson,186,4,137,327
+Laporte,LP 33,County Coroner,,DEM,Mark P. Baker,96,16,100,212
+Laporte,LP 33,County Surveyor,,REP,John Matwyshyn,153,4,111,268
+Laporte,LP 33,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,119,14,122,255
+Laporte,LP 33,County Commissioner District 2,,REP,Steve Holifield,160,6,110,276
+Laporte,LP 33,County Commissioner District 2,,DEM,Mike Kellems,119,13,127,259
+Laporte,LP 33,County Commissioner District 3,,REP,Joe Haney,169,5,121,295
+Laporte,LP 33,County Commissioner District 3,,DEM,Randy Novak,109,14,114,237
+Laporte,LP 33,County Council Member At Large,,REP,Brett H. Kessler,147,4,108,259
+Laporte,LP 33,County Council Member At Large,,REP,Adam Koronka,131,3,102,236
+Laporte,LP 33,County Council Member At Large,,REP,Heather Oake,118,2,89,209
+Laporte,LP 33,County Council Member At Large,,DEM,Scott (Scotty) Ford,77,9,99,185
+Laporte,LP 33,County Council Member At Large,,DEM,Mike Mollenhauer,104,10,106,220
+Laporte,LP 33,County Council Member At Large,,DEM,Johnny Stimley,64,9,88,161
+Laporte,LP 33,Laporte Community School Board At Large,,,Jim Arnold,150,14,116,280
+Laporte,LP 33,Laporte Community School Board At Large,,,Monica L. Beaty,118,11,114,243
+Laporte,LP 33,Laporte Community School Board At Large,,,Maria L. Ria Carpenter,112,6,99,217
+Laporte,LP 33,Laporte Community School Board At Large,,,Ed Gilliland,103,7,89,199
+Laporte,LP 33,Laporte Community School Board At Large,,,Tucker King,148,8,129,285
+Laporte,LP 33,IN Supreme Court-Rush,,,Yes,170,12,129,311
+Laporte,LP 33,IN Supreme Court-Rush,,,No,71,2,80,153
+Laporte,LP 33,IN Supreme Court-Massa,,,Yes,170,10,126,306
+Laporte,LP 33,IN Supreme Court-Massa,,,No,70,5,84,159
+Laporte,LP 33,IN Supreme Court-Molter,,,Yes,175,8,130,313
+Laporte,LP 33,IN Supreme Court-Molter,,,No,66,6,80,152
+Laporte,LP 33,Court of Appeals Dist 4-Pyle III,,,Yes,169,9,127,305
+Laporte,LP 33,Court of Appeals Dist 4-Pyle III,,,No,71,6,80,157
+Laporte,LP 33,Straight Party,,DEM,Democratic Party,,,,60
+Laporte,LP 33,Straight Party,,REP,Republican Party,,,,120
+Laporte,LP 34,Ballots Cast,,,,255,26,257,538
+Laporte,LP 34,Registered Voters,,,,,,,780
+Laporte,LP 34,Public Question-Const Amendment,,,Yes,126,4,118,248
+Laporte,LP 34,Public Question-Const Amendment,,,No,100,7,107,214
+Laporte,LP 34,President and Vice-President of the U.S.,,REP,Trump \ Vance,132,9,125,266
+Laporte,LP 34,President and Vice-President of the U.S.,,DEM,Harris \ Walz,111,15,127,253
+Laporte,LP 34,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,3,1,0,4
+Laporte,LP 34,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,4,0,2,6
+Laporte,LP 34,President and Vice-President of the U.S.,,,Write-In,2,1,2,5
+Laporte,LP 34,United States Senator,,REP,Jim Banks,119,10,120,249
+Laporte,LP 34,United States Senator,,DEM,Valerie McCray,104,14,119,237
+Laporte,LP 34,United States Senator,,LIB,Andrew Horning,10,1,6,17
+Laporte,LP 34,United States Senator,,,Write-In,0,0,1,1
+Laporte,LP 34,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,121,11,115,247
+Laporte,LP 34,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,113,14,130,257
+Laporte,LP 34,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,9,0,3,12
+Laporte,LP 34,Governor And Lieutenant Governor,,,Write-In,0,0,1,1
+Laporte,LP 34,Attorney General,,REP,Todd Rokita,135,9,126,270
+Laporte,LP 34,Attorney General,,DEM,Destiny Wells,107,15,123,245
+Laporte,LP 34,United States Representative,1,REP,Randy Niemeyer,115,10,118,243
+Laporte,LP 34,United States Representative,1,DEM,Frank J. Mrvan,120,14,126,260
+Laporte,LP 34,United States Representative,1,LIB,Dakotah Miskus,11,1,8,20
+Laporte,LP 34,United States Representative,1,,Write-In,0,0,0,0
+Laporte,LP 34,State Senator District 8,,REP,Mike Bohacek,148,12,145,305
+Laporte,LP 34,State Senator District 8,,DEM,Leon P. Smith,94,12,105,211
+Laporte,LP 34,State Representative,20,REP,Jim Pressel,171,15,161,347
+Laporte,LP 34,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,155,12,161,328
+Laporte,LP 34,Circuit Court Clerk,,REP,Heather Stevens,135,11,125,271
+Laporte,LP 34,Circuit Court Clerk,,DEM,Angela Henzman,97,14,120,231
+Laporte,LP 34,County Auditor,,REP,Mike Rosenbaum,163,12,172,347
+Laporte,LP 34,County Recorder,,REP,Elzbieta (Ela) Bilderback,133,12,135,280
+Laporte,LP 34,County Recorder,,DEM,Matthew Sikorski,107,13,114,234
+Laporte,LP 34,County Treasurer,,REP,Dan Barenie,117,9,127,253
+Laporte,LP 34,County Treasurer,,DEM,Joie Winski,123,16,124,263
+Laporte,LP 34,County Coroner,,REP,Lynn Swanson,148,11,144,303
+Laporte,LP 34,County Coroner,,DEM,Mark P. Baker,96,14,106,216
+Laporte,LP 34,County Surveyor,,REP,John Matwyshyn,110,8,116,234
+Laporte,LP 34,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,122,17,133,272
+Laporte,LP 34,County Commissioner District 2,,REP,Steve Holifield,106,10,120,236
+Laporte,LP 34,County Commissioner District 2,,DEM,Mike Kellems,132,15,129,276
+Laporte,LP 34,County Commissioner District 3,,REP,Joe Haney,117,9,116,242
+Laporte,LP 34,County Commissioner District 3,,DEM,Randy Novak,120,16,128,264
+Laporte,LP 34,County Council Member At Large,,REP,Brett H. Kessler,120,9,115,244
+Laporte,LP 34,County Council Member At Large,,REP,Adam Koronka,107,8,105,220
+Laporte,LP 34,County Council Member At Large,,REP,Heather Oake,95,2,91,188
+Laporte,LP 34,County Council Member At Large,,DEM,Scott (Scotty) Ford,100,10,115,225
+Laporte,LP 34,County Council Member At Large,,DEM,Mike Mollenhauer,110,11,124,245
+Laporte,LP 34,County Council Member At Large,,DEM,Johnny Stimley,84,8,97,189
+Laporte,LP 34,Laporte Community School Board At Large,,,Jim Arnold,139,6,119,264
+Laporte,LP 34,Laporte Community School Board At Large,,,Monica L. Beaty,121,13,118,252
+Laporte,LP 34,Laporte Community School Board At Large,,,Maria L. Ria Carpenter,88,8,99,195
+Laporte,LP 34,Laporte Community School Board At Large,,,Ed Gilliland,111,9,97,217
+Laporte,LP 34,Laporte Community School Board At Large,,,Tucker King,115,10,112,237
+Laporte,LP 34,IN Supreme Court-Rush,,,Yes,150,12,140,302
+Laporte,LP 34,IN Supreme Court-Rush,,,No,56,3,72,131
+Laporte,LP 34,IN Supreme Court-Massa,,,Yes,142,7,133,282
+Laporte,LP 34,IN Supreme Court-Massa,,,No,61,7,77,145
+Laporte,LP 34,IN Supreme Court-Molter,,,Yes,142,7,131,280
+Laporte,LP 34,IN Supreme Court-Molter,,,No,65,5,79,149
+Laporte,LP 34,Court of Appeals Dist 4-Pyle III,,,Yes,144,8,132,284
+Laporte,LP 34,Court of Appeals Dist 4-Pyle III,,,No,62,5,77,144
+Laporte,LP 34,Straight Party,,DEM,Democratic Party,,,,76
+Laporte,LP 34,Straight Party,,REP,Republican Party,,,,82
+Laporte,LP 35,Ballots Cast,,,,8,2,30,40
+Laporte,LP 35,Registered Voters,,,,,,,58
+Laporte,LP 35,Public Question-Const Amendment,,,Yes,4,0,5,9
+Laporte,LP 35,Public Question-Const Amendment,,,No,4,0,12,16
+Laporte,LP 35,President and Vice-President of the U.S.,,REP,Trump \ Vance,6,0,12,18
+Laporte,LP 35,President and Vice-President of the U.S.,,DEM,Harris \ Walz,1,2,15,18
+Laporte,LP 35,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,0,0,0,0
+Laporte,LP 35,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,1,0,3,4
+Laporte,LP 35,President and Vice-President of the U.S.,,,Write-In,0,0,0,0
+Laporte,LP 35,United States Senator,,REP,Jim Banks,7,0,11,18
+Laporte,LP 35,United States Senator,,DEM,Valerie McCray,1,2,11,14
+Laporte,LP 35,United States Senator,,LIB,Andrew Horning,0,0,2,2
+Laporte,LP 35,United States Senator,,,Write-In,0,0,0,0
+Laporte,LP 35,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,5,0,14,19
+Laporte,LP 35,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,2,2,11,15
+Laporte,LP 35,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,1,0,0,1
+Laporte,LP 35,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,LP 35,Attorney General,,REP,Todd Rokita,6,0,14,20
+Laporte,LP 35,Attorney General,,DEM,Destiny Wells,2,2,13,17
+Laporte,LP 35,United States Representative,2,REP,Rudy Yakym,6,0,14,20
+Laporte,LP 35,United States Representative,2,DEM,Lori A. Camp,1,2,10,13
+Laporte,LP 35,United States Representative,2,LIB,William E. Henry,1,0,3,4
+Laporte,LP 35,United States Representative,2,,Write-In,0,0,0,0
+Laporte,LP 35,State Senator District 8,,REP,Mike Bohacek,6,0,17,23
+Laporte,LP 35,State Senator District 8,,DEM,Leon P. Smith,2,2,10,14
+Laporte,LP 35,State Representative,20,REP,Jim Pressel,8,2,19,29
+Laporte,LP 35,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,8,0,18,26
+Laporte,LP 35,Circuit Court Clerk,,REP,Heather Stevens,6,0,14,20
+Laporte,LP 35,Circuit Court Clerk,,DEM,Angela Henzman,2,2,12,16
+Laporte,LP 35,County Auditor,,REP,Mike Rosenbaum,8,0,17,25
+Laporte,LP 35,County Recorder,,REP,Elzbieta (Ela) Bilderback,6,0,15,21
+Laporte,LP 35,County Recorder,,DEM,Matthew Sikorski,2,2,12,16
+Laporte,LP 35,County Treasurer,,REP,Dan Barenie,6,0,11,17
+Laporte,LP 35,County Treasurer,,DEM,Joie Winski,2,2,14,18
+Laporte,LP 35,County Coroner,,REP,Lynn Swanson,6,0,15,21
+Laporte,LP 35,County Coroner,,DEM,Mark P. Baker,2,0,11,13
+Laporte,LP 35,County Surveyor,,REP,John Matwyshyn,6,0,11,17
+Laporte,LP 35,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,2,2,15,19
+Laporte,LP 35,County Commissioner District 2,,REP,Steve Holifield,6,0,12,18
+Laporte,LP 35,County Commissioner District 2,,DEM,Mike Kellems,2,2,13,17
+Laporte,LP 35,County Commissioner District 3,,REP,Joe Haney,8,0,10,18
+Laporte,LP 35,County Commissioner District 3,,DEM,Randy Novak,0,2,17,19
+Laporte,LP 35,County Council Member At Large,,REP,Brett H. Kessler,4,0,11,15
+Laporte,LP 35,County Council Member At Large,,REP,Adam Koronka,5,0,10,15
+Laporte,LP 35,County Council Member At Large,,REP,Heather Oake,5,1,9,15
+Laporte,LP 35,County Council Member At Large,,DEM,Scott (Scotty) Ford,3,2,11,16
+Laporte,LP 35,County Council Member At Large,,DEM,Mike Mollenhauer,2,2,12,16
+Laporte,LP 35,County Council Member At Large,,DEM,Johnny Stimley,1,1,12,14
+Laporte,LP 35,Laporte Community School Board At Large,,,Jim Arnold,4,2,10,16
+Laporte,LP 35,Laporte Community School Board At Large,,,Monica L. Beaty,2,0,3,5
+Laporte,LP 35,Laporte Community School Board At Large,,,Maria L. Ria Carpenter,3,2,9,14
+Laporte,LP 35,Laporte Community School Board At Large,,,Ed Gilliland,4,2,8,14
+Laporte,LP 35,Laporte Community School Board At Large,,,Tucker King,7,0,12,19
+Laporte,LP 35,IN Supreme Court-Rush,,,Yes,6,0,12,18
+Laporte,LP 35,IN Supreme Court-Rush,,,No,2,0,6,8
+Laporte,LP 35,IN Supreme Court-Massa,,,Yes,6,0,11,17
+Laporte,LP 35,IN Supreme Court-Massa,,,No,2,0,7,9
+Laporte,LP 35,IN Supreme Court-Molter,,,Yes,7,0,13,20
+Laporte,LP 35,IN Supreme Court-Molter,,,No,1,0,4,5
+Laporte,LP 35,Court of Appeals Dist 4-Pyle III,,,Yes,7,0,13,20
+Laporte,LP 35,Court of Appeals Dist 4-Pyle III,,,No,1,0,5,6
+Laporte,LP 35,Straight Party,,DEM,Democratic Party,,,,7
+Laporte,LP 35,Straight Party,,REP,Republican Party,,,,12
+Laporte,LP 36,Ballots Cast,,,,22,6,31,59
+Laporte,LP 36,Registered Voters,,,,,,,63
+Laporte,LP 36,Public Question-Const Amendment,,,Yes,8,0,13,21
+Laporte,LP 36,Public Question-Const Amendment,,,No,9,2,14,25
+Laporte,LP 36,President and Vice-President of the U.S.,,REP,Trump \ Vance,14,0,17,31
+Laporte,LP 36,President and Vice-President of the U.S.,,DEM,Harris \ Walz,7,6,14,27
+Laporte,LP 36,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,0,0,0,0
+Laporte,LP 36,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,0,0,0,0
+Laporte,LP 36,President and Vice-President of the U.S.,,,Write-In,0,0,0,0
+Laporte,LP 36,United States Senator,,REP,Jim Banks,14,0,17,31
+Laporte,LP 36,United States Senator,,DEM,Valerie McCray,5,5,12,22
+Laporte,LP 36,United States Senator,,LIB,Andrew Horning,0,0,1,1
+Laporte,LP 36,United States Senator,,,Write-In,0,0,0,0
+Laporte,LP 36,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,12,0,16,28
+Laporte,LP 36,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,6,5,13,24
+Laporte,LP 36,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,1,0,1,2
+Laporte,LP 36,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,LP 36,Attorney General,,REP,Todd Rokita,15,1,18,34
+Laporte,LP 36,Attorney General,,DEM,Destiny Wells,4,4,12,20
+Laporte,LP 36,United States Representative,1,REP,Randy Niemeyer,12,0,16,28
+Laporte,LP 36,United States Representative,1,DEM,Frank J. Mrvan,8,5,15,28
+Laporte,LP 36,United States Representative,1,LIB,Dakotah Miskus,0,0,0,0
+Laporte,LP 36,United States Representative,1,,Write-In,0,0,0,0
+Laporte,LP 36,State Senator District 8,,REP,Mike Bohacek,16,1,19,36
+Laporte,LP 36,State Senator District 8,,DEM,Leon P. Smith,4,5,12,21
+Laporte,LP 36,State Representative,20,REP,Jim Pressel,18,2,25,45
+Laporte,LP 36,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,15,1,24,40
+Laporte,LP 36,Circuit Court Clerk,,REP,Heather Stevens,14,1,18,33
+Laporte,LP 36,Circuit Court Clerk,,DEM,Angela Henzman,3,4,13,20
+Laporte,LP 36,County Auditor,,REP,Mike Rosenbaum,16,1,23,40
+Laporte,LP 36,County Recorder,,REP,Elzbieta (Ela) Bilderback,11,2,19,32
+Laporte,LP 36,County Recorder,,DEM,Matthew Sikorski,6,3,12,21
+Laporte,LP 36,County Treasurer,,REP,Dan Barenie,13,0,20,33
+Laporte,LP 36,County Treasurer,,DEM,Joie Winski,6,6,11,23
+Laporte,LP 36,County Coroner,,REP,Lynn Swanson,16,0,17,33
+Laporte,LP 36,County Coroner,,DEM,Mark P. Baker,2,5,14,21
+Laporte,LP 36,County Surveyor,,REP,John Matwyshyn,12,1,15,28
+Laporte,LP 36,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,6,5,16,27
+Laporte,LP 36,County Commissioner District 2,,REP,Steve Holifield,12,0,16,28
+Laporte,LP 36,County Commissioner District 2,,DEM,Mike Kellems,7,6,15,28
+Laporte,LP 36,County Commissioner District 3,,REP,Joe Haney,11,1,16,28
+Laporte,LP 36,County Commissioner District 3,,DEM,Randy Novak,8,5,14,27
+Laporte,LP 36,County Council Member At Large,,REP,Brett H. Kessler,10,1,12,23
+Laporte,LP 36,County Council Member At Large,,REP,Adam Koronka,11,0,15,26
+Laporte,LP 36,County Council Member At Large,,REP,Heather Oake,10,1,13,24
+Laporte,LP 36,County Council Member At Large,,DEM,Scott (Scotty) Ford,4,5,12,21
+Laporte,LP 36,County Council Member At Large,,DEM,Mike Mollenhauer,7,5,14,26
+Laporte,LP 36,County Council Member At Large,,DEM,Johnny Stimley,4,4,10,18
+Laporte,LP 36,Laporte Community School Board At Large,,,Jim Arnold,12,2,14,28
+Laporte,LP 36,Laporte Community School Board At Large,,,Monica L. Beaty,8,1,14,23
+Laporte,LP 36,Laporte Community School Board At Large,,,Maria L. Ria Carpenter,9,2,10,21
+Laporte,LP 36,Laporte Community School Board At Large,,,Ed Gilliland,13,0,17,30
+Laporte,LP 36,Laporte Community School Board At Large,,,Tucker King,13,2,16,31
+Laporte,LP 36,IN Supreme Court-Rush,,,Yes,13,1,17,31
+Laporte,LP 36,IN Supreme Court-Rush,,,No,1,1,9,11
+Laporte,LP 36,IN Supreme Court-Massa,,,Yes,13,0,16,29
+Laporte,LP 36,IN Supreme Court-Massa,,,No,1,2,10,13
+Laporte,LP 36,IN Supreme Court-Molter,,,Yes,13,0,16,29
+Laporte,LP 36,IN Supreme Court-Molter,,,No,1,2,10,13
+Laporte,LP 36,Court of Appeals Dist 4-Pyle III,,,Yes,13,1,17,31
+Laporte,LP 36,Court of Appeals Dist 4-Pyle III,,,No,1,1,9,11
+Laporte,LP 36,Straight Party,,DEM,Democratic Party,,,,4
+Laporte,LP 36,Straight Party,,REP,Republican Party,,,,13
+Laporte,LP 37,Ballots Cast,,,,187,19,172,378
+Laporte,LP 37,Registered Voters,,,,,,,688
+Laporte,LP 37,Public Question-Const Amendment,,,Yes,94,10,85,189
+Laporte,LP 37,Public Question-Const Amendment,,,No,69,7,62,138
+Laporte,LP 37,President and Vice-President of the U.S.,,REP,Trump \ Vance,107,6,90,203
+Laporte,LP 37,President and Vice-President of the U.S.,,DEM,Harris \ Walz,73,13,79,165
+Laporte,LP 37,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,2,0,1,3
+Laporte,LP 37,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,3,0,1,4
+Laporte,LP 37,President and Vice-President of the U.S.,,,Write-In,1,0,0,1
+Laporte,LP 37,United States Senator,,REP,Jim Banks,97,5,84,186
+Laporte,LP 37,United States Senator,,DEM,Valerie McCray,71,13,71,155
+Laporte,LP 37,United States Senator,,LIB,Andrew Horning,7,0,4,11
+Laporte,LP 37,United States Senator,,,Write-In,0,0,0,0
+Laporte,LP 37,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,90,6,79,175
+Laporte,LP 37,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,76,13,75,164
+Laporte,LP 37,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,9,0,8,17
+Laporte,LP 37,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,LP 37,Attorney General,,REP,Todd Rokita,103,6,88,197
+Laporte,LP 37,Attorney General,,DEM,Destiny Wells,68,13,75,156
+Laporte,LP 37,United States Representative,2,REP,Rudy Yakym,98,5,80,183
+Laporte,LP 37,United States Representative,2,DEM,Lori A. Camp,70,14,76,160
+Laporte,LP 37,United States Representative,2,LIB,William E. Henry,8,0,7,15
+Laporte,LP 37,United States Representative,2,,Write-In,0,0,0,0
+Laporte,LP 37,State Senator District 8,,REP,Mike Bohacek,108,7,99,214
+Laporte,LP 37,State Senator District 8,,DEM,Leon P. Smith,70,12,66,148
+Laporte,LP 37,State Representative,20,REP,Jim Pressel,131,7,105,243
+Laporte,LP 37,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,121,8,105,234
+Laporte,LP 37,Circuit Court Clerk,,REP,Heather Stevens,102,9,93,204
+Laporte,LP 37,Circuit Court Clerk,,DEM,Angela Henzman,70,10,65,145
+Laporte,LP 37,County Auditor,,REP,Mike Rosenbaum,130,9,106,245
+Laporte,LP 37,County Recorder,,REP,Elzbieta (Ela) Bilderback,99,7,87,193
+Laporte,LP 37,County Recorder,,DEM,Matthew Sikorski,76,11,73,160
+Laporte,LP 37,County Treasurer,,REP,Dan Barenie,99,5,82,186
+Laporte,LP 37,County Treasurer,,DEM,Joie Winski,74,14,80,168
+Laporte,LP 37,County Coroner,,REP,Lynn Swanson,109,8,100,217
+Laporte,LP 37,County Coroner,,DEM,Mark P. Baker,67,10,64,141
+Laporte,LP 37,County Surveyor,,REP,John Matwyshyn,96,6,79,181
+Laporte,LP 37,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,81,13,81,175
+Laporte,LP 37,County Commissioner District 2,,REP,Steve Holifield,92,4,83,179
+Laporte,LP 37,County Commissioner District 2,,DEM,Mike Kellems,85,15,77,177
+Laporte,LP 37,County Commissioner District 3,,REP,Joe Haney,97,6,81,184
+Laporte,LP 37,County Commissioner District 3,,DEM,Randy Novak,80,13,81,174
+Laporte,LP 37,County Council Member At Large,,REP,Brett H. Kessler,80,7,68,155
+Laporte,LP 37,County Council Member At Large,,REP,Adam Koronka,69,3,61,133
+Laporte,LP 37,County Council Member At Large,,REP,Heather Oake,67,4,57,128
+Laporte,LP 37,County Council Member At Large,,DEM,Scott (Scotty) Ford,59,14,60,133
+Laporte,LP 37,County Council Member At Large,,DEM,Mike Mollenhauer,70,14,61,145
+Laporte,LP 37,County Council Member At Large,,DEM,Johnny Stimley,48,13,56,117
+Laporte,LP 37,Laporte Community School Board At Large,,,Jim Arnold,93,14,73,180
+Laporte,LP 37,Laporte Community School Board At Large,,,Monica L. Beaty,71,10,70,151
+Laporte,LP 37,Laporte Community School Board At Large,,,Maria L. Ria Carpenter,74,12,76,162
+Laporte,LP 37,Laporte Community School Board At Large,,,Ed Gilliland,72,8,58,138
+Laporte,LP 37,Laporte Community School Board At Large,,,Tucker King,71,7,75,153
+Laporte,LP 37,IN Supreme Court-Rush,,,Yes,106,10,83,199
+Laporte,LP 37,IN Supreme Court-Rush,,,No,43,8,42,93
+Laporte,LP 37,IN Supreme Court-Massa,,,Yes,102,9,85,196
+Laporte,LP 37,IN Supreme Court-Massa,,,No,46,9,39,94
+Laporte,LP 37,IN Supreme Court-Molter,,,Yes,100,10,86,196
+Laporte,LP 37,IN Supreme Court-Molter,,,No,48,8,40,96
+Laporte,LP 37,Court of Appeals Dist 4-Pyle III,,,Yes,95,8,86,189
+Laporte,LP 37,Court of Appeals Dist 4-Pyle III,,,No,54,10,40,104
+Laporte,LP 37,Straight Party,,DEM,Democratic Party,,,,53
+Laporte,LP 37,Straight Party,,REP,Republican Party,,,,81
+Laporte,LP 38,Ballots Cast,,,,275,22,200,497
+Laporte,LP 38,Registered Voters,,,,,,,872
+Laporte,LP 38,Public Question-Const Amendment,,,Yes,142,5,90,237
+Laporte,LP 38,Public Question-Const Amendment,,,No,97,12,91,200
+Laporte,LP 38,President and Vice-President of the U.S.,,REP,Trump \ Vance,151,8,115,274
+Laporte,LP 38,President and Vice-President of the U.S.,,DEM,Harris \ Walz,112,14,79,205
+Laporte,LP 38,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,3,0,2,5
+Laporte,LP 38,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,5,0,3,8
+Laporte,LP 38,President and Vice-President of the U.S.,,,Write-In,1,0,0,1
+Laporte,LP 38,United States Senator,,REP,Jim Banks,131,10,106,247
+Laporte,LP 38,United States Senator,,DEM,Valerie McCray,98,12,73,183
+Laporte,LP 38,United States Senator,,LIB,Andrew Horning,15,0,3,18
+Laporte,LP 38,United States Senator,,,Write-In,0,0,0,0
+Laporte,LP 38,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,119,9,93,221
+Laporte,LP 38,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,117,12,83,212
+Laporte,LP 38,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,18,0,8,26
+Laporte,LP 38,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,LP 38,Attorney General,,REP,Todd Rokita,137,12,110,259
+Laporte,LP 38,Attorney General,,DEM,Destiny Wells,101,10,80,191
+Laporte,LP 38,United States Representative,2,REP,Rudy Yakym,132,10,106,248
+Laporte,LP 38,United States Representative,2,DEM,Lori A. Camp,97,11,81,189
+Laporte,LP 38,United States Representative,2,LIB,William E. Henry,14,0,3,17
+Laporte,LP 38,United States Representative,2,,Write-In,0,0,0,0
+Laporte,LP 38,State Senator District 8,,REP,Mike Bohacek,149,13,110,272
+Laporte,LP 38,State Senator District 8,,DEM,Leon P. Smith,98,9,79,186
+Laporte,LP 38,State Representative,20,REP,Jim Pressel,187,15,134,336
+Laporte,LP 38,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,171,11,130,312
+Laporte,LP 38,Circuit Court Clerk,,REP,Heather Stevens,146,10,110,266
+Laporte,LP 38,Circuit Court Clerk,,DEM,Angela Henzman,94,12,74,180
+Laporte,LP 38,County Auditor,,REP,Mike Rosenbaum,184,14,137,335
+Laporte,LP 38,County Recorder,,REP,Elzbieta (Ela) Bilderback,140,11,115,266
+Laporte,LP 38,County Recorder,,DEM,Matthew Sikorski,103,11,78,192
+Laporte,LP 38,County Treasurer,,REP,Dan Barenie,127,8,109,244
+Laporte,LP 38,County Treasurer,,DEM,Joie Winski,114,13,85,212
+Laporte,LP 38,County Coroner,,REP,Lynn Swanson,149,12,112,273
+Laporte,LP 38,County Coroner,,DEM,Mark P. Baker,95,8,78,181
+Laporte,LP 38,County Surveyor,,REP,John Matwyshyn,127,8,100,235
+Laporte,LP 38,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,107,14,89,210
+Laporte,LP 38,County Commissioner District 2,,REP,Steve Holifield,128,9,91,228
+Laporte,LP 38,County Commissioner District 2,,DEM,Mike Kellems,117,13,97,227
+Laporte,LP 38,County Commissioner District 3,,REP,Joe Haney,137,7,105,249
+Laporte,LP 38,County Commissioner District 3,,DEM,Randy Novak,111,13,83,207
+Laporte,LP 38,County Council Member At Large,,REP,Brett H. Kessler,105,9,87,201
+Laporte,LP 38,County Council Member At Large,,REP,Adam Koronka,105,6,82,193
+Laporte,LP 38,County Council Member At Large,,REP,Heather Oake,88,6,78,172
+Laporte,LP 38,County Council Member At Large,,DEM,Scott (Scotty) Ford,90,15,74,179
+Laporte,LP 38,County Council Member At Large,,DEM,Mike Mollenhauer,98,15,75,188
+Laporte,LP 38,County Council Member At Large,,DEM,Johnny Stimley,78,8,64,150
+Laporte,LP 38,Laporte Community School Board At Large,,,Jim Arnold,121,14,103,238
+Laporte,LP 38,Laporte Community School Board At Large,,,Monica L. Beaty,101,9,85,195
+Laporte,LP 38,Laporte Community School Board At Large,,,Maria L. Ria Carpenter,98,11,80,189
+Laporte,LP 38,Laporte Community School Board At Large,,,Ed Gilliland,90,12,76,178
+Laporte,LP 38,Laporte Community School Board At Large,,,Tucker King,113,14,83,210
+Laporte,LP 38,IN Supreme Court-Rush,,,Yes,136,17,104,257
+Laporte,LP 38,IN Supreme Court-Rush,,,No,73,3,60,136
+Laporte,LP 38,IN Supreme Court-Massa,,,Yes,131,16,96,243
+Laporte,LP 38,IN Supreme Court-Massa,,,No,76,3,65,144
+Laporte,LP 38,IN Supreme Court-Molter,,,Yes,130,16,98,244
+Laporte,LP 38,IN Supreme Court-Molter,,,No,78,5,63,146
+Laporte,LP 38,Court of Appeals Dist 4-Pyle III,,,Yes,127,16,99,242
+Laporte,LP 38,Court of Appeals Dist 4-Pyle III,,,No,79,4,60,143
+Laporte,LP 38,Straight Party,,DEM,Democratic Party,,,,53
+Laporte,LP 38,Straight Party,,REP,Republican Party,,,,95
+Laporte,LP 39,Ballots Cast,,,,105,7,74,186
+Laporte,LP 39,Registered Voters,,,,,,,306
+Laporte,LP 39,Public Question-Const Amendment,,,Yes,46,2,28,76
+Laporte,LP 39,Public Question-Const Amendment,,,No,42,2,34,78
+Laporte,LP 39,President and Vice-President of the U.S.,,REP,Trump \ Vance,54,4,41,99
+Laporte,LP 39,President and Vice-President of the U.S.,,DEM,Harris \ Walz,47,3,31,81
+Laporte,LP 39,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,0,0,0,0
+Laporte,LP 39,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,2,0,0,2
+Laporte,LP 39,President and Vice-President of the U.S.,,,Write-In,0,0,0,0
+Laporte,LP 39,United States Senator,,REP,Jim Banks,53,3,40,96
+Laporte,LP 39,United States Senator,,DEM,Valerie McCray,39,3,29,71
+Laporte,LP 39,United States Senator,,LIB,Andrew Horning,6,0,1,7
+Laporte,LP 39,United States Senator,,,Write-In,0,0,0,0
+Laporte,LP 39,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,47,4,38,89
+Laporte,LP 39,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,43,3,29,75
+Laporte,LP 39,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,9,0,4,13
+Laporte,LP 39,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,LP 39,Attorney General,,REP,Todd Rokita,59,3,40,102
+Laporte,LP 39,Attorney General,,DEM,Destiny Wells,40,3,31,74
+Laporte,LP 39,United States Representative,2,REP,Rudy Yakym,53,4,40,97
+Laporte,LP 39,United States Representative,2,DEM,Lori A. Camp,40,3,31,74
+Laporte,LP 39,United States Representative,2,LIB,William E. Henry,6,0,1,7
+Laporte,LP 39,United States Representative,2,,Write-In,0,0,0,0
+Laporte,LP 39,State Senator District 8,,REP,Mike Bohacek,56,3,47,106
+Laporte,LP 39,State Senator District 8,,DEM,Leon P. Smith,42,3,25,70
+Laporte,LP 39,State Representative,20,REP,Jim Pressel,75,3,53,131
+Laporte,LP 39,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,69,2,47,118
+Laporte,LP 39,Circuit Court Clerk,,REP,Heather Stevens,53,3,41,97
+Laporte,LP 39,Circuit Court Clerk,,DEM,Angela Henzman,44,3,28,75
+Laporte,LP 39,County Auditor,,REP,Mike Rosenbaum,73,2,53,128
+Laporte,LP 39,County Recorder,,REP,Elzbieta (Ela) Bilderback,57,3,42,102
+Laporte,LP 39,County Recorder,,DEM,Matthew Sikorski,41,3,30,74
+Laporte,LP 39,County Treasurer,,REP,Dan Barenie,54,2,39,95
+Laporte,LP 39,County Treasurer,,DEM,Joie Winski,44,3,33,80
+Laporte,LP 39,County Coroner,,REP,Lynn Swanson,63,3,45,111
+Laporte,LP 39,County Coroner,,DEM,Mark P. Baker,35,3,28,66
+Laporte,LP 39,County Surveyor,,REP,John Matwyshyn,52,2,39,93
+Laporte,LP 39,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,46,3,33,82
+Laporte,LP 39,County Commissioner District 2,,REP,Steve Holifield,50,2,41,93
+Laporte,LP 39,County Commissioner District 2,,DEM,Mike Kellems,50,3,31,84
+Laporte,LP 39,County Commissioner District 3,,REP,Joe Haney,53,2,36,91
+Laporte,LP 39,County Commissioner District 3,,DEM,Randy Novak,47,3,36,86
+Laporte,LP 39,County Council Member At Large,,REP,Brett H. Kessler,43,2,37,82
+Laporte,LP 39,County Council Member At Large,,REP,Adam Koronka,36,2,33,71
+Laporte,LP 39,County Council Member At Large,,REP,Heather Oake,28,2,24,54
+Laporte,LP 39,County Council Member At Large,,DEM,Scott (Scotty) Ford,34,3,31,68
+Laporte,LP 39,County Council Member At Large,,DEM,Mike Mollenhauer,39,3,29,71
+Laporte,LP 39,County Council Member At Large,,DEM,Johnny Stimley,34,3,26,63
+Laporte,LP 39,New Prairie United School Corp At Lg,,,Jill Smith,64,1,34,99
+Laporte,LP 39,New Prairie United School Corp At Lg,,,Mike Yacullo,21,0,18,39
+Laporte,LP 39,New Prairie United School Corp Dist 1,,,Rich Shail,74,0,45,119
+Laporte,LP 39,New Prairie United School Corp Dist 3,,,Phillip J. King,48,1,23,72
+Laporte,LP 39,New Prairie United School Corp Dist 3,,,Andrew Oake,28,1,23,52
+Laporte,LP 39,IN Supreme Court-Rush,,,Yes,56,0,32,88
+Laporte,LP 39,IN Supreme Court-Rush,,,No,27,1,24,52
+Laporte,LP 39,IN Supreme Court-Massa,,,Yes,45,1,32,78
+Laporte,LP 39,IN Supreme Court-Massa,,,No,36,1,24,61
+Laporte,LP 39,IN Supreme Court-Molter,,,Yes,46,1,32,79
+Laporte,LP 39,IN Supreme Court-Molter,,,No,35,1,25,61
+Laporte,LP 39,Court of Appeals Dist 4-Pyle III,,,Yes,49,0,34,83
+Laporte,LP 39,Court of Appeals Dist 4-Pyle III,,,No,33,1,22,56
+Laporte,LP 39,Straight Party,,DEM,Democratic Party,,,,23
+Laporte,LP 39,Straight Party,,REP,Republican Party,,,,32
+Laporte,LP 40,Ballots Cast,,,,258,43,297,598
+Laporte,LP 40,Registered Voters,,,,,,,935
+Laporte,LP 40,Public Question-Const Amendment,,,Yes,136,17,137,290
+Laporte,LP 40,Public Question-Const Amendment,,,No,92,18,124,234
+Laporte,LP 40,President and Vice-President of the U.S.,,REP,Trump \ Vance,166,9,146,321
+Laporte,LP 40,President and Vice-President of the U.S.,,DEM,Harris \ Walz,80,32,143,255
+Laporte,LP 40,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,2,0,0,2
+Laporte,LP 40,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,8,0,2,10
+Laporte,LP 40,President and Vice-President of the U.S.,,,Write-In,1,0,0,1
+Laporte,LP 40,United States Senator,,REP,Jim Banks,150,10,140,300
+Laporte,LP 40,United States Senator,,DEM,Valerie McCray,81,29,128,238
+Laporte,LP 40,United States Senator,,LIB,Andrew Horning,9,1,1,11
+Laporte,LP 40,United States Senator,,,Write-In,0,0,0,0
+Laporte,LP 40,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,134,10,134,278
+Laporte,LP 40,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,94,32,134,260
+Laporte,LP 40,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,11,0,6,17
+Laporte,LP 40,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,LP 40,Attorney General,,REP,Todd Rokita,154,10,142,306
+Laporte,LP 40,Attorney General,,DEM,Destiny Wells,86,29,141,256
+Laporte,LP 40,United States Representative,2,REP,Rudy Yakym,142,12,139,293
+Laporte,LP 40,United States Representative,2,DEM,Lori A. Camp,86,27,136,249
+Laporte,LP 40,United States Representative,2,LIB,William E. Henry,10,1,4,15
+Laporte,LP 40,United States Representative,2,,Write-In,0,0,0,0
+Laporte,LP 40,State Senator District 8,,REP,Mike Bohacek,171,18,165,354
+Laporte,LP 40,State Senator District 8,,DEM,Leon P. Smith,73,22,118,213
+Laporte,LP 40,State Representative,20,REP,Jim Pressel,197,21,187,405
+Laporte,LP 40,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,182,21,170,373
+Laporte,LP 40,Circuit Court Clerk,,REP,Heather Stevens,158,17,142,317
+Laporte,LP 40,Circuit Court Clerk,,DEM,Angela Henzman,72,21,125,218
+Laporte,LP 40,County Auditor,,REP,Mike Rosenbaum,197,25,187,409
+Laporte,LP 40,County Recorder,,REP,Elzbieta (Ela) Bilderback,156,14,152,322
+Laporte,LP 40,County Recorder,,DEM,Matthew Sikorski,82,24,126,232
+Laporte,LP 40,County Treasurer,,REP,Dan Barenie,142,7,133,282
+Laporte,LP 40,County Treasurer,,DEM,Joie Winski,98,32,145,275
+Laporte,LP 40,County Coroner,,REP,Lynn Swanson,165,19,155,339
+Laporte,LP 40,County Coroner,,DEM,Mark P. Baker,79,21,126,226
+Laporte,LP 40,County Surveyor,,REP,John Matwyshyn,135,7,123,265
+Laporte,LP 40,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,94,32,149,275
+Laporte,LP 40,County Commissioner District 2,,REP,Steve Holifield,121,8,129,258
+Laporte,LP 40,County Commissioner District 2,,DEM,Mike Kellems,114,32,149,295
+Laporte,LP 40,County Commissioner District 3,,REP,Joe Haney,143,11,132,286
+Laporte,LP 40,County Commissioner District 3,,DEM,Randy Novak,94,28,142,264
+Laporte,LP 40,County Council Member At Large,,REP,Brett H. Kessler,127,13,114,254
+Laporte,LP 40,County Council Member At Large,,REP,Adam Koronka,108,13,117,238
+Laporte,LP 40,County Council Member At Large,,REP,Heather Oake,106,6,106,218
+Laporte,LP 40,County Council Member At Large,,DEM,Scott (Scotty) Ford,77,22,115,214
+Laporte,LP 40,County Council Member At Large,,DEM,Mike Mollenhauer,101,27,136,264
+Laporte,LP 40,County Council Member At Large,,DEM,Johnny Stimley,61,21,100,182
+Laporte,LP 40,Laporte Community School Board At Large,,,Jim Arnold,143,21,153,317
+Laporte,LP 40,Laporte Community School Board At Large,,,Monica L. Beaty,117,19,126,262
+Laporte,LP 40,Laporte Community School Board At Large,,,Maria L. Ria Carpenter,114,14,130,258
+Laporte,LP 40,Laporte Community School Board At Large,,,Ed Gilliland,89,16,119,224
+Laporte,LP 40,Laporte Community School Board At Large,,,Tucker King,103,14,117,234
+Laporte,LP 40,IN Supreme Court-Rush,,,Yes,151,16,148,315
+Laporte,LP 40,IN Supreme Court-Rush,,,No,55,15,78,148
+Laporte,LP 40,IN Supreme Court-Massa,,,Yes,141,16,139,296
+Laporte,LP 40,IN Supreme Court-Massa,,,No,64,14,85,163
+Laporte,LP 40,IN Supreme Court-Molter,,,Yes,146,15,138,299
+Laporte,LP 40,IN Supreme Court-Molter,,,No,61,15,89,165
+Laporte,LP 40,Court of Appeals Dist 4-Pyle III,,,Yes,145,19,146,310
+Laporte,LP 40,Court of Appeals Dist 4-Pyle III,,,No,61,13,79,153
+Laporte,LP 40,Straight Party,,DEM,Democratic Party,,,,68
+Laporte,LP 40,Straight Party,,REP,Republican Party,,,,115
+Laporte,LP 41,Ballots Cast,,,,284,35,387,706
+Laporte,LP 41,Registered Voters,,,,,,,1114
+Laporte,LP 41,Public Question-Const Amendment,,,Yes,167,15,174,356
+Laporte,LP 41,Public Question-Const Amendment,,,No,86,9,155,250
+Laporte,LP 41,President and Vice-President of the U.S.,,REP,Trump \ Vance,171,11,206,388
+Laporte,LP 41,President and Vice-President of the U.S.,,DEM,Harris \ Walz,104,22,172,298
+Laporte,LP 41,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,1,0,1,2
+Laporte,LP 41,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,4,0,4,8
+Laporte,LP 41,President and Vice-President of the U.S.,,,Write-In,2,0,0,2
+Laporte,LP 41,United States Senator,,REP,Jim Banks,156,12,196,364
+Laporte,LP 41,United States Senator,,DEM,Valerie McCray,84,21,157,262
+Laporte,LP 41,United States Senator,,LIB,Andrew Horning,12,1,7,20
+Laporte,LP 41,United States Senator,,,Write-In,0,0,0,0
+Laporte,LP 41,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,151,13,191,355
+Laporte,LP 41,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,100,21,163,284
+Laporte,LP 41,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,13,0,10,23
+Laporte,LP 41,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,LP 41,Attorney General,,REP,Todd Rokita,167,13,201,381
+Laporte,LP 41,Attorney General,,DEM,Destiny Wells,96,21,167,284
+Laporte,LP 41,United States Representative,1,REP,Randy Niemeyer,151,12,193,356
+Laporte,LP 41,United States Representative,1,DEM,Frank J. Mrvan,102,22,170,294
+Laporte,LP 41,United States Representative,1,LIB,Dakotah Miskus,15,0,6,21
+Laporte,LP 41,United States Representative,1,,Write-In,0,0,0,0
+Laporte,LP 41,State Senator District 8,,REP,Mike Bohacek,190,17,224,431
+Laporte,LP 41,State Senator District 8,,DEM,Leon P. Smith,74,16,142,232
+Laporte,LP 41,State Representative,20,REP,Jim Pressel,218,25,261,504
+Laporte,LP 41,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,204,23,230,457
+Laporte,LP 41,Circuit Court Clerk,,REP,Heather Stevens,173,16,207,396
+Laporte,LP 41,Circuit Court Clerk,,DEM,Angela Henzman,79,16,141,236
+Laporte,LP 41,County Auditor,,REP,Mike Rosenbaum,216,23,251,490
+Laporte,LP 41,County Recorder,,REP,Elzbieta (Ela) Bilderback,162,13,212,387
+Laporte,LP 41,County Recorder,,DEM,Matthew Sikorski,94,19,150,263
+Laporte,LP 41,County Treasurer,,REP,Dan Barenie,168,15,199,382
+Laporte,LP 41,County Treasurer,,DEM,Joie Winski,93,16,170,279
+Laporte,LP 41,County Coroner,,REP,Lynn Swanson,171,15,226,412
+Laporte,LP 41,County Coroner,,DEM,Mark P. Baker,88,17,142,247
+Laporte,LP 41,County Surveyor,,REP,John Matwyshyn,144,12,187,343
+Laporte,LP 41,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,107,20,175,302
+Laporte,LP 41,County Commissioner District 2,,REP,Steve Holifield,146,12,189,347
+Laporte,LP 41,County Commissioner District 2,,DEM,Mike Kellems,114,20,175,309
+Laporte,LP 41,County Commissioner District 3,,REP,Joe Haney,145,12,189,346
+Laporte,LP 41,County Commissioner District 3,,DEM,Randy Novak,116,18,175,309
+Laporte,LP 41,County Council Member At Large,,REP,Brett H. Kessler,145,11,168,324
+Laporte,LP 41,County Council Member At Large,,REP,Adam Koronka,132,11,158,301
+Laporte,LP 41,County Council Member At Large,,REP,Heather Oake,120,11,144,275
+Laporte,LP 41,County Council Member At Large,,DEM,Scott (Scotty) Ford,77,11,140,228
+Laporte,LP 41,County Council Member At Large,,DEM,Mike Mollenhauer,104,10,159,273
+Laporte,LP 41,County Council Member At Large,,DEM,Johnny Stimley,63,11,120,194
+Laporte,LP 41,Laporte Community School Board At Large,,,Jim Arnold,159,15,181,355
+Laporte,LP 41,Laporte Community School Board At Large,,,Monica L. Beaty,126,13,179,318
+Laporte,LP 41,Laporte Community School Board At Large,,,Maria L. Ria Carpenter,98,15,144,257
+Laporte,LP 41,Laporte Community School Board At Large,,,Ed Gilliland,108,10,136,254
+Laporte,LP 41,Laporte Community School Board At Large,,,Tucker King,129,9,168,306
+Laporte,LP 41,IN Supreme Court-Rush,,,Yes,156,15,197,368
+Laporte,LP 41,IN Supreme Court-Rush,,,No,72,7,98,177
+Laporte,LP 41,IN Supreme Court-Massa,,,Yes,152,13,194,359
+Laporte,LP 41,IN Supreme Court-Massa,,,No,75,9,103,187
+Laporte,LP 41,IN Supreme Court-Molter,,,Yes,152,13,190,355
+Laporte,LP 41,IN Supreme Court-Molter,,,No,71,9,107,187
+Laporte,LP 41,Court of Appeals Dist 4-Pyle III,,,Yes,157,15,197,369
+Laporte,LP 41,Court of Appeals Dist 4-Pyle III,,,No,65,7,100,172
+Laporte,LP 41,Straight Party,,DEM,Democratic Party,,,,86
+Laporte,LP 41,Straight Party,,REP,Republican Party,,,,135
+Laporte,LP 42,Ballots Cast,,,,89,2,64,155
+Laporte,LP 42,Registered Voters,,,,,,,236
+Laporte,LP 42,Public Question-Const Amendment,,,Yes,54,1,27,82
+Laporte,LP 42,Public Question-Const Amendment,,,No,25,1,23,49
+Laporte,LP 42,President and Vice-President of the U.S.,,REP,Trump \ Vance,51,0,29,80
+Laporte,LP 42,President and Vice-President of the U.S.,,DEM,Harris \ Walz,35,1,33,69
+Laporte,LP 42,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,0,0,1,1
+Laporte,LP 42,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,2,1,0,3
+Laporte,LP 42,President and Vice-President of the U.S.,,,Write-In,1,0,1,2
+Laporte,LP 42,United States Senator,,REP,Jim Banks,49,0,28,77
+Laporte,LP 42,United States Senator,,DEM,Valerie McCray,31,2,32,65
+Laporte,LP 42,United States Senator,,LIB,Andrew Horning,3,0,0,3
+Laporte,LP 42,United States Senator,,,Write-In,0,0,0,0
+Laporte,LP 42,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,40,0,27,67
+Laporte,LP 42,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,39,2,33,74
+Laporte,LP 42,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,4,0,1,5
+Laporte,LP 42,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,LP 42,Attorney General,,REP,Todd Rokita,51,0,32,83
+Laporte,LP 42,Attorney General,,DEM,Destiny Wells,34,2,30,66
+Laporte,LP 42,United States Representative,1,REP,Randy Niemeyer,44,0,31,75
+Laporte,LP 42,United States Representative,1,DEM,Frank J. Mrvan,36,2,32,70
+Laporte,LP 42,United States Representative,1,LIB,Dakotah Miskus,3,0,0,3
+Laporte,LP 42,United States Representative,1,,Write-In,0,0,0,0
+Laporte,LP 42,State Senator District 8,,REP,Mike Bohacek,56,0,34,90
+Laporte,LP 42,State Senator District 8,,DEM,Leon P. Smith,29,2,29,60
+Laporte,LP 42,State Representative,20,REP,Jim Pressel,62,0,41,103
+Laporte,LP 42,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,57,0,36,93
+Laporte,LP 42,Circuit Court Clerk,,REP,Heather Stevens,51,0,30,81
+Laporte,LP 42,Circuit Court Clerk,,DEM,Angela Henzman,30,2,30,62
+Laporte,LP 42,County Auditor,,REP,Mike Rosenbaum,61,0,39,100
+Laporte,LP 42,County Recorder,,REP,Elzbieta (Ela) Bilderback,54,0,34,88
+Laporte,LP 42,County Recorder,,DEM,Matthew Sikorski,29,2,30,61
+Laporte,LP 42,County Treasurer,,REP,Dan Barenie,47,0,29,76
+Laporte,LP 42,County Treasurer,,DEM,Joie Winski,37,2,34,73
+Laporte,LP 42,County Coroner,,REP,Lynn Swanson,54,0,34,88
+Laporte,LP 42,County Coroner,,DEM,Mark P. Baker,30,2,29,61
+Laporte,LP 42,County Surveyor,,REP,John Matwyshyn,44,0,29,73
+Laporte,LP 42,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,35,2,34,71
+Laporte,LP 42,County Commissioner District 2,,REP,Steve Holifield,46,0,28,74
+Laporte,LP 42,County Commissioner District 2,,DEM,Mike Kellems,34,2,34,70
+Laporte,LP 42,County Commissioner District 3,,REP,Joe Haney,44,0,32,76
+Laporte,LP 42,County Commissioner District 3,,DEM,Randy Novak,38,2,32,72
+Laporte,LP 42,County Council Member At Large,,REP,Brett H. Kessler,42,0,25,67
+Laporte,LP 42,County Council Member At Large,,REP,Adam Koronka,42,0,19,61
+Laporte,LP 42,County Council Member At Large,,REP,Heather Oake,33,0,21,54
+Laporte,LP 42,County Council Member At Large,,DEM,Scott (Scotty) Ford,31,2,23,56
+Laporte,LP 42,County Council Member At Large,,DEM,Mike Mollenhauer,30,1,33,64
+Laporte,LP 42,County Council Member At Large,,DEM,Johnny Stimley,24,1,21,46
+Laporte,LP 42,Laporte Community School Board At Large,,,Jim Arnold,45,1,32,78
+Laporte,LP 42,Laporte Community School Board At Large,,,Monica L. Beaty,43,2,24,69
+Laporte,LP 42,Laporte Community School Board At Large,,,Maria L. Ria Carpenter,37,2,25,64
+Laporte,LP 42,Laporte Community School Board At Large,,,Ed Gilliland,38,0,21,59
+Laporte,LP 42,Laporte Community School Board At Large,,,Tucker King,44,1,26,71
+Laporte,LP 42,IN Supreme Court-Rush,,,Yes,43,1,32,76
+Laporte,LP 42,IN Supreme Court-Rush,,,No,30,1,17,48
+Laporte,LP 42,IN Supreme Court-Massa,,,Yes,48,1,29,78
+Laporte,LP 42,IN Supreme Court-Massa,,,No,27,1,19,47
+Laporte,LP 42,IN Supreme Court-Molter,,,Yes,46,0,31,77
+Laporte,LP 42,IN Supreme Court-Molter,,,No,29,2,17,48
+Laporte,LP 42,Court of Appeals Dist 4-Pyle III,,,Yes,42,0,30,72
+Laporte,LP 42,Court of Appeals Dist 4-Pyle III,,,No,32,2,17,51
+Laporte,LP 42,Straight Party,,DEM,Democratic Party,,,,23
+Laporte,LP 42,Straight Party,,REP,Republican Party,,,,40
+Laporte,LP 43,Ballots Cast,,,,217,36,171,424
+Laporte,LP 43,Registered Voters,,,,,,,730
+Laporte,LP 43,Public Question-Const Amendment,,,Yes,102,10,75,187
+Laporte,LP 43,Public Question-Const Amendment,,,No,83,19,62,164
+Laporte,LP 43,President and Vice-President of the U.S.,,REP,Trump \ Vance,140,10,94,244
+Laporte,LP 43,President and Vice-President of the U.S.,,DEM,Harris \ Walz,75,26,73,174
+Laporte,LP 43,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,0,0,1,1
+Laporte,LP 43,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,0,0,0,0
+Laporte,LP 43,President and Vice-President of the U.S.,,,Write-In,0,0,0,0
+Laporte,LP 43,United States Senator,,REP,Jim Banks,132,9,88,229
+Laporte,LP 43,United States Senator,,DEM,Valerie McCray,69,24,70,163
+Laporte,LP 43,United States Senator,,LIB,Andrew Horning,4,1,0,5
+Laporte,LP 43,United States Senator,,,Write-In,0,0,0,0
+Laporte,LP 43,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,119,9,85,213
+Laporte,LP 43,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,73,24,71,168
+Laporte,LP 43,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,8,1,4,13
+Laporte,LP 43,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,LP 43,Attorney General,,REP,Todd Rokita,133,10,91,234
+Laporte,LP 43,Attorney General,,DEM,Destiny Wells,76,23,71,170
+Laporte,LP 43,United States Representative,1,REP,Randy Niemeyer,127,11,87,225
+Laporte,LP 43,United States Representative,1,DEM,Frank J. Mrvan,78,23,70,171
+Laporte,LP 43,United States Representative,1,LIB,Dakotah Miskus,5,2,2,9
+Laporte,LP 43,United States Representative,1,,Write-In,0,0,0,0
+Laporte,LP 43,State Senator District 8,,REP,Mike Bohacek,140,11,106,257
+Laporte,LP 43,State Senator District 8,,DEM,Leon P. Smith,68,23,58,149
+Laporte,LP 43,State Representative,20,REP,Jim Pressel,164,19,104,287
+Laporte,LP 43,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,161,21,109,291
+Laporte,LP 43,Circuit Court Clerk,,REP,Heather Stevens,136,12,95,243
+Laporte,LP 43,Circuit Court Clerk,,DEM,Angela Henzman,61,21,61,143
+Laporte,LP 43,County Auditor,,REP,Mike Rosenbaum,173,22,113,308
+Laporte,LP 43,County Recorder,,REP,Elzbieta (Ela) Bilderback,137,13,93,243
+Laporte,LP 43,County Recorder,,DEM,Matthew Sikorski,70,20,66,156
+Laporte,LP 43,County Treasurer,,REP,Dan Barenie,127,10,91,228
+Laporte,LP 43,County Treasurer,,DEM,Joie Winski,82,22,72,176
+Laporte,LP 43,County Coroner,,REP,Lynn Swanson,139,12,102,253
+Laporte,LP 43,County Coroner,,DEM,Mark P. Baker,70,20,60,150
+Laporte,LP 43,County Surveyor,,REP,John Matwyshyn,123,11,84,218
+Laporte,LP 43,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,84,22,76,182
+Laporte,LP 43,County Commissioner District 2,,REP,Steve Holifield,123,9,79,211
+Laporte,LP 43,County Commissioner District 2,,DEM,Mike Kellems,80,23,83,186
+Laporte,LP 43,County Commissioner District 3,,REP,Joe Haney,116,8,94,218
+Laporte,LP 43,County Commissioner District 3,,DEM,Randy Novak,88,23,71,182
+Laporte,LP 43,County Council Member At Large,,REP,Brett H. Kessler,108,9,72,189
+Laporte,LP 43,County Council Member At Large,,REP,Adam Koronka,89,7,77,173
+Laporte,LP 43,County Council Member At Large,,REP,Heather Oake,96,10,64,170
+Laporte,LP 43,County Council Member At Large,,DEM,Scott (Scotty) Ford,55,21,56,132
+Laporte,LP 43,County Council Member At Large,,DEM,Mike Mollenhauer,74,20,64,158
+Laporte,LP 43,County Council Member At Large,,DEM,Johnny Stimley,51,21,45,117
+Laporte,LP 43,Laporte Community School Board At Large,,,Jim Arnold,106,23,93,222
+Laporte,LP 43,Laporte Community School Board At Large,,,Monica L. Beaty,92,19,83,194
+Laporte,LP 43,Laporte Community School Board At Large,,,Maria L. Ria Carpenter,82,16,60,158
+Laporte,LP 43,Laporte Community School Board At Large,,,Ed Gilliland,77,13,61,151
+Laporte,LP 43,Laporte Community School Board At Large,,,Tucker King,99,14,66,179
+Laporte,LP 43,IN Supreme Court-Rush,,,Yes,128,21,82,231
+Laporte,LP 43,IN Supreme Court-Rush,,,No,49,8,43,100
+Laporte,LP 43,IN Supreme Court-Massa,,,Yes,115,21,80,216
+Laporte,LP 43,IN Supreme Court-Massa,,,No,61,7,44,112
+Laporte,LP 43,IN Supreme Court-Molter,,,Yes,120,21,79,220
+Laporte,LP 43,IN Supreme Court-Molter,,,No,57,8,44,109
+Laporte,LP 43,Court of Appeals Dist 4-Pyle III,,,Yes,121,17,78,216
+Laporte,LP 43,Court of Appeals Dist 4-Pyle III,,,No,57,10,44,111
+Laporte,LP 43,Straight Party,,DEM,Democratic Party,,,,46
+Laporte,LP 43,Straight Party,,REP,Republican Party,,,,101
+Laporte,LP 44,Ballots Cast,,,,262,20,199,481
+Laporte,LP 44,Registered Voters,,,,,,,860
+Laporte,LP 44,Public Question-Const Amendment,,,Yes,132,9,91,232
+Laporte,LP 44,Public Question-Const Amendment,,,No,102,6,86,194
+Laporte,LP 44,President and Vice-President of the U.S.,,REP,Trump \ Vance,156,11,102,269
+Laporte,LP 44,President and Vice-President of the U.S.,,DEM,Harris \ Walz,91,9,93,193
+Laporte,LP 44,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,3,0,0,3
+Laporte,LP 44,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,7,0,4,11
+Laporte,LP 44,President and Vice-President of the U.S.,,,Write-In,3,0,0,3
+Laporte,LP 44,United States Senator,,REP,Jim Banks,149,10,98,257
+Laporte,LP 44,United States Senator,,DEM,Valerie McCray,89,9,87,185
+Laporte,LP 44,United States Senator,,LIB,Andrew Horning,12,1,7,20
+Laporte,LP 44,United States Senator,,,Write-In,0,0,0,0
+Laporte,LP 44,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,137,8,98,243
+Laporte,LP 44,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,97,10,88,195
+Laporte,LP 44,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,13,2,7,22
+Laporte,LP 44,Governor And Lieutenant Governor,,,Write-In,1,0,0,1
+Laporte,LP 44,Attorney General,,REP,Todd Rokita,151,10,101,262
+Laporte,LP 44,Attorney General,,DEM,Destiny Wells,94,10,91,195
+Laporte,LP 44,United States Representative,1,REP,Randy Niemeyer,132,12,90,234
+Laporte,LP 44,United States Representative,1,DEM,Frank J. Mrvan,104,8,99,211
+Laporte,LP 44,United States Representative,1,LIB,Dakotah Miskus,8,0,7,15
+Laporte,LP 44,United States Representative,1,,Write-In,1,0,0,1
+Laporte,LP 44,State Senator District 8,,REP,Mike Bohacek,161,14,123,298
+Laporte,LP 44,State Senator District 8,,DEM,Leon P. Smith,86,6,73,165
+Laporte,LP 44,State Representative,20,REP,Jim Pressel,190,14,135,339
+Laporte,LP 44,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,180,14,137,331
+Laporte,LP 44,Circuit Court Clerk,,REP,Heather Stevens,156,12,107,275
+Laporte,LP 44,Circuit Court Clerk,,DEM,Angela Henzman,86,8,83,177
+Laporte,LP 44,County Auditor,,REP,Mike Rosenbaum,191,14,137,342
+Laporte,LP 44,County Recorder,,REP,Elzbieta (Ela) Bilderback,148,12,102,262
+Laporte,LP 44,County Recorder,,DEM,Matthew Sikorski,92,8,90,190
+Laporte,LP 44,County Treasurer,,REP,Dan Barenie,145,11,100,256
+Laporte,LP 44,County Treasurer,,DEM,Joie Winski,97,9,93,199
+Laporte,LP 44,County Coroner,,REP,Lynn Swanson,157,14,110,281
+Laporte,LP 44,County Coroner,,DEM,Mark P. Baker,86,6,84,176
+Laporte,LP 44,County Surveyor,,REP,John Matwyshyn,139,10,95,244
+Laporte,LP 44,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,103,9,99,211
+Laporte,LP 44,County Commissioner District 2,,REP,Steve Holifield,150,10,91,251
+Laporte,LP 44,County Commissioner District 2,,DEM,Mike Kellems,95,10,102,207
+Laporte,LP 44,County Commissioner District 3,,REP,Joe Haney,142,11,97,250
+Laporte,LP 44,County Commissioner District 3,,DEM,Randy Novak,101,8,96,205
+Laporte,LP 44,County Council Member At Large,,REP,Brett H. Kessler,123,9,82,214
+Laporte,LP 44,County Council Member At Large,,REP,Adam Koronka,116,6,80,202
+Laporte,LP 44,County Council Member At Large,,REP,Heather Oake,116,11,81,208
+Laporte,LP 44,County Council Member At Large,,DEM,Scott (Scotty) Ford,80,7,83,170
+Laporte,LP 44,County Council Member At Large,,DEM,Mike Mollenhauer,81,6,93,180
+Laporte,LP 44,County Council Member At Large,,DEM,Johnny Stimley,63,5,70,138
+Laporte,LP 44,Laporte Community School Board At Large,,,Jim Arnold,120,9,102,231
+Laporte,LP 44,Laporte Community School Board At Large,,,Monica L. Beaty,111,10,84,205
+Laporte,LP 44,Laporte Community School Board At Large,,,Maria L. Ria Carpenter,103,10,83,196
+Laporte,LP 44,Laporte Community School Board At Large,,,Ed Gilliland,97,7,73,177
+Laporte,LP 44,Laporte Community School Board At Large,,,Tucker King,121,6,100,227
+Laporte,LP 44,IN Supreme Court-Rush,,,Yes,141,10,110,261
+Laporte,LP 44,IN Supreme Court-Rush,,,No,67,5,55,127
+Laporte,LP 44,IN Supreme Court-Massa,,,Yes,129,8,105,242
+Laporte,LP 44,IN Supreme Court-Massa,,,No,77,5,58,140
+Laporte,LP 44,IN Supreme Court-Molter,,,Yes,135,8,107,250
+Laporte,LP 44,IN Supreme Court-Molter,,,No,74,6,56,136
+Laporte,LP 44,Court of Appeals Dist 4-Pyle III,,,Yes,129,10,109,248
+Laporte,LP 44,Court of Appeals Dist 4-Pyle III,,,No,78,5,57,140
+Laporte,LP 44,Straight Party,,DEM,Democratic Party,,,,50
+Laporte,LP 44,Straight Party,,REP,Republican Party,,,,109
+Laporte,MC 01,Ballots Cast,,,,228,48,416,692
+Laporte,MC 01,Registered Voters,,,,,,,1162
+Laporte,MC 01,Public Question-Const Amendment,,,Yes,112,18,215,345
+Laporte,MC 01,Public Question-Const Amendment,,,No,94,17,165,276
+Laporte,MC 01,President and Vice-President of the U.S.,,REP,Trump \ Vance,97,13,140,250
+Laporte,MC 01,President and Vice-President of the U.S.,,DEM,Harris \ Walz,121,35,265,421
+Laporte,MC 01,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,2,0,4,6
+Laporte,MC 01,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,4,0,2,6
+Laporte,MC 01,President and Vice-President of the U.S.,,,Write-In,0,0,1,1
+Laporte,MC 01,United States Senator,,REP,Jim Banks,93,15,140,248
+Laporte,MC 01,United States Senator,,DEM,Valerie McCray,117,28,239,384
+Laporte,MC 01,United States Senator,,LIB,Andrew Horning,6,0,10,16
+Laporte,MC 01,United States Senator,,,Write-In,1,0,0,1
+Laporte,MC 01,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,97,15,142,254
+Laporte,MC 01,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,112,28,240,380
+Laporte,MC 01,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,9,0,11,20
+Laporte,MC 01,Governor And Lieutenant Governor,,,Write-In,1,0,0,1
+Laporte,MC 01,Attorney General,,REP,Todd Rokita,104,15,158,277
+Laporte,MC 01,Attorney General,,DEM,Destiny Wells,112,28,237,377
+Laporte,MC 01,United States Representative,1,REP,Randy Niemeyer,86,15,149,250
+Laporte,MC 01,United States Representative,1,DEM,Frank J. Mrvan,126,29,253,408
+Laporte,MC 01,United States Representative,1,LIB,Dakotah Miskus,8,0,4,12
+Laporte,MC 01,United States Representative,1,,Write-In,0,0,0,0
+Laporte,MC 01,State Representative,09,REP,Joel Florek,99,15,145,259
+Laporte,MC 01,State Representative,09,DEM,Patricia A. (Pat) Boy,118,28,248,394
+Laporte,MC 01,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,129,25,194,348
+Laporte,MC 01,Circuit Court Clerk,,REP,Heather Stevens,95,16,150,261
+Laporte,MC 01,Circuit Court Clerk,,DEM,Angela Henzman,113,26,235,374
+Laporte,MC 01,County Auditor,,REP,Mike Rosenbaum,138,25,207,370
+Laporte,MC 01,County Recorder,,REP,Elzbieta (Ela) Bilderback,94,16,157,267
+Laporte,MC 01,County Recorder,,DEM,Matthew Sikorski,112,27,228,367
+Laporte,MC 01,County Treasurer,,REP,Dan Barenie,87,14,141,242
+Laporte,MC 01,County Treasurer,,DEM,Joie Winski,125,28,260,413
+Laporte,MC 01,County Coroner,,REP,Lynn Swanson,110,17,169,296
+Laporte,MC 01,County Coroner,,DEM,Mark P. Baker,103,26,222,351
+Laporte,MC 01,County Surveyor,,REP,John Matwyshyn,89,16,145,250
+Laporte,MC 01,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,117,25,239,381
+Laporte,MC 01,County Commissioner District 2,,REP,Steve Holifield,92,17,148,257
+Laporte,MC 01,County Commissioner District 2,,DEM,Mike Kellems,116,26,239,381
+Laporte,MC 01,County Commissioner District 3,,REP,Joe Haney,86,14,135,235
+Laporte,MC 01,County Commissioner District 3,,DEM,Randy Novak,127,29,256,412
+Laporte,MC 01,County Council Member At Large,,REP,Brett H. Kessler,77,17,119,213
+Laporte,MC 01,County Council Member At Large,,REP,Adam Koronka,72,11,110,193
+Laporte,MC 01,County Council Member At Large,,REP,Heather Oake,74,10,116,200
+Laporte,MC 01,County Council Member At Large,,DEM,Scott (Scotty) Ford,75,14,180,269
+Laporte,MC 01,County Council Member At Large,,DEM,Mike Mollenhauer,72,16,209,297
+Laporte,MC 01,County Council Member At Large,,DEM,Johnny Stimley,92,16,210,318
+Laporte,MC 01,MC Area SB Civil City,,,Marty M. Corley,97,10,199,306
+Laporte,MC 01,MC Area SB Civil City,,,Rodney McCormick,75,9,98,182
+Laporte,MC 01,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,49,3,84,136
+Laporte,MC 01,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,46,3,51,100
+Laporte,MC 01,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,37,6,59,102
+Laporte,MC 01,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,29,6,78,113
+Laporte,MC 01,MC Area SB Michigan/Springfield Twps,,,James Stewart,153,14,272,439
+Laporte,MC 01,IN Supreme Court-Rush,,,Yes,108,17,185,310
+Laporte,MC 01,IN Supreme Court-Rush,,,No,61,8,123,192
+Laporte,MC 01,IN Supreme Court-Massa,,,Yes,110,13,179,302
+Laporte,MC 01,IN Supreme Court-Massa,,,No,58,10,128,196
+Laporte,MC 01,IN Supreme Court-Molter,,,Yes,111,15,174,300
+Laporte,MC 01,IN Supreme Court-Molter,,,No,60,10,133,203
+Laporte,MC 01,Court of Appeals Dist 4-Pyle III,,,Yes,113,18,183,314
+Laporte,MC 01,Court of Appeals Dist 4-Pyle III,,,No,58,8,130,196
+Laporte,MC 01,Straight Party,,DEM,Democratic Party,,,,163
+Laporte,MC 01,Straight Party,,LIB,Libertarian Party,,,,1
+Laporte,MC 01,Straight Party,,REP,Republican Party,,,,112
+Laporte,MC 02,Ballots Cast,,,,164,18,186,368
+Laporte,MC 02,Registered Voters,,,,,,,860
+Laporte,MC 02,Public Question-Const Amendment,,,Yes,88,3,76,167
+Laporte,MC 02,Public Question-Const Amendment,,,No,60,4,73,137
+Laporte,MC 02,President and Vice-President of the U.S.,,REP,Trump \ Vance,51,1,50,102
+Laporte,MC 02,President and Vice-President of the U.S.,,DEM,Harris \ Walz,105,17,130,252
+Laporte,MC 02,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,1,0,1,2
+Laporte,MC 02,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,5,0,1,6
+Laporte,MC 02,President and Vice-President of the U.S.,,,Write-In,0,0,2,2
+Laporte,MC 02,United States Senator,,REP,Jim Banks,44,1,47,92
+Laporte,MC 02,United States Senator,,DEM,Valerie McCray,92,14,120,226
+Laporte,MC 02,United States Senator,,LIB,Andrew Horning,5,0,5,10
+Laporte,MC 02,United States Senator,,,Write-In,0,0,0,0
+Laporte,MC 02,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,44,2,42,88
+Laporte,MC 02,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,97,12,125,234
+Laporte,MC 02,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,5,0,8,13
+Laporte,MC 02,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,MC 02,Attorney General,,REP,Todd Rokita,47,2,45,94
+Laporte,MC 02,Attorney General,,DEM,Destiny Wells,101,12,133,246
+Laporte,MC 02,United States Representative,1,REP,Randy Niemeyer,48,2,45,95
+Laporte,MC 02,United States Representative,1,DEM,Frank J. Mrvan,98,13,129,240
+Laporte,MC 02,United States Representative,1,LIB,Dakotah Miskus,6,0,4,10
+Laporte,MC 02,United States Representative,1,,Write-In,0,0,0,0
+Laporte,MC 02,State Representative,09,REP,Joel Florek,57,2,50,109
+Laporte,MC 02,State Representative,09,DEM,Patricia A. (Pat) Boy,97,13,129,239
+Laporte,MC 02,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,84,5,64,153
+Laporte,MC 02,Circuit Court Clerk,,REP,Heather Stevens,52,2,47,101
+Laporte,MC 02,Circuit Court Clerk,,DEM,Angela Henzman,97,11,126,234
+Laporte,MC 02,County Auditor,,REP,Mike Rosenbaum,87,6,80,173
+Laporte,MC 02,County Recorder,,REP,Elzbieta (Ela) Bilderback,55,1,47,103
+Laporte,MC 02,County Recorder,,DEM,Matthew Sikorski,100,11,122,233
+Laporte,MC 02,County Treasurer,,REP,Dan Barenie,43,1,46,90
+Laporte,MC 02,County Treasurer,,DEM,Joie Winski,110,13,131,254
+Laporte,MC 02,County Coroner,,REP,Lynn Swanson,60,2,53,115
+Laporte,MC 02,County Coroner,,DEM,Mark P. Baker,94,11,120,225
+Laporte,MC 02,County Surveyor,,REP,John Matwyshyn,45,1,45,91
+Laporte,MC 02,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,107,11,128,246
+Laporte,MC 02,County Commissioner District 2,,REP,Steve Holifield,48,1,47,96
+Laporte,MC 02,County Commissioner District 2,,DEM,Mike Kellems,106,12,129,247
+Laporte,MC 02,County Commissioner District 3,,REP,Joe Haney,45,1,45,91
+Laporte,MC 02,County Commissioner District 3,,DEM,Randy Novak,107,12,133,252
+Laporte,MC 02,County Council Member At Large,,REP,Brett H. Kessler,38,1,33,72
+Laporte,MC 02,County Council Member At Large,,REP,Adam Koronka,25,0,26,51
+Laporte,MC 02,County Council Member At Large,,REP,Heather Oake,37,0,23,60
+Laporte,MC 02,County Council Member At Large,,DEM,Scott (Scotty) Ford,67,8,93,168
+Laporte,MC 02,County Council Member At Large,,DEM,Mike Mollenhauer,80,9,94,183
+Laporte,MC 02,County Council Member At Large,,DEM,Johnny Stimley,81,13,110,204
+Laporte,MC 02,MC Area SB Civil City,,,Marty M. Corley,85,1,84,170
+Laporte,MC 02,MC Area SB Civil City,,,Rodney McCormick,45,6,42,93
+Laporte,MC 02,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,41,4,44,89
+Laporte,MC 02,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,30,0,27,57
+Laporte,MC 02,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,25,1,25,51
+Laporte,MC 02,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,25,2,24,51
+Laporte,MC 02,MC Area SB Michigan/Springfield Twps,,,James Stewart,115,7,111,233
+Laporte,MC 02,IN Supreme Court-Rush,,,Yes,75,5,88,168
+Laporte,MC 02,IN Supreme Court-Rush,,,No,55,4,41,100
+Laporte,MC 02,IN Supreme Court-Massa,,,Yes,66,2,74,142
+Laporte,MC 02,IN Supreme Court-Massa,,,No,64,7,52,123
+Laporte,MC 02,IN Supreme Court-Molter,,,Yes,69,2,73,144
+Laporte,MC 02,IN Supreme Court-Molter,,,No,62,7,52,121
+Laporte,MC 02,Court of Appeals Dist 4-Pyle III,,,Yes,67,5,71,143
+Laporte,MC 02,Court of Appeals Dist 4-Pyle III,,,No,63,4,55,122
+Laporte,MC 02,Straight Party,,DEM,Democratic Party,,,,95
+Laporte,MC 02,Straight Party,,REP,Republican Party,,,,29
+Laporte,MC 03,Ballots Cast,,,,223,32,188,443
+Laporte,MC 03,Registered Voters,,,,,,,1020
+Laporte,MC 03,Public Question-Const Amendment,,,Yes,119,10,73,202
+Laporte,MC 03,Public Question-Const Amendment,,,No,82,18,69,169
+Laporte,MC 03,President and Vice-President of the U.S.,,REP,Trump \ Vance,65,6,45,116
+Laporte,MC 03,President and Vice-President of the U.S.,,DEM,Harris \ Walz,148,26,134,308
+Laporte,MC 03,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,2,0,3,5
+Laporte,MC 03,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,2,0,1,3
+Laporte,MC 03,President and Vice-President of the U.S.,,,Write-In,2,0,1,3
+Laporte,MC 03,United States Senator,,REP,Jim Banks,57,6,40,103
+Laporte,MC 03,United States Senator,,DEM,Valerie McCray,140,26,122,288
+Laporte,MC 03,United States Senator,,LIB,Andrew Horning,9,0,8,17
+Laporte,MC 03,United States Senator,,,Write-In,0,0,0,0
+Laporte,MC 03,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,55,2,39,96
+Laporte,MC 03,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,142,26,125,293
+Laporte,MC 03,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,11,4,6,21
+Laporte,MC 03,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,MC 03,Attorney General,,REP,Todd Rokita,58,4,37,99
+Laporte,MC 03,Attorney General,,DEM,Destiny Wells,149,28,135,312
+Laporte,MC 03,United States Representative,1,REP,Randy Niemeyer,57,4,39,100
+Laporte,MC 03,United States Representative,1,DEM,Frank J. Mrvan,146,26,132,304
+Laporte,MC 03,United States Representative,1,LIB,Dakotah Miskus,12,2,8,22
+Laporte,MC 03,United States Representative,1,,Write-In,0,0,0,0
+Laporte,MC 03,State Representative,09,REP,Joel Florek,59,6,42,107
+Laporte,MC 03,State Representative,09,DEM,Patricia A. (Pat) Boy,148,26,134,308
+Laporte,MC 03,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,87,10,58,155
+Laporte,MC 03,Circuit Court Clerk,,REP,Heather Stevens,62,4,38,104
+Laporte,MC 03,Circuit Court Clerk,,DEM,Angela Henzman,138,28,132,298
+Laporte,MC 03,County Auditor,,REP,Mike Rosenbaum,88,10,63,161
+Laporte,MC 03,County Recorder,,REP,Elzbieta (Ela) Bilderback,59,6,42,107
+Laporte,MC 03,County Recorder,,DEM,Matthew Sikorski,142,24,133,299
+Laporte,MC 03,County Treasurer,,REP,Dan Barenie,53,4,38,95
+Laporte,MC 03,County Treasurer,,DEM,Joie Winski,155,28,139,322
+Laporte,MC 03,County Coroner,,REP,Lynn Swanson,71,14,54,139
+Laporte,MC 03,County Coroner,,DEM,Mark P. Baker,135,18,122,275
+Laporte,MC 03,County Surveyor,,REP,John Matwyshyn,55,6,38,99
+Laporte,MC 03,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,146,26,136,308
+Laporte,MC 03,County Commissioner District 2,,REP,Steve Holifield,55,4,45,104
+Laporte,MC 03,County Commissioner District 2,,DEM,Mike Kellems,146,28,126,300
+Laporte,MC 03,County Commissioner District 3,,REP,Joe Haney,53,8,41,102
+Laporte,MC 03,County Commissioner District 3,,DEM,Randy Novak,154,22,132,308
+Laporte,MC 03,County Council Member At Large,,REP,Brett H. Kessler,41,6,31,78
+Laporte,MC 03,County Council Member At Large,,REP,Adam Koronka,33,8,24,65
+Laporte,MC 03,County Council Member At Large,,REP,Heather Oake,39,6,30,75
+Laporte,MC 03,County Council Member At Large,,DEM,Scott (Scotty) Ford,81,22,80,183
+Laporte,MC 03,County Council Member At Large,,DEM,Mike Mollenhauer,99,16,86,201
+Laporte,MC 03,County Council Member At Large,,DEM,Johnny Stimley,98,26,83,207
+Laporte,MC 03,MC Area SB Civil City,,,Marty M. Corley,86,20,80,186
+Laporte,MC 03,MC Area SB Civil City,,,Rodney McCormick,90,10,66,166
+Laporte,MC 03,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,60,12,47,119
+Laporte,MC 03,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,47,6,37,90
+Laporte,MC 03,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,32,2,14,48
+Laporte,MC 03,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,22,8,21,51
+Laporte,MC 03,MC Area SB Michigan/Springfield Twps,,,James Stewart,148,22,114,284
+Laporte,MC 03,IN Supreme Court-Rush,,,Yes,106,16,79,201
+Laporte,MC 03,IN Supreme Court-Rush,,,No,57,12,53,122
+Laporte,MC 03,IN Supreme Court-Massa,,,Yes,94,6,70,170
+Laporte,MC 03,IN Supreme Court-Massa,,,No,64,22,57,143
+Laporte,MC 03,IN Supreme Court-Molter,,,Yes,92,12,71,175
+Laporte,MC 03,IN Supreme Court-Molter,,,No,64,16,56,136
+Laporte,MC 03,Court of Appeals Dist 4-Pyle III,,,Yes,89,10,74,173
+Laporte,MC 03,Court of Appeals Dist 4-Pyle III,,,No,65,18,54,137
+Laporte,MC 03,Straight Party,,DEM,Democratic Party,,,,145
+Laporte,MC 03,Straight Party,,LIB,Libertarian Party,,,,1
+Laporte,MC 03,Straight Party,,REP,Republican Party,,,,45
+Laporte,MC 04,Ballots Cast,,,,185,11,180,376
+Laporte,MC 04,Registered Voters,,,,,,,976
+Laporte,MC 04,Public Question-Const Amendment,,,Yes,88,2,73,163
+Laporte,MC 04,Public Question-Const Amendment,,,No,60,7,68,135
+Laporte,MC 04,President and Vice-President of the U.S.,,REP,Trump \ Vance,43,2,22,67
+Laporte,MC 04,President and Vice-President of the U.S.,,DEM,Harris \ Walz,135,8,152,295
+Laporte,MC 04,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,2,0,1,3
+Laporte,MC 04,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,2,0,2,4
+Laporte,MC 04,President and Vice-President of the U.S.,,,Write-In,0,0,0,0
+Laporte,MC 04,United States Senator,,REP,Jim Banks,38,2,19,59
+Laporte,MC 04,United States Senator,,DEM,Valerie McCray,128,9,141,278
+Laporte,MC 04,United States Senator,,LIB,Andrew Horning,3,0,4,7
+Laporte,MC 04,United States Senator,,,Write-In,0,0,0,0
+Laporte,MC 04,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,38,1,21,60
+Laporte,MC 04,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,125,9,134,268
+Laporte,MC 04,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,6,1,7,14
+Laporte,MC 04,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,MC 04,Attorney General,,REP,Todd Rokita,38,3,21,62
+Laporte,MC 04,Attorney General,,DEM,Destiny Wells,135,8,140,283
+Laporte,MC 04,United States Representative,1,REP,Randy Niemeyer,39,2,18,59
+Laporte,MC 04,United States Representative,1,DEM,Frank J. Mrvan,127,8,143,278
+Laporte,MC 04,United States Representative,1,LIB,Dakotah Miskus,10,1,4,15
+Laporte,MC 04,United States Representative,1,,Write-In,0,0,0,0
+Laporte,MC 04,State Representative,09,REP,Joel Florek,46,2,24,72
+Laporte,MC 04,State Representative,09,DEM,Patricia A. (Pat) Boy,125,9,142,276
+Laporte,MC 04,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,55,6,37,98
+Laporte,MC 04,Circuit Court Clerk,,REP,Heather Stevens,41,2,20,63
+Laporte,MC 04,Circuit Court Clerk,,DEM,Angela Henzman,130,9,142,281
+Laporte,MC 04,County Auditor,,REP,Mike Rosenbaum,63,5,43,111
+Laporte,MC 04,County Recorder,,REP,Elzbieta (Ela) Bilderback,38,3,20,61
+Laporte,MC 04,County Recorder,,DEM,Matthew Sikorski,134,8,143,285
+Laporte,MC 04,County Treasurer,,REP,Dan Barenie,38,2,21,61
+Laporte,MC 04,County Treasurer,,DEM,Joie Winski,134,9,143,286
+Laporte,MC 04,County Coroner,,REP,Lynn Swanson,50,3,27,80
+Laporte,MC 04,County Coroner,,DEM,Mark P. Baker,123,8,136,267
+Laporte,MC 04,County Surveyor,,REP,John Matwyshyn,40,3,18,61
+Laporte,MC 04,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,127,8,144,279
+Laporte,MC 04,County Commissioner District 2,,REP,Steve Holifield,40,2,20,62
+Laporte,MC 04,County Commissioner District 2,,DEM,Mike Kellems,126,9,142,277
+Laporte,MC 04,County Commissioner District 3,,REP,Joe Haney,42,3,22,67
+Laporte,MC 04,County Commissioner District 3,,DEM,Randy Novak,124,8,143,275
+Laporte,MC 04,County Council Member At Large,,REP,Brett H. Kessler,32,2,22,56
+Laporte,MC 04,County Council Member At Large,,REP,Adam Koronka,27,3,11,41
+Laporte,MC 04,County Council Member At Large,,REP,Heather Oake,18,3,12,33
+Laporte,MC 04,County Council Member At Large,,DEM,Scott (Scotty) Ford,76,7,82,165
+Laporte,MC 04,County Council Member At Large,,DEM,Mike Mollenhauer,84,7,93,184
+Laporte,MC 04,County Council Member At Large,,DEM,Johnny Stimley,81,9,91,181
+Laporte,MC 04,MC Area SB Civil City,,,Marty M. Corley,73,6,81,160
+Laporte,MC 04,MC Area SB Civil City,,,Rodney McCormick,75,4,58,137
+Laporte,MC 04,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,55,6,43,104
+Laporte,MC 04,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,44,0,46,90
+Laporte,MC 04,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,24,1,20,45
+Laporte,MC 04,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,17,3,8,28
+Laporte,MC 04,MC Area SB Michigan/Springfield Twps,,,James Stewart,125,9,112,246
+Laporte,MC 04,IN Supreme Court-Rush,,,Yes,87,8,77,172
+Laporte,MC 04,IN Supreme Court-Rush,,,No,46,2,39,87
+Laporte,MC 04,IN Supreme Court-Massa,,,Yes,78,5,67,150
+Laporte,MC 04,IN Supreme Court-Massa,,,No,52,5,46,103
+Laporte,MC 04,IN Supreme Court-Molter,,,Yes,81,6,71,158
+Laporte,MC 04,IN Supreme Court-Molter,,,No,54,4,44,102
+Laporte,MC 04,Court of Appeals Dist 4-Pyle III,,,Yes,77,7,65,149
+Laporte,MC 04,Court of Appeals Dist 4-Pyle III,,,No,55,3,48,106
+Laporte,MC 04,Straight Party,,DEM,Democratic Party,,,,149
+Laporte,MC 04,Straight Party,,REP,Republican Party,,,,24
+Laporte,MC 05,Ballots Cast,,,,192,16,228,436
+Laporte,MC 05,Registered Voters,,,,,,,918
+Laporte,MC 05,Public Question-Const Amendment,,,Yes,101,10,100,211
+Laporte,MC 05,Public Question-Const Amendment,,,No,81,0,89,170
+Laporte,MC 05,President and Vice-President of the U.S.,,REP,Trump \ Vance,87,9,76,172
+Laporte,MC 05,President and Vice-President of the U.S.,,DEM,Harris \ Walz,96,7,148,251
+Laporte,MC 05,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,2,0,0,2
+Laporte,MC 05,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,3,0,2,5
+Laporte,MC 05,President and Vice-President of the U.S.,,,Write-In,2,0,0,2
+Laporte,MC 05,United States Senator,,REP,Jim Banks,68,7,70,145
+Laporte,MC 05,United States Senator,,DEM,Valerie McCray,104,7,140,251
+Laporte,MC 05,United States Senator,,LIB,Andrew Horning,5,0,2,7
+Laporte,MC 05,United States Senator,,,Write-In,1,0,0,1
+Laporte,MC 05,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,64,7,72,143
+Laporte,MC 05,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,99,7,138,244
+Laporte,MC 05,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,14,0,4,18
+Laporte,MC 05,Governor And Lieutenant Governor,,,Write-In,1,0,0,1
+Laporte,MC 05,Attorney General,,REP,Todd Rokita,78,7,77,162
+Laporte,MC 05,Attorney General,,DEM,Destiny Wells,101,7,136,244
+Laporte,MC 05,United States Representative,1,REP,Randy Niemeyer,71,7,67,145
+Laporte,MC 05,United States Representative,1,DEM,Frank J. Mrvan,105,7,150,262
+Laporte,MC 05,United States Representative,1,LIB,Dakotah Miskus,8,0,2,10
+Laporte,MC 05,United States Representative,1,,Write-In,1,0,0,1
+Laporte,MC 05,State Representative,09,REP,Joel Florek,85,7,71,163
+Laporte,MC 05,State Representative,09,DEM,Patricia A. (Pat) Boy,94,7,145,246
+Laporte,MC 05,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,109,6,108,223
+Laporte,MC 05,Circuit Court Clerk,,REP,Heather Stevens,82,7,71,160
+Laporte,MC 05,Circuit Court Clerk,,DEM,Angela Henzman,93,7,140,240
+Laporte,MC 05,County Auditor,,REP,Mike Rosenbaum,114,7,113,234
+Laporte,MC 05,County Recorder,,REP,Elzbieta (Ela) Bilderback,78,6,74,158
+Laporte,MC 05,County Recorder,,DEM,Matthew Sikorski,104,8,140,252
+Laporte,MC 05,County Treasurer,,REP,Dan Barenie,71,7,72,150
+Laporte,MC 05,County Treasurer,,DEM,Joie Winski,111,7,148,266
+Laporte,MC 05,County Coroner,,REP,Lynn Swanson,79,7,80,166
+Laporte,MC 05,County Coroner,,DEM,Mark P. Baker,102,5,140,247
+Laporte,MC 05,County Surveyor,,REP,John Matwyshyn,70,7,66,143
+Laporte,MC 05,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,107,7,148,262
+Laporte,MC 05,County Commissioner District 2,,REP,Steve Holifield,75,7,69,151
+Laporte,MC 05,County Commissioner District 2,,DEM,Mike Kellems,104,7,148,259
+Laporte,MC 05,County Commissioner District 3,,REP,Joe Haney,68,7,71,146
+Laporte,MC 05,County Commissioner District 3,,DEM,Randy Novak,113,7,147,267
+Laporte,MC 05,County Council Member At Large,,REP,Brett H. Kessler,59,4,58,121
+Laporte,MC 05,County Council Member At Large,,REP,Adam Koronka,44,5,48,97
+Laporte,MC 05,County Council Member At Large,,REP,Heather Oake,49,4,45,98
+Laporte,MC 05,County Council Member At Large,,DEM,Scott (Scotty) Ford,75,3,103,181
+Laporte,MC 05,County Council Member At Large,,DEM,Mike Mollenhauer,73,3,121,197
+Laporte,MC 05,County Council Member At Large,,DEM,Johnny Stimley,85,7,122,214
+Laporte,MC 05,MC Area SB Civil City,,,Marty M. Corley,90,4,84,178
+Laporte,MC 05,MC Area SB Civil City,,,Rodney McCormick,77,4,83,164
+Laporte,MC 05,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,54,3,52,109
+Laporte,MC 05,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,27,3,37,67
+Laporte,MC 05,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,33,0,32,65
+Laporte,MC 05,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,33,2,36,71
+Laporte,MC 05,MC Area SB Michigan/Springfield Twps,,,James Stewart,140,6,146,292
+Laporte,MC 05,IN Supreme Court-Rush,,,Yes,110,7,93,210
+Laporte,MC 05,IN Supreme Court-Rush,,,No,45,3,76,124
+Laporte,MC 05,IN Supreme Court-Massa,,,Yes,103,6,88,197
+Laporte,MC 05,IN Supreme Court-Massa,,,No,52,5,81,138
+Laporte,MC 05,IN Supreme Court-Molter,,,Yes,111,6,91,208
+Laporte,MC 05,IN Supreme Court-Molter,,,No,44,5,80,129
+Laporte,MC 05,Court of Appeals Dist 4-Pyle III,,,Yes,108,7,97,212
+Laporte,MC 05,Court of Appeals Dist 4-Pyle III,,,No,45,3,74,122
+Laporte,MC 05,Straight Party,,DEM,Democratic Party,,,,100
+Laporte,MC 05,Straight Party,,REP,Republican Party,,,,66
+Laporte,MC 06,Ballots Cast,,,,238,19,281,538
+Laporte,MC 06,Registered Voters,,,,,,,1001
+Laporte,MC 06,Public Question-Const Amendment,,,Yes,136,10,125,271
+Laporte,MC 06,Public Question-Const Amendment,,,No,81,5,116,202
+Laporte,MC 06,President and Vice-President of the U.S.,,REP,Trump \ Vance,126,7,112,245
+Laporte,MC 06,President and Vice-President of the U.S.,,DEM,Harris \ Walz,100,10,165,275
+Laporte,MC 06,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,3,0,0,3
+Laporte,MC 06,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,5,0,1,6
+Laporte,MC 06,President and Vice-President of the U.S.,,,Write-In,3,1,0,4
+Laporte,MC 06,United States Senator,,REP,Jim Banks,108,8,96,212
+Laporte,MC 06,United States Senator,,DEM,Valerie McCray,102,9,156,267
+Laporte,MC 06,United States Senator,,LIB,Andrew Horning,7,1,3,11
+Laporte,MC 06,United States Senator,,,Write-In,0,0,1,1
+Laporte,MC 06,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,109,6,99,214
+Laporte,MC 06,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,105,11,149,265
+Laporte,MC 06,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,5,1,10,16
+Laporte,MC 06,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,MC 06,Attorney General,,REP,Todd Rokita,125,9,101,235
+Laporte,MC 06,Attorney General,,DEM,Destiny Wells,105,9,160,274
+Laporte,MC 06,United States Representative,1,REP,Randy Niemeyer,105,6,104,215
+Laporte,MC 06,United States Representative,1,DEM,Frank J. Mrvan,109,9,161,279
+Laporte,MC 06,United States Representative,1,LIB,Dakotah Miskus,12,1,4,17
+Laporte,MC 06,United States Representative,1,,Write-In,0,0,0,0
+Laporte,MC 06,State Representative,09,REP,Joel Florek,120,7,109,236
+Laporte,MC 06,State Representative,09,DEM,Patricia A. (Pat) Boy,102,11,157,270
+Laporte,MC 06,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,148,9,136,293
+Laporte,MC 06,Circuit Court Clerk,,REP,Heather Stevens,127,10,110,247
+Laporte,MC 06,Circuit Court Clerk,,DEM,Angela Henzman,93,8,152,253
+Laporte,MC 06,County Auditor,,REP,Mike Rosenbaum,161,10,147,318
+Laporte,MC 06,County Recorder,,REP,Elzbieta (Ela) Bilderback,121,9,105,235
+Laporte,MC 06,County Recorder,,DEM,Matthew Sikorski,102,9,157,268
+Laporte,MC 06,County Treasurer,,REP,Dan Barenie,112,8,102,222
+Laporte,MC 06,County Treasurer,,DEM,Joie Winski,114,10,164,288
+Laporte,MC 06,County Coroner,,REP,Lynn Swanson,126,9,115,250
+Laporte,MC 06,County Coroner,,DEM,Mark P. Baker,97,9,151,257
+Laporte,MC 06,County Surveyor,,REP,John Matwyshyn,112,8,97,217
+Laporte,MC 06,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,110,10,162,282
+Laporte,MC 06,County Commissioner District 2,,REP,Steve Holifield,114,8,99,221
+Laporte,MC 06,County Commissioner District 2,,DEM,Mike Kellems,109,10,164,283
+Laporte,MC 06,County Commissioner District 3,,REP,Joe Haney,107,6,94,207
+Laporte,MC 06,County Commissioner District 3,,DEM,Randy Novak,119,11,170,300
+Laporte,MC 06,County Council Member At Large,,REP,Brett H. Kessler,96,2,84,182
+Laporte,MC 06,County Council Member At Large,,REP,Adam Koronka,68,3,66,137
+Laporte,MC 06,County Council Member At Large,,REP,Heather Oake,68,3,65,136
+Laporte,MC 06,County Council Member At Large,,DEM,Scott (Scotty) Ford,74,6,115,195
+Laporte,MC 06,County Council Member At Large,,DEM,Mike Mollenhauer,85,8,125,218
+Laporte,MC 06,County Council Member At Large,,DEM,Johnny Stimley,94,10,140,244
+Laporte,MC 06,MC Area SB Civil City,,,Marty M. Corley,121,7,127,255
+Laporte,MC 06,MC Area SB Civil City,,,Rodney McCormick,63,4,83,150
+Laporte,MC 06,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,59,2,58,119
+Laporte,MC 06,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,29,4,46,79
+Laporte,MC 06,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,58,1,44,103
+Laporte,MC 06,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,22,3,38,63
+Laporte,MC 06,MC Area SB Michigan/Springfield Twps,,,James Stewart,163,8,182,353
+Laporte,MC 06,IN Supreme Court-Rush,,,Yes,110,8,127,245
+Laporte,MC 06,IN Supreme Court-Rush,,,No,72,5,76,153
+Laporte,MC 06,IN Supreme Court-Massa,,,Yes,111,5,127,243
+Laporte,MC 06,IN Supreme Court-Massa,,,No,71,6,68,145
+Laporte,MC 06,IN Supreme Court-Molter,,,Yes,121,4,137,262
+Laporte,MC 06,IN Supreme Court-Molter,,,No,62,7,61,130
+Laporte,MC 06,Court of Appeals Dist 4-Pyle III,,,Yes,118,6,125,249
+Laporte,MC 06,Court of Appeals Dist 4-Pyle III,,,No,65,7,71,143
+Laporte,MC 06,Straight Party,,DEM,Democratic Party,,,,97
+Laporte,MC 06,Straight Party,,REP,Republican Party,,,,108
+Laporte,MC 07,Ballots Cast,,,,209,10,148,367
+Laporte,MC 07,Registered Voters,,,,,,,840
+Laporte,MC 07,Public Question-Const Amendment,,,Yes,122,2,62,186
+Laporte,MC 07,Public Question-Const Amendment,,,No,69,7,60,136
+Laporte,MC 07,President and Vice-President of the U.S.,,REP,Trump \ Vance,97,2,76,175
+Laporte,MC 07,President and Vice-President of the U.S.,,DEM,Harris \ Walz,107,8,70,185
+Laporte,MC 07,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,0,0,0,0
+Laporte,MC 07,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,5,0,0,5
+Laporte,MC 07,President and Vice-President of the U.S.,,,Write-In,0,0,1,1
+Laporte,MC 07,United States Senator,,REP,Jim Banks,91,2,68,161
+Laporte,MC 07,United States Senator,,DEM,Valerie McCray,101,8,65,174
+Laporte,MC 07,United States Senator,,LIB,Andrew Horning,3,0,1,4
+Laporte,MC 07,United States Senator,,,Write-In,0,0,0,0
+Laporte,MC 07,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,89,2,69,160
+Laporte,MC 07,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,101,8,61,170
+Laporte,MC 07,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,4,0,4,8
+Laporte,MC 07,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,MC 07,Attorney General,,REP,Todd Rokita,87,2,72,161
+Laporte,MC 07,Attorney General,,DEM,Destiny Wells,106,8,64,178
+Laporte,MC 07,United States Representative,1,REP,Randy Niemeyer,85,2,71,158
+Laporte,MC 07,United States Representative,1,DEM,Frank J. Mrvan,109,7,69,185
+Laporte,MC 07,United States Representative,1,LIB,Dakotah Miskus,7,1,3,11
+Laporte,MC 07,United States Representative,1,,Write-In,1,0,0,1
+Laporte,MC 07,State Representative,09,REP,Joel Florek,98,3,72,173
+Laporte,MC 07,State Representative,09,DEM,Patricia A. (Pat) Boy,103,7,64,174
+Laporte,MC 07,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,119,4,79,202
+Laporte,MC 07,Circuit Court Clerk,,REP,Heather Stevens,93,2,71,166
+Laporte,MC 07,Circuit Court Clerk,,DEM,Angela Henzman,101,8,62,171
+Laporte,MC 07,County Auditor,,REP,Mike Rosenbaum,128,3,85,216
+Laporte,MC 07,County Recorder,,REP,Elzbieta (Ela) Bilderback,88,3,72,163
+Laporte,MC 07,County Recorder,,DEM,Matthew Sikorski,109,7,63,179
+Laporte,MC 07,County Treasurer,,REP,Dan Barenie,83,2,67,152
+Laporte,MC 07,County Treasurer,,DEM,Joie Winski,116,8,73,197
+Laporte,MC 07,County Coroner,,REP,Lynn Swanson,101,4,81,186
+Laporte,MC 07,County Coroner,,DEM,Mark P. Baker,100,6,60,166
+Laporte,MC 07,County Surveyor,,REP,John Matwyshyn,87,3,69,159
+Laporte,MC 07,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,109,7,70,186
+Laporte,MC 07,County Commissioner District 2,,REP,Steve Holifield,86,3,73,162
+Laporte,MC 07,County Commissioner District 2,,DEM,Mike Kellems,112,7,64,183
+Laporte,MC 07,County Commissioner District 3,,REP,Joe Haney,82,2,66,150
+Laporte,MC 07,County Commissioner District 3,,DEM,Randy Novak,115,8,74,197
+Laporte,MC 07,County Council Member At Large,,REP,Brett H. Kessler,65,1,43,109
+Laporte,MC 07,County Council Member At Large,,REP,Adam Koronka,47,1,39,87
+Laporte,MC 07,County Council Member At Large,,REP,Heather Oake,47,2,45,94
+Laporte,MC 07,County Council Member At Large,,DEM,Scott (Scotty) Ford,69,4,37,110
+Laporte,MC 07,County Council Member At Large,,DEM,Mike Mollenhauer,81,4,54,139
+Laporte,MC 07,County Council Member At Large,,DEM,Johnny Stimley,91,5,62,158
+Laporte,MC 07,MC Area SB Civil City,,,Marty M. Corley,97,4,68,169
+Laporte,MC 07,MC Area SB Civil City,,,Rodney McCormick,63,3,45,111
+Laporte,MC 07,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,44,2,33,79
+Laporte,MC 07,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,28,2,22,52
+Laporte,MC 07,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,43,1,19,63
+Laporte,MC 07,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,36,1,28,65
+Laporte,MC 07,MC Area SB Michigan/Springfield Twps,,,James Stewart,148,5,99,252
+Laporte,MC 07,IN Supreme Court-Rush,,,Yes,102,3,69,174
+Laporte,MC 07,IN Supreme Court-Rush,,,No,55,3,44,102
+Laporte,MC 07,IN Supreme Court-Massa,,,Yes,97,3,62,162
+Laporte,MC 07,IN Supreme Court-Massa,,,No,56,3,51,110
+Laporte,MC 07,IN Supreme Court-Molter,,,Yes,101,3,65,169
+Laporte,MC 07,IN Supreme Court-Molter,,,No,55,3,51,109
+Laporte,MC 07,Court of Appeals Dist 4-Pyle III,,,Yes,98,2,57,157
+Laporte,MC 07,Court of Appeals Dist 4-Pyle III,,,No,56,4,55,115
+Laporte,MC 07,Straight Party,,DEM,Democratic Party,,,,77
+Laporte,MC 07,Straight Party,,REP,Republican Party,,,,72
+Laporte,MC 08,Ballots Cast,,,,181,13,177,371
+Laporte,MC 08,Registered Voters,,,,,,,685
+Laporte,MC 08,Public Question-Const Amendment,,,Yes,99,9,69,177
+Laporte,MC 08,Public Question-Const Amendment,,,No,66,4,81,151
+Laporte,MC 08,President and Vice-President of the U.S.,,REP,Trump \ Vance,107,2,71,180
+Laporte,MC 08,President and Vice-President of the U.S.,,DEM,Harris \ Walz,70,11,101,182
+Laporte,MC 08,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,1,0,1,2
+Laporte,MC 08,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,2,0,2,4
+Laporte,MC 08,President and Vice-President of the U.S.,,,Write-In,0,0,0,0
+Laporte,MC 08,United States Senator,,REP,Jim Banks,90,3,61,154
+Laporte,MC 08,United States Senator,,DEM,Valerie McCray,67,10,94,171
+Laporte,MC 08,United States Senator,,LIB,Andrew Horning,8,0,2,10
+Laporte,MC 08,United States Senator,,,Write-In,0,0,0,0
+Laporte,MC 08,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,81,1,62,144
+Laporte,MC 08,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,70,11,100,181
+Laporte,MC 08,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,11,1,4,16
+Laporte,MC 08,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,MC 08,Attorney General,,REP,Todd Rokita,103,1,65,169
+Laporte,MC 08,Attorney General,,DEM,Destiny Wells,69,12,101,182
+Laporte,MC 08,United States Representative,1,REP,Randy Niemeyer,85,3,60,148
+Laporte,MC 08,United States Representative,1,DEM,Frank J. Mrvan,78,9,103,190
+Laporte,MC 08,United States Representative,1,LIB,Dakotah Miskus,7,1,1,9
+Laporte,MC 08,United States Representative,1,,Write-In,0,0,0,0
+Laporte,MC 08,State Representative,09,REP,Joel Florek,94,1,67,162
+Laporte,MC 08,State Representative,09,DEM,Patricia A. (Pat) Boy,73,12,102,187
+Laporte,MC 08,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,112,4,76,192
+Laporte,MC 08,Circuit Court Clerk,,REP,Heather Stevens,98,2,67,167
+Laporte,MC 08,Circuit Court Clerk,,DEM,Angela Henzman,66,10,94,170
+Laporte,MC 08,County Auditor,,REP,Mike Rosenbaum,118,4,86,208
+Laporte,MC 08,County Recorder,,REP,Elzbieta (Ela) Bilderback,94,2,68,164
+Laporte,MC 08,County Recorder,,DEM,Matthew Sikorski,73,11,99,183
+Laporte,MC 08,County Treasurer,,REP,Dan Barenie,87,1,58,146
+Laporte,MC 08,County Treasurer,,DEM,Joie Winski,83,12,108,203
+Laporte,MC 08,County Coroner,,REP,Lynn Swanson,100,0,74,174
+Laporte,MC 08,County Coroner,,DEM,Mark P. Baker,71,13,92,176
+Laporte,MC 08,County Surveyor,,REP,John Matwyshyn,90,1,61,152
+Laporte,MC 08,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,73,12,101,186
+Laporte,MC 08,County Commissioner District 2,,REP,Steve Holifield,93,2,61,156
+Laporte,MC 08,County Commissioner District 2,,DEM,Mike Kellems,74,11,102,187
+Laporte,MC 08,County Commissioner District 3,,REP,Joe Haney,82,1,57,140
+Laporte,MC 08,County Commissioner District 3,,DEM,Randy Novak,85,12,107,204
+Laporte,MC 08,County Council Member At Large,,REP,Brett H. Kessler,64,1,56,121
+Laporte,MC 08,County Council Member At Large,,REP,Adam Koronka,52,2,44,98
+Laporte,MC 08,County Council Member At Large,,REP,Heather Oake,53,2,46,101
+Laporte,MC 08,County Council Member At Large,,DEM,Scott (Scotty) Ford,51,7,76,134
+Laporte,MC 08,County Council Member At Large,,DEM,Mike Mollenhauer,57,6,81,144
+Laporte,MC 08,County Council Member At Large,,DEM,Johnny Stimley,68,7,88,163
+Laporte,MC 08,MC Area SB Civil City,,,Marty M. Corley,84,6,75,165
+Laporte,MC 08,MC Area SB Civil City,,,Rodney McCormick,53,3,55,111
+Laporte,MC 08,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,58,5,32,95
+Laporte,MC 08,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,16,0,33,49
+Laporte,MC 08,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,32,1,21,54
+Laporte,MC 08,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,23,1,34,58
+Laporte,MC 08,MC Area SB Michigan/Springfield Twps,,,James Stewart,128,6,109,243
+Laporte,MC 08,IN Supreme Court-Rush,,,Yes,84,5,80,169
+Laporte,MC 08,IN Supreme Court-Rush,,,No,53,5,53,111
+Laporte,MC 08,IN Supreme Court-Massa,,,Yes,91,3,71,165
+Laporte,MC 08,IN Supreme Court-Massa,,,No,47,7,59,113
+Laporte,MC 08,IN Supreme Court-Molter,,,Yes,84,3,67,154
+Laporte,MC 08,IN Supreme Court-Molter,,,No,53,7,63,123
+Laporte,MC 08,Court of Appeals Dist 4-Pyle III,,,Yes,85,4,65,154
+Laporte,MC 08,Court of Appeals Dist 4-Pyle III,,,No,53,6,65,124
+Laporte,MC 08,Straight Party,,DEM,Democratic Party,,,,76
+Laporte,MC 08,Straight Party,,REP,Republican Party,,,,64
+Laporte,MC 09,Ballots Cast,,,,158,8,118,284
+Laporte,MC 09,Registered Voters,,,,,,,831
+Laporte,MC 09,Public Question-Const Amendment,,,Yes,88,2,45,135
+Laporte,MC 09,Public Question-Const Amendment,,,No,49,6,51,106
+Laporte,MC 09,President and Vice-President of the U.S.,,REP,Trump \ Vance,60,0,24,84
+Laporte,MC 09,President and Vice-President of the U.S.,,DEM,Harris \ Walz,91,8,94,193
+Laporte,MC 09,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,1,0,0,1
+Laporte,MC 09,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,2,0,0,2
+Laporte,MC 09,President and Vice-President of the U.S.,,,Write-In,1,0,0,1
+Laporte,MC 09,United States Senator,,REP,Jim Banks,57,0,18,75
+Laporte,MC 09,United States Senator,,DEM,Valerie McCray,83,8,80,171
+Laporte,MC 09,United States Senator,,LIB,Andrew Horning,4,0,2,6
+Laporte,MC 09,United States Senator,,,Write-In,0,0,1,1
+Laporte,MC 09,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,52,0,17,69
+Laporte,MC 09,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,81,8,85,174
+Laporte,MC 09,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,7,0,3,10
+Laporte,MC 09,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,MC 09,Attorney General,,REP,Todd Rokita,57,0,22,79
+Laporte,MC 09,Attorney General,,DEM,Destiny Wells,87,8,82,177
+Laporte,MC 09,United States Representative,1,REP,Randy Niemeyer,47,0,17,64
+Laporte,MC 09,United States Representative,1,DEM,Frank J. Mrvan,91,8,84,183
+Laporte,MC 09,United States Representative,1,LIB,Dakotah Miskus,6,0,5,11
+Laporte,MC 09,United States Representative,1,,Write-In,0,0,0,0
+Laporte,MC 09,State Representative,09,REP,Joel Florek,63,0,23,86
+Laporte,MC 09,State Representative,09,DEM,Patricia A. (Pat) Boy,82,8,83,173
+Laporte,MC 09,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,64,3,32,99
+Laporte,MC 09,Circuit Court Clerk,,REP,Heather Stevens,57,0,23,80
+Laporte,MC 09,Circuit Court Clerk,,DEM,Angela Henzman,85,8,77,170
+Laporte,MC 09,County Auditor,,REP,Mike Rosenbaum,72,3,39,114
+Laporte,MC 09,County Recorder,,REP,Elzbieta (Ela) Bilderback,56,0,28,84
+Laporte,MC 09,County Recorder,,DEM,Matthew Sikorski,88,8,74,170
+Laporte,MC 09,County Treasurer,,REP,Dan Barenie,51,0,18,69
+Laporte,MC 09,County Treasurer,,DEM,Joie Winski,95,8,86,189
+Laporte,MC 09,County Coroner,,REP,Lynn Swanson,64,0,28,92
+Laporte,MC 09,County Coroner,,DEM,Mark P. Baker,82,8,77,167
+Laporte,MC 09,County Surveyor,,REP,John Matwyshyn,49,0,20,69
+Laporte,MC 09,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,92,8,82,182
+Laporte,MC 09,County Commissioner District 2,,REP,Steve Holifield,57,0,23,80
+Laporte,MC 09,County Commissioner District 2,,DEM,Mike Kellems,87,8,78,173
+Laporte,MC 09,County Commissioner District 3,,REP,Joe Haney,54,3,18,75
+Laporte,MC 09,County Commissioner District 3,,DEM,Randy Novak,91,5,83,179
+Laporte,MC 09,County Council Member At Large,,REP,Brett H. Kessler,34,0,15,49
+Laporte,MC 09,County Council Member At Large,,REP,Adam Koronka,24,0,12,36
+Laporte,MC 09,County Council Member At Large,,REP,Heather Oake,23,0,10,33
+Laporte,MC 09,County Council Member At Large,,DEM,Scott (Scotty) Ford,50,7,47,104
+Laporte,MC 09,County Council Member At Large,,DEM,Mike Mollenhauer,51,7,53,111
+Laporte,MC 09,County Council Member At Large,,DEM,Johnny Stimley,49,7,55,111
+Laporte,MC 09,MC Area SB Civil City,,,Marty M. Corley,62,4,62,128
+Laporte,MC 09,MC Area SB Civil City,,,Rodney McCormick,55,3,30,88
+Laporte,MC 09,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,42,1,31,74
+Laporte,MC 09,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,39,5,35,79
+Laporte,MC 09,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,17,1,15,33
+Laporte,MC 09,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,15,0,6,21
+Laporte,MC 09,MC Area SB Michigan/Springfield Twps,,,James Stewart,94,4,71,169
+Laporte,MC 09,IN Supreme Court-Rush,,,Yes,85,3,55,143
+Laporte,MC 09,IN Supreme Court-Rush,,,No,35,4,26,65
+Laporte,MC 09,IN Supreme Court-Massa,,,Yes,76,1,49,126
+Laporte,MC 09,IN Supreme Court-Massa,,,No,42,6,29,77
+Laporte,MC 09,IN Supreme Court-Molter,,,Yes,75,2,54,131
+Laporte,MC 09,IN Supreme Court-Molter,,,No,42,5,27,74
+Laporte,MC 09,Court of Appeals Dist 4-Pyle III,,,Yes,82,3,46,131
+Laporte,MC 09,Court of Appeals Dist 4-Pyle III,,,No,37,4,31,72
+Laporte,MC 09,Straight Party,,DEM,Democratic Party,,,,92
+Laporte,MC 09,Straight Party,,REP,Republican Party,,,,31
+Laporte,MC 10,Ballots Cast,,,,206,17,218,441
+Laporte,MC 10,Registered Voters,,,,,,,1012
+Laporte,MC 10,Public Question-Const Amendment,,,Yes,106,5,100,211
+Laporte,MC 10,Public Question-Const Amendment,,,No,69,6,84,159
+Laporte,MC 10,President and Vice-President of the U.S.,,REP,Trump \ Vance,99,4,95,198
+Laporte,MC 10,President and Vice-President of the U.S.,,DEM,Harris \ Walz,104,13,118,235
+Laporte,MC 10,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,1,0,2,3
+Laporte,MC 10,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,1,0,1,2
+Laporte,MC 10,President and Vice-President of the U.S.,,,Write-In,0,0,0,0
+Laporte,MC 10,United States Senator,,REP,Jim Banks,81,4,92,177
+Laporte,MC 10,United States Senator,,DEM,Valerie McCray,91,12,100,203
+Laporte,MC 10,United States Senator,,LIB,Andrew Horning,4,0,6,10
+Laporte,MC 10,United States Senator,,,Write-In,0,0,0,0
+Laporte,MC 10,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,69,4,88,161
+Laporte,MC 10,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,100,12,106,218
+Laporte,MC 10,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,10,0,6,16
+Laporte,MC 10,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,MC 10,Attorney General,,REP,Todd Rokita,86,4,101,191
+Laporte,MC 10,Attorney General,,DEM,Destiny Wells,96,11,102,209
+Laporte,MC 10,United States Representative,1,REP,Randy Niemeyer,79,4,95,178
+Laporte,MC 10,United States Representative,1,DEM,Frank J. Mrvan,106,12,106,224
+Laporte,MC 10,United States Representative,1,LIB,Dakotah Miskus,6,0,7,13
+Laporte,MC 10,United States Representative,1,,Write-In,0,0,0,0
+Laporte,MC 10,State Representative,09,REP,Joel Florek,92,4,99,195
+Laporte,MC 10,State Representative,09,DEM,Patricia A. (Pat) Boy,91,12,106,209
+Laporte,MC 10,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,115,9,117,241
+Laporte,MC 10,Circuit Court Clerk,,REP,Heather Stevens,88,4,105,197
+Laporte,MC 10,Circuit Court Clerk,,DEM,Angela Henzman,94,12,96,202
+Laporte,MC 10,County Auditor,,REP,Mike Rosenbaum,122,9,126,257
+Laporte,MC 10,County Recorder,,REP,Elzbieta (Ela) Bilderback,79,4,96,179
+Laporte,MC 10,County Recorder,,DEM,Matthew Sikorski,107,12,104,223
+Laporte,MC 10,County Treasurer,,REP,Dan Barenie,82,5,92,179
+Laporte,MC 10,County Treasurer,,DEM,Joie Winski,104,11,112,227
+Laporte,MC 10,County Coroner,,REP,Lynn Swanson,95,4,105,204
+Laporte,MC 10,County Coroner,,DEM,Mark P. Baker,93,12,99,204
+Laporte,MC 10,County Surveyor,,REP,John Matwyshyn,81,4,92,177
+Laporte,MC 10,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,101,12,110,223
+Laporte,MC 10,County Commissioner District 2,,REP,Steve Holifield,82,4,87,173
+Laporte,MC 10,County Commissioner District 2,,DEM,Mike Kellems,102,11,109,222
+Laporte,MC 10,County Commissioner District 3,,REP,Joe Haney,86,4,87,177
+Laporte,MC 10,County Commissioner District 3,,DEM,Randy Novak,98,12,116,226
+Laporte,MC 10,County Council Member At Large,,REP,Brett H. Kessler,59,1,74,134
+Laporte,MC 10,County Council Member At Large,,REP,Adam Koronka,51,1,61,113
+Laporte,MC 10,County Council Member At Large,,REP,Heather Oake,37,4,60,101
+Laporte,MC 10,County Council Member At Large,,DEM,Scott (Scotty) Ford,64,10,74,148
+Laporte,MC 10,County Council Member At Large,,DEM,Mike Mollenhauer,69,10,84,163
+Laporte,MC 10,County Council Member At Large,,DEM,Johnny Stimley,81,11,81,173
+Laporte,MC 10,MC Area SB Civil City,,,Marty M. Corley,88,8,97,193
+Laporte,MC 10,MC Area SB Civil City,,,Rodney McCormick,63,5,66,134
+Laporte,MC 10,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,41,5,53,99
+Laporte,MC 10,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,37,1,34,72
+Laporte,MC 10,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,40,1,33,74
+Laporte,MC 10,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,23,5,27,55
+Laporte,MC 10,MC Area SB Michigan/Springfield Twps,,,James Stewart,141,10,128,279
+Laporte,MC 10,IN Supreme Court-Rush,,,Yes,93,8,95,196
+Laporte,MC 10,IN Supreme Court-Rush,,,No,59,5,54,118
+Laporte,MC 10,IN Supreme Court-Massa,,,Yes,88,8,95,191
+Laporte,MC 10,IN Supreme Court-Massa,,,No,61,5,54,120
+Laporte,MC 10,IN Supreme Court-Molter,,,Yes,98,8,99,205
+Laporte,MC 10,IN Supreme Court-Molter,,,No,55,5,50,110
+Laporte,MC 10,Court of Appeals Dist 4-Pyle III,,,Yes,102,8,92,202
+Laporte,MC 10,Court of Appeals Dist 4-Pyle III,,,No,55,5,56,116
+Laporte,MC 10,Straight Party,,DEM,Democratic Party,,,,86
+Laporte,MC 10,Straight Party,,REP,Republican Party,,,,84
+Laporte,MC 11,Ballots Cast,,,,66,4,42,112
+Laporte,MC 11,Registered Voters,,,,,,,210
+Laporte,MC 11,Public Question-Const Amendment,,,Yes,26,2,16,44
+Laporte,MC 11,Public Question-Const Amendment,,,No,32,1,17,50
+Laporte,MC 11,President and Vice-President of the U.S.,,REP,Trump \ Vance,35,0,12,47
+Laporte,MC 11,President and Vice-President of the U.S.,,DEM,Harris \ Walz,29,4,29,62
+Laporte,MC 11,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,0,0,0,0
+Laporte,MC 11,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,2,0,0,2
+Laporte,MC 11,President and Vice-President of the U.S.,,,Write-In,0,0,0,0
+Laporte,MC 11,United States Senator,,REP,Jim Banks,24,0,7,31
+Laporte,MC 11,United States Senator,,DEM,Valerie McCray,36,3,30,69
+Laporte,MC 11,United States Senator,,LIB,Andrew Horning,3,0,0,3
+Laporte,MC 11,United States Senator,,,Write-In,0,0,0,0
+Laporte,MC 11,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,24,0,7,31
+Laporte,MC 11,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,32,3,31,66
+Laporte,MC 11,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,7,0,1,8
+Laporte,MC 11,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,MC 11,Attorney General,,REP,Todd Rokita,32,0,12,44
+Laporte,MC 11,Attorney General,,DEM,Destiny Wells,32,3,28,63
+Laporte,MC 11,United States Representative,1,REP,Randy Niemeyer,28,0,7,35
+Laporte,MC 11,United States Representative,1,DEM,Frank J. Mrvan,36,3,32,71
+Laporte,MC 11,United States Representative,1,LIB,Dakotah Miskus,2,0,0,2
+Laporte,MC 11,United States Representative,1,,Write-In,0,0,0,0
+Laporte,MC 11,State Representative,09,REP,Joel Florek,27,0,11,38
+Laporte,MC 11,State Representative,09,DEM,Patricia A. (Pat) Boy,37,3,30,70
+Laporte,MC 11,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,38,2,13,53
+Laporte,MC 11,Circuit Court Clerk,,REP,Heather Stevens,28,0,12,40
+Laporte,MC 11,Circuit Court Clerk,,DEM,Angela Henzman,33,3,28,64
+Laporte,MC 11,County Auditor,,REP,Mike Rosenbaum,44,1,15,60
+Laporte,MC 11,County Recorder,,REP,Elzbieta (Ela) Bilderback,34,0,9,43
+Laporte,MC 11,County Recorder,,DEM,Matthew Sikorski,30,3,30,63
+Laporte,MC 11,County Treasurer,,REP,Dan Barenie,25,0,7,32
+Laporte,MC 11,County Treasurer,,DEM,Joie Winski,37,3,32,72
+Laporte,MC 11,County Coroner,,REP,Lynn Swanson,31,1,11,43
+Laporte,MC 11,County Coroner,,DEM,Mark P. Baker,31,2,27,60
+Laporte,MC 11,County Surveyor,,REP,John Matwyshyn,25,0,8,33
+Laporte,MC 11,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,36,3,32,71
+Laporte,MC 11,County Commissioner District 2,,REP,Steve Holifield,25,0,11,36
+Laporte,MC 11,County Commissioner District 2,,DEM,Mike Kellems,36,3,28,67
+Laporte,MC 11,County Commissioner District 3,,REP,Joe Haney,27,0,9,36
+Laporte,MC 11,County Commissioner District 3,,DEM,Randy Novak,35,3,31,69
+Laporte,MC 11,County Council Member At Large,,REP,Brett H. Kessler,21,0,9,30
+Laporte,MC 11,County Council Member At Large,,REP,Adam Koronka,17,0,8,25
+Laporte,MC 11,County Council Member At Large,,REP,Heather Oake,17,0,7,24
+Laporte,MC 11,County Council Member At Large,,DEM,Scott (Scotty) Ford,22,2,20,44
+Laporte,MC 11,County Council Member At Large,,DEM,Mike Mollenhauer,24,3,22,49
+Laporte,MC 11,County Council Member At Large,,DEM,Johnny Stimley,31,3,19,53
+Laporte,MC 11,MC Area SB Civil City,,,Marty M. Corley,27,3,20,50
+Laporte,MC 11,MC Area SB Civil City,,,Rodney McCormick,27,0,9,36
+Laporte,MC 11,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,17,0,7,24
+Laporte,MC 11,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,9,1,7,17
+Laporte,MC 11,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,8,0,5,13
+Laporte,MC 11,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,11,0,8,19
+Laporte,MC 11,MC Area SB Michigan/Springfield Twps,,,James Stewart,49,1,25,75
+Laporte,MC 11,IN Supreme Court-Rush,,,Yes,29,1,19,49
+Laporte,MC 11,IN Supreme Court-Rush,,,No,20,2,10,32
+Laporte,MC 11,IN Supreme Court-Massa,,,Yes,30,1,13,44
+Laporte,MC 11,IN Supreme Court-Massa,,,No,18,2,16,36
+Laporte,MC 11,IN Supreme Court-Molter,,,Yes,27,0,15,42
+Laporte,MC 11,IN Supreme Court-Molter,,,No,21,3,13,37
+Laporte,MC 11,Court of Appeals Dist 4-Pyle III,,,Yes,29,0,14,43
+Laporte,MC 11,Court of Appeals Dist 4-Pyle III,,,No,20,3,14,37
+Laporte,MC 11,Straight Party,,DEM,Democratic Party,,,,26
+Laporte,MC 11,Straight Party,,REP,Republican Party,,,,14
+Laporte,MC 12,Ballots Cast,,,,320,42,358,720
+Laporte,MC 12,Registered Voters,,,,,,,1199
+Laporte,MC 12,Public Question-Const Amendment,,,Yes,157,12,153,322
+Laporte,MC 12,Public Question-Const Amendment,,,No,120,17,164,301
+Laporte,MC 12,President and Vice-President of the U.S.,,REP,Trump \ Vance,161,9,151,321
+Laporte,MC 12,President and Vice-President of the U.S.,,DEM,Harris \ Walz,149,33,204,386
+Laporte,MC 12,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,0,0,1,1
+Laporte,MC 12,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,5,0,0,5
+Laporte,MC 12,President and Vice-President of the U.S.,,,Write-In,0,0,2,2
+Laporte,MC 12,United States Senator,,REP,Jim Banks,133,9,140,282
+Laporte,MC 12,United States Senator,,DEM,Valerie McCray,142,31,184,357
+Laporte,MC 12,United States Senator,,LIB,Andrew Horning,6,0,5,11
+Laporte,MC 12,United States Senator,,,Write-In,1,0,0,1
+Laporte,MC 12,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,137,7,136,280
+Laporte,MC 12,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,146,32,185,363
+Laporte,MC 12,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,8,0,8,16
+Laporte,MC 12,Governor And Lieutenant Governor,,,Write-In,0,0,1,1
+Laporte,MC 12,Attorney General,,REP,Todd Rokita,145,8,151,304
+Laporte,MC 12,Attorney General,,DEM,Destiny Wells,143,32,188,363
+Laporte,MC 12,United States Representative,1,REP,Randy Niemeyer,129,9,138,276
+Laporte,MC 12,United States Representative,1,DEM,Frank J. Mrvan,158,31,201,390
+Laporte,MC 12,United States Representative,1,LIB,Dakotah Miskus,9,0,6,15
+Laporte,MC 12,United States Representative,1,,Write-In,0,0,0,0
+Laporte,MC 12,State Representative,09,REP,Joel Florek,150,8,142,300
+Laporte,MC 12,State Representative,09,DEM,Patricia A. (Pat) Boy,147,34,198,379
+Laporte,MC 12,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,169,22,186,377
+Laporte,MC 12,Circuit Court Clerk,,REP,Heather Stevens,141,11,161,313
+Laporte,MC 12,Circuit Court Clerk,,DEM,Angela Henzman,135,29,174,338
+Laporte,MC 12,County Auditor,,REP,Mike Rosenbaum,192,19,196,407
+Laporte,MC 12,County Recorder,,REP,Elzbieta (Ela) Bilderback,141,9,152,302
+Laporte,MC 12,County Recorder,,DEM,Matthew Sikorski,152,31,187,370
+Laporte,MC 12,County Treasurer,,REP,Dan Barenie,129,7,133,269
+Laporte,MC 12,County Treasurer,,DEM,Joie Winski,162,35,209,406
+Laporte,MC 12,County Coroner,,REP,Lynn Swanson,158,10,173,341
+Laporte,MC 12,County Coroner,,DEM,Mark P. Baker,137,30,168,335
+Laporte,MC 12,County Surveyor,,REP,John Matwyshyn,133,10,130,273
+Laporte,MC 12,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,147,30,204,381
+Laporte,MC 12,County Commissioner District 2,,REP,Steve Holifield,132,8,131,271
+Laporte,MC 12,County Commissioner District 2,,DEM,Mike Kellems,149,32,198,379
+Laporte,MC 12,County Commissioner District 3,,REP,Joe Haney,129,7,125,261
+Laporte,MC 12,County Commissioner District 3,,DEM,Randy Novak,155,34,212,401
+Laporte,MC 12,County Council Member At Large,,REP,Brett H. Kessler,105,6,102,213
+Laporte,MC 12,County Council Member At Large,,REP,Adam Koronka,92,5,89,186
+Laporte,MC 12,County Council Member At Large,,REP,Heather Oake,84,5,90,179
+Laporte,MC 12,County Council Member At Large,,DEM,Scott (Scotty) Ford,100,26,147,273
+Laporte,MC 12,County Council Member At Large,,DEM,Mike Mollenhauer,120,27,163,310
+Laporte,MC 12,County Council Member At Large,,DEM,Johnny Stimley,122,27,173,322
+Laporte,MC 12,MC Area SB Civil City,,,Marty M. Corley,157,23,177,357
+Laporte,MC 12,MC Area SB Civil City,,,Rodney McCormick,101,11,94,206
+Laporte,MC 12,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,70,6,77,153
+Laporte,MC 12,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,74,4,50,128
+Laporte,MC 12,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,55,10,64,129
+Laporte,MC 12,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,34,8,51,93
+Laporte,MC 12,MC Area SB Michigan/Springfield Twps,,,James Stewart,208,28,235,471
+Laporte,MC 12,IN Supreme Court-Rush,,,Yes,151,19,174,344
+Laporte,MC 12,IN Supreme Court-Rush,,,No,87,11,95,193
+Laporte,MC 12,IN Supreme Court-Massa,,,Yes,150,18,166,334
+Laporte,MC 12,IN Supreme Court-Massa,,,No,87,12,98,197
+Laporte,MC 12,IN Supreme Court-Molter,,,Yes,145,18,166,329
+Laporte,MC 12,IN Supreme Court-Molter,,,No,90,12,102,204
+Laporte,MC 12,Court of Appeals Dist 4-Pyle III,,,Yes,151,19,172,342
+Laporte,MC 12,Court of Appeals Dist 4-Pyle III,,,No,90,11,93,194
+Laporte,MC 12,Straight Party,,DEM,Democratic Party,,,,129
+Laporte,MC 12,Straight Party,,REP,Republican Party,,,,124
+Laporte,MC 13,Ballots Cast,,,,203,10,156,369
+Laporte,MC 13,Registered Voters,,,,,,,899
+Laporte,MC 13,Public Question-Const Amendment,,,Yes,118,2,63,183
+Laporte,MC 13,Public Question-Const Amendment,,,No,61,2,59,122
+Laporte,MC 13,President and Vice-President of the U.S.,,REP,Trump \ Vance,62,2,31,95
+Laporte,MC 13,President and Vice-President of the U.S.,,DEM,Harris \ Walz,134,7,121,262
+Laporte,MC 13,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,2,0,1,3
+Laporte,MC 13,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,4,0,0,4
+Laporte,MC 13,President and Vice-President of the U.S.,,,Write-In,1,0,0,1
+Laporte,MC 13,United States Senator,,REP,Jim Banks,53,1,25,79
+Laporte,MC 13,United States Senator,,DEM,Valerie McCray,123,9,111,243
+Laporte,MC 13,United States Senator,,LIB,Andrew Horning,7,0,2,9
+Laporte,MC 13,United States Senator,,,Write-In,0,0,0,0
+Laporte,MC 13,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,53,1,28,82
+Laporte,MC 13,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,121,9,109,239
+Laporte,MC 13,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,11,0,3,14
+Laporte,MC 13,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,MC 13,Attorney General,,REP,Todd Rokita,58,0,32,90
+Laporte,MC 13,Attorney General,,DEM,Destiny Wells,128,9,110,247
+Laporte,MC 13,United States Representative,1,REP,Randy Niemeyer,51,1,29,81
+Laporte,MC 13,United States Representative,1,DEM,Frank J. Mrvan,130,9,116,255
+Laporte,MC 13,United States Representative,1,LIB,Dakotah Miskus,12,0,1,13
+Laporte,MC 13,United States Representative,1,,Write-In,0,0,0,0
+Laporte,MC 13,State Representative,09,REP,Joel Florek,62,1,29,92
+Laporte,MC 13,State Representative,09,DEM,Patricia A. (Pat) Boy,122,9,111,242
+Laporte,MC 13,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,78,2,41,121
+Laporte,MC 13,Circuit Court Clerk,,REP,Heather Stevens,55,0,32,87
+Laporte,MC 13,Circuit Court Clerk,,DEM,Angela Henzman,128,10,107,245
+Laporte,MC 13,County Auditor,,REP,Mike Rosenbaum,83,2,44,129
+Laporte,MC 13,County Recorder,,REP,Elzbieta (Ela) Bilderback,58,1,32,91
+Laporte,MC 13,County Recorder,,DEM,Matthew Sikorski,127,9,109,245
+Laporte,MC 13,County Treasurer,,REP,Dan Barenie,61,1,33,95
+Laporte,MC 13,County Treasurer,,DEM,Joie Winski,123,9,113,245
+Laporte,MC 13,County Coroner,,REP,Lynn Swanson,62,1,36,99
+Laporte,MC 13,County Coroner,,DEM,Mark P. Baker,125,9,109,243
+Laporte,MC 13,County Surveyor,,REP,John Matwyshyn,57,1,30,88
+Laporte,MC 13,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,124,9,106,239
+Laporte,MC 13,County Commissioner District 2,,REP,Steve Holifield,59,1,31,91
+Laporte,MC 13,County Commissioner District 2,,DEM,Mike Kellems,124,9,106,239
+Laporte,MC 13,County Commissioner District 3,,REP,Joe Haney,53,0,28,81
+Laporte,MC 13,County Commissioner District 3,,DEM,Randy Novak,129,10,111,250
+Laporte,MC 13,County Council Member At Large,,REP,Brett H. Kessler,45,1,21,67
+Laporte,MC 13,County Council Member At Large,,REP,Adam Koronka,33,1,19,53
+Laporte,MC 13,County Council Member At Large,,REP,Heather Oake,29,1,25,55
+Laporte,MC 13,County Council Member At Large,,DEM,Scott (Scotty) Ford,75,2,69,146
+Laporte,MC 13,County Council Member At Large,,DEM,Mike Mollenhauer,83,1,67,151
+Laporte,MC 13,County Council Member At Large,,DEM,Johnny Stimley,77,3,73,153
+Laporte,MC 13,MC Area SB Civil City,,,Marty M. Corley,82,4,60,146
+Laporte,MC 13,MC Area SB Civil City,,,Rodney McCormick,65,3,47,115
+Laporte,MC 13,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,61,2,40,103
+Laporte,MC 13,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,40,2,32,74
+Laporte,MC 13,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,27,1,14,42
+Laporte,MC 13,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,16,1,16,33
+Laporte,MC 13,MC Area SB Michigan/Springfield Twps,,,James Stewart,130,5,90,225
+Laporte,MC 13,IN Supreme Court-Rush,,,Yes,92,2,69,163
+Laporte,MC 13,IN Supreme Court-Rush,,,No,59,2,32,93
+Laporte,MC 13,IN Supreme Court-Massa,,,Yes,88,1,69,158
+Laporte,MC 13,IN Supreme Court-Massa,,,No,54,3,35,92
+Laporte,MC 13,IN Supreme Court-Molter,,,Yes,93,2,64,159
+Laporte,MC 13,IN Supreme Court-Molter,,,No,53,2,36,91
+Laporte,MC 13,Court of Appeals Dist 4-Pyle III,,,Yes,89,3,65,157
+Laporte,MC 13,Court of Appeals Dist 4-Pyle III,,,No,55,2,33,90
+Laporte,MC 13,Straight Party,,DEM,Democratic Party,,,,135
+Laporte,MC 13,Straight Party,,LIB,Libertarian Party,,,,2
+Laporte,MC 13,Straight Party,,REP,Republican Party,,,,33
+Laporte,MC 14,Ballots Cast,,,,181,20,122,323
+Laporte,MC 14,Registered Voters,,,,,,,988
+Laporte,MC 14,Public Question-Const Amendment,,,Yes,95,6,57,158
+Laporte,MC 14,Public Question-Const Amendment,,,No,67,8,40,115
+Laporte,MC 14,President and Vice-President of the U.S.,,REP,Trump \ Vance,52,7,33,92
+Laporte,MC 14,President and Vice-President of the U.S.,,DEM,Harris \ Walz,127,13,87,227
+Laporte,MC 14,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,0,0,0,0
+Laporte,MC 14,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,2,0,1,3
+Laporte,MC 14,President and Vice-President of the U.S.,,,Write-In,0,0,0,0
+Laporte,MC 14,United States Senator,,REP,Jim Banks,46,8,32,86
+Laporte,MC 14,United States Senator,,DEM,Valerie McCray,115,12,80,207
+Laporte,MC 14,United States Senator,,LIB,Andrew Horning,6,0,1,7
+Laporte,MC 14,United States Senator,,,Write-In,0,0,0,0
+Laporte,MC 14,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,43,8,30,81
+Laporte,MC 14,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,119,12,80,211
+Laporte,MC 14,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,5,0,2,7
+Laporte,MC 14,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,MC 14,Attorney General,,REP,Todd Rokita,46,7,32,85
+Laporte,MC 14,Attorney General,,DEM,Destiny Wells,128,13,86,227
+Laporte,MC 14,United States Representative,1,REP,Randy Niemeyer,42,7,32,81
+Laporte,MC 14,United States Representative,1,DEM,Frank J. Mrvan,122,13,86,221
+Laporte,MC 14,United States Representative,1,LIB,Dakotah Miskus,9,0,2,11
+Laporte,MC 14,United States Representative,1,,Write-In,0,0,0,0
+Laporte,MC 14,State Representative,09,REP,Joel Florek,56,7,33,96
+Laporte,MC 14,State Representative,09,DEM,Patricia A. (Pat) Boy,115,13,83,211
+Laporte,MC 14,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,68,12,49,129
+Laporte,MC 14,Circuit Court Clerk,,REP,Heather Stevens,50,8,32,90
+Laporte,MC 14,Circuit Court Clerk,,DEM,Angela Henzman,115,11,81,207
+Laporte,MC 14,County Auditor,,REP,Mike Rosenbaum,75,12,55,142
+Laporte,MC 14,County Recorder,,REP,Elzbieta (Ela) Bilderback,48,7,32,87
+Laporte,MC 14,County Recorder,,DEM,Matthew Sikorski,121,12,86,219
+Laporte,MC 14,County Treasurer,,REP,Dan Barenie,47,7,30,84
+Laporte,MC 14,County Treasurer,,DEM,Joie Winski,125,12,89,226
+Laporte,MC 14,County Coroner,,REP,Lynn Swanson,52,9,35,96
+Laporte,MC 14,County Coroner,,DEM,Mark P. Baker,118,10,84,212
+Laporte,MC 14,County Surveyor,,REP,John Matwyshyn,47,7,30,84
+Laporte,MC 14,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,123,12,88,223
+Laporte,MC 14,County Commissioner District 2,,REP,Steve Holifield,49,8,30,87
+Laporte,MC 14,County Commissioner District 2,,DEM,Mike Kellems,118,11,87,216
+Laporte,MC 14,County Commissioner District 3,,REP,Joe Haney,51,8,31,90
+Laporte,MC 14,County Commissioner District 3,,DEM,Randy Novak,117,11,88,216
+Laporte,MC 14,County Council Member At Large,,REP,Brett H. Kessler,43,5,20,68
+Laporte,MC 14,County Council Member At Large,,REP,Adam Koronka,30,5,18,53
+Laporte,MC 14,County Council Member At Large,,REP,Heather Oake,35,5,21,61
+Laporte,MC 14,County Council Member At Large,,DEM,Scott (Scotty) Ford,77,9,59,145
+Laporte,MC 14,County Council Member At Large,,DEM,Mike Mollenhauer,79,8,52,139
+Laporte,MC 14,County Council Member At Large,,DEM,Johnny Stimley,73,7,48,128
+Laporte,MC 14,MC Area SB Civil City,,,Marty M. Corley,73,6,43,122
+Laporte,MC 14,MC Area SB Civil City,,,Rodney McCormick,65,6,35,106
+Laporte,MC 14,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,61,5,32,98
+Laporte,MC 14,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,32,0,18,50
+Laporte,MC 14,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,19,5,12,36
+Laporte,MC 14,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,14,1,16,31
+Laporte,MC 14,MC Area SB Michigan/Springfield Twps,,,James Stewart,126,11,66,203
+Laporte,MC 14,IN Supreme Court-Rush,,,Yes,98,9,51,158
+Laporte,MC 14,IN Supreme Court-Rush,,,No,42,5,34,81
+Laporte,MC 14,IN Supreme Court-Massa,,,Yes,97,7,56,160
+Laporte,MC 14,IN Supreme Court-Massa,,,No,42,6,30,78
+Laporte,MC 14,IN Supreme Court-Molter,,,Yes,91,8,58,157
+Laporte,MC 14,IN Supreme Court-Molter,,,No,44,6,28,78
+Laporte,MC 14,Court of Appeals Dist 4-Pyle III,,,Yes,93,8,50,151
+Laporte,MC 14,Court of Appeals Dist 4-Pyle III,,,No,41,6,37,84
+Laporte,MC 14,Straight Party,,DEM,Democratic Party,,,,129
+Laporte,MC 14,Straight Party,,REP,Republican Party,,,,43
+Laporte,MC 15,Ballots Cast,,,,155,26,270,451
+Laporte,MC 15,Registered Voters,,,,,,,754
+Laporte,MC 15,Public Question-Const Amendment,,,Yes,91,7,101,199
+Laporte,MC 15,Public Question-Const Amendment,,,No,49,14,98,161
+Laporte,MC 15,President and Vice-President of the U.S.,,REP,Trump \ Vance,64,8,84,156
+Laporte,MC 15,President and Vice-President of the U.S.,,DEM,Harris \ Walz,83,18,175,276
+Laporte,MC 15,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,2,0,2,4
+Laporte,MC 15,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,3,0,2,5
+Laporte,MC 15,President and Vice-President of the U.S.,,,Write-In,0,0,1,1
+Laporte,MC 15,United States Senator,,REP,Jim Banks,61,9,76,146
+Laporte,MC 15,United States Senator,,DEM,Valerie McCray,76,16,167,259
+Laporte,MC 15,United States Senator,,LIB,Andrew Horning,4,0,5,9
+Laporte,MC 15,United States Senator,,,Write-In,0,0,0,0
+Laporte,MC 15,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,63,9,78,150
+Laporte,MC 15,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,76,17,170,263
+Laporte,MC 15,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,4,0,5,9
+Laporte,MC 15,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,MC 15,Attorney General,,REP,Todd Rokita,66,8,83,157
+Laporte,MC 15,Attorney General,,DEM,Destiny Wells,81,16,168,265
+Laporte,MC 15,United States Representative,1,REP,Randy Niemeyer,58,8,76,142
+Laporte,MC 15,United States Representative,1,DEM,Frank J. Mrvan,85,16,177,278
+Laporte,MC 15,United States Representative,1,LIB,Dakotah Miskus,7,0,4,11
+Laporte,MC 15,United States Representative,1,,Write-In,0,0,0,0
+Laporte,MC 15,State Representative,09,REP,Joel Florek,69,8,77,154
+Laporte,MC 15,State Representative,09,DEM,Patricia A. (Pat) Boy,79,18,175,272
+Laporte,MC 15,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,84,12,108,204
+Laporte,MC 15,Circuit Court Clerk,,REP,Heather Stevens,68,11,81,160
+Laporte,MC 15,Circuit Court Clerk,,DEM,Angela Henzman,78,14,163,255
+Laporte,MC 15,County Auditor,,REP,Mike Rosenbaum,90,12,122,224
+Laporte,MC 15,County Recorder,,REP,Elzbieta (Ela) Bilderback,64,9,79,152
+Laporte,MC 15,County Recorder,,DEM,Matthew Sikorski,80,15,172,267
+Laporte,MC 15,County Treasurer,,REP,Dan Barenie,59,9,75,143
+Laporte,MC 15,County Treasurer,,DEM,Joie Winski,88,15,180,283
+Laporte,MC 15,County Coroner,,REP,Lynn Swanson,68,11,88,167
+Laporte,MC 15,County Coroner,,DEM,Mark P. Baker,76,13,164,253
+Laporte,MC 15,County Surveyor,,REP,John Matwyshyn,62,10,75,147
+Laporte,MC 15,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,82,13,175,270
+Laporte,MC 15,County Commissioner District 2,,REP,Steve Holifield,63,11,77,151
+Laporte,MC 15,County Commissioner District 2,,DEM,Mike Kellems,82,13,170,265
+Laporte,MC 15,County Commissioner District 3,,REP,Joe Haney,61,6,69,136
+Laporte,MC 15,County Commissioner District 3,,DEM,Randy Novak,89,17,181,287
+Laporte,MC 15,County Council Member At Large,,REP,Brett H. Kessler,50,7,64,121
+Laporte,MC 15,County Council Member At Large,,REP,Adam Koronka,39,6,51,96
+Laporte,MC 15,County Council Member At Large,,REP,Heather Oake,35,6,64,105
+Laporte,MC 15,County Council Member At Large,,DEM,Scott (Scotty) Ford,60,11,128,199
+Laporte,MC 15,County Council Member At Large,,DEM,Mike Mollenhauer,66,13,144,223
+Laporte,MC 15,County Council Member At Large,,DEM,Johnny Stimley,74,11,149,234
+Laporte,MC 15,MC Area SB Civil City,,,Marty M. Corley,67,11,120,198
+Laporte,MC 15,MC Area SB Civil City,,,Rodney McCormick,51,6,65,122
+Laporte,MC 15,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,37,3,46,86
+Laporte,MC 15,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,23,3,42,68
+Laporte,MC 15,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,30,7,35,72
+Laporte,MC 15,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,21,4,45,70
+Laporte,MC 15,MC Area SB Michigan/Springfield Twps,,,James Stewart,110,9,159,278
+Laporte,MC 15,IN Supreme Court-Rush,,,Yes,78,8,117,203
+Laporte,MC 15,IN Supreme Court-Rush,,,No,39,9,63,111
+Laporte,MC 15,IN Supreme Court-Massa,,,Yes,80,8,114,202
+Laporte,MC 15,IN Supreme Court-Massa,,,No,40,9,68,117
+Laporte,MC 15,IN Supreme Court-Molter,,,Yes,74,9,114,197
+Laporte,MC 15,IN Supreme Court-Molter,,,No,40,8,69,117
+Laporte,MC 15,Court of Appeals Dist 4-Pyle III,,,Yes,80,9,114,203
+Laporte,MC 15,Court of Appeals Dist 4-Pyle III,,,No,38,8,67,113
+Laporte,MC 15,Straight Party,,DEM,Democratic Party,,,,113
+Laporte,MC 15,Straight Party,,REP,Republican Party,,,,68
+Laporte,MC 16,Ballots Cast,,,,255,47,273,575
+Laporte,MC 16,Registered Voters,,,,,,,1082
+Laporte,MC 16,Public Question-Const Amendment,,,Yes,122,17,131,270
+Laporte,MC 16,Public Question-Const Amendment,,,No,111,12,100,223
+Laporte,MC 16,President and Vice-President of the U.S.,,REP,Trump \ Vance,90,7,106,203
+Laporte,MC 16,President and Vice-President of the U.S.,,DEM,Harris \ Walz,151,38,162,351
+Laporte,MC 16,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,5,0,0,5
+Laporte,MC 16,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,3,0,0,3
+Laporte,MC 16,President and Vice-President of the U.S.,,,Write-In,3,1,1,5
+Laporte,MC 16,United States Senator,,REP,Jim Banks,84,9,92,185
+Laporte,MC 16,United States Senator,,DEM,Valerie McCray,139,37,155,331
+Laporte,MC 16,United States Senator,,LIB,Andrew Horning,7,0,5,12
+Laporte,MC 16,United States Senator,,,Write-In,0,0,0,0
+Laporte,MC 16,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,90,9,90,189
+Laporte,MC 16,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,136,37,157,330
+Laporte,MC 16,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,5,0,3,8
+Laporte,MC 16,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,MC 16,Attorney General,,REP,Todd Rokita,95,9,100,204
+Laporte,MC 16,Attorney General,,DEM,Destiny Wells,136,37,153,326
+Laporte,MC 16,United States Representative,1,REP,Randy Niemeyer,82,9,91,182
+Laporte,MC 16,United States Representative,1,DEM,Frank J. Mrvan,152,38,166,356
+Laporte,MC 16,United States Representative,1,LIB,Dakotah Miskus,8,0,3,11
+Laporte,MC 16,United States Representative,1,,Write-In,0,0,0,0
+Laporte,MC 16,State Representative,09,REP,Joel Florek,88,7,97,192
+Laporte,MC 16,State Representative,09,DEM,Patricia A. (Pat) Boy,150,40,156,346
+Laporte,MC 16,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,121,14,122,257
+Laporte,MC 16,Circuit Court Clerk,,REP,Heather Stevens,97,11,98,206
+Laporte,MC 16,Circuit Court Clerk,,DEM,Angela Henzman,139,35,147,321
+Laporte,MC 16,County Auditor,,REP,Mike Rosenbaum,132,14,136,282
+Laporte,MC 16,County Recorder,,REP,Elzbieta (Ela) Bilderback,90,10,99,199
+Laporte,MC 16,County Recorder,,DEM,Matthew Sikorski,146,36,149,331
+Laporte,MC 16,County Treasurer,,REP,Dan Barenie,85,7,85,177
+Laporte,MC 16,County Treasurer,,DEM,Joie Winski,156,40,172,368
+Laporte,MC 16,County Coroner,,REP,Lynn Swanson,104,11,113,228
+Laporte,MC 16,County Coroner,,DEM,Mark P. Baker,137,35,140,312
+Laporte,MC 16,County Surveyor,,REP,John Matwyshyn,85,7,83,175
+Laporte,MC 16,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,146,33,163,342
+Laporte,MC 16,County Commissioner District 2,,REP,Steve Holifield,86,8,93,187
+Laporte,MC 16,County Commissioner District 2,,DEM,Mike Kellems,145,37,157,339
+Laporte,MC 16,County Commissioner District 3,,REP,Joe Haney,90,6,89,185
+Laporte,MC 16,County Commissioner District 3,,DEM,Randy Novak,147,40,164,351
+Laporte,MC 16,County Council Member At Large,,REP,Brett H. Kessler,57,6,73,136
+Laporte,MC 16,County Council Member At Large,,REP,Adam Koronka,52,7,64,123
+Laporte,MC 16,County Council Member At Large,,REP,Heather Oake,49,5,65,119
+Laporte,MC 16,County Council Member At Large,,DEM,Scott (Scotty) Ford,99,21,108,228
+Laporte,MC 16,County Council Member At Large,,DEM,Mike Mollenhauer,99,26,125,250
+Laporte,MC 16,County Council Member At Large,,DEM,Johnny Stimley,106,24,130,260
+Laporte,MC 16,MC Area SB Civil City,,,Marty M. Corley,126,18,137,281
+Laporte,MC 16,MC Area SB Civil City,,,Rodney McCormick,80,7,71,158
+Laporte,MC 16,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,57,7,62,126
+Laporte,MC 16,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,49,8,52,109
+Laporte,MC 16,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,42,2,35,79
+Laporte,MC 16,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,39,6,37,82
+Laporte,MC 16,MC Area SB Michigan/Springfield Twps,,,James Stewart,178,19,180,377
+Laporte,MC 16,IN Supreme Court-Rush,,,Yes,120,19,118,257
+Laporte,MC 16,IN Supreme Court-Rush,,,No,77,12,67,156
+Laporte,MC 16,IN Supreme Court-Massa,,,Yes,119,16,114,249
+Laporte,MC 16,IN Supreme Court-Massa,,,No,80,14,71,165
+Laporte,MC 16,IN Supreme Court-Molter,,,Yes,127,16,116,259
+Laporte,MC 16,IN Supreme Court-Molter,,,No,72,14,71,157
+Laporte,MC 16,Court of Appeals Dist 4-Pyle III,,,Yes,124,20,118,262
+Laporte,MC 16,Court of Appeals Dist 4-Pyle III,,,No,76,9,69,154
+Laporte,MC 16,Straight Party,,DEM,Democratic Party,,,,138
+Laporte,MC 16,Straight Party,,REP,Republican Party,,,,72
+Laporte,MC 17,Ballots Cast,,,,217,12,224,453
+Laporte,MC 17,Registered Voters,,,,,,,681
+Laporte,MC 17,Public Question-Const Amendment,,,Yes,114,6,103,223
+Laporte,MC 17,Public Question-Const Amendment,,,No,89,5,89,183
+Laporte,MC 17,President and Vice-President of the U.S.,,REP,Trump \ Vance,90,5,82,177
+Laporte,MC 17,President and Vice-President of the U.S.,,DEM,Harris \ Walz,121,7,135,263
+Laporte,MC 17,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,3,0,1,4
+Laporte,MC 17,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,0,0,1,1
+Laporte,MC 17,President and Vice-President of the U.S.,,,Write-In,0,0,2,2
+Laporte,MC 17,United States Senator,,REP,Jim Banks,75,5,76,156
+Laporte,MC 17,United States Senator,,DEM,Valerie McCray,107,7,125,239
+Laporte,MC 17,United States Senator,,LIB,Andrew Horning,7,0,5,12
+Laporte,MC 17,United States Senator,,,Write-In,1,0,0,1
+Laporte,MC 17,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,73,5,75,153
+Laporte,MC 17,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,114,7,132,253
+Laporte,MC 17,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,5,0,6,11
+Laporte,MC 17,Governor And Lieutenant Governor,,,Write-In,1,0,0,1
+Laporte,MC 17,Attorney General,,REP,Todd Rokita,83,5,86,174
+Laporte,MC 17,Attorney General,,DEM,Destiny Wells,117,7,127,251
+Laporte,MC 17,United States Representative,1,REP,Randy Niemeyer,76,4,77,157
+Laporte,MC 17,United States Representative,1,DEM,Frank J. Mrvan,122,8,132,262
+Laporte,MC 17,United States Representative,1,LIB,Dakotah Miskus,4,0,6,10
+Laporte,MC 17,United States Representative,1,,Write-In,0,0,0,0
+Laporte,MC 17,State Representative,09,REP,Joel Florek,78,5,81,164
+Laporte,MC 17,State Representative,09,DEM,Patricia A. (Pat) Boy,119,7,136,262
+Laporte,MC 17,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,103,5,105,213
+Laporte,MC 17,Circuit Court Clerk,,REP,Heather Stevens,73,5,84,162
+Laporte,MC 17,Circuit Court Clerk,,DEM,Angela Henzman,119,7,128,254
+Laporte,MC 17,County Auditor,,REP,Mike Rosenbaum,119,6,108,233
+Laporte,MC 17,County Recorder,,REP,Elzbieta (Ela) Bilderback,72,6,88,166
+Laporte,MC 17,County Recorder,,DEM,Matthew Sikorski,122,6,124,252
+Laporte,MC 17,County Treasurer,,REP,Dan Barenie,67,3,76,146
+Laporte,MC 17,County Treasurer,,DEM,Joie Winski,134,9,143,286
+Laporte,MC 17,County Coroner,,REP,Lynn Swanson,92,5,93,190
+Laporte,MC 17,County Coroner,,DEM,Mark P. Baker,107,7,122,236
+Laporte,MC 17,County Surveyor,,REP,John Matwyshyn,72,4,77,153
+Laporte,MC 17,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,122,7,134,263
+Laporte,MC 17,County Commissioner District 2,,REP,Steve Holifield,71,5,80,156
+Laporte,MC 17,County Commissioner District 2,,DEM,Mike Kellems,122,7,131,260
+Laporte,MC 17,County Commissioner District 3,,REP,Joe Haney,73,5,74,152
+Laporte,MC 17,County Commissioner District 3,,DEM,Randy Novak,123,7,141,271
+Laporte,MC 17,County Council Member At Large,,REP,Brett H. Kessler,64,5,61,130
+Laporte,MC 17,County Council Member At Large,,REP,Adam Koronka,53,4,57,114
+Laporte,MC 17,County Council Member At Large,,REP,Heather Oake,62,4,53,119
+Laporte,MC 17,County Council Member At Large,,DEM,Scott (Scotty) Ford,91,4,105,200
+Laporte,MC 17,County Council Member At Large,,DEM,Mike Mollenhauer,101,5,126,232
+Laporte,MC 17,County Council Member At Large,,DEM,Johnny Stimley,111,5,126,242
+Laporte,MC 17,MC Area SB Civil City,,,Marty M. Corley,126,5,105,236
+Laporte,MC 17,MC Area SB Civil City,,,Rodney McCormick,57,0,61,118
+Laporte,MC 17,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,41,0,40,81
+Laporte,MC 17,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,49,2,51,102
+Laporte,MC 17,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,47,2,39,88
+Laporte,MC 17,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,31,2,29,62
+Laporte,MC 17,MC Area SB Michigan/Springfield Twps,,,James Stewart,166,4,147,317
+Laporte,MC 17,IN Supreme Court-Rush,,,Yes,112,4,87,203
+Laporte,MC 17,IN Supreme Court-Rush,,,No,57,2,82,141
+Laporte,MC 17,IN Supreme Court-Massa,,,Yes,103,3,88,194
+Laporte,MC 17,IN Supreme Court-Massa,,,No,64,3,79,146
+Laporte,MC 17,IN Supreme Court-Molter,,,Yes,111,4,94,209
+Laporte,MC 17,IN Supreme Court-Molter,,,No,63,2,78,143
+Laporte,MC 17,Court of Appeals Dist 4-Pyle III,,,Yes,108,2,83,193
+Laporte,MC 17,Court of Appeals Dist 4-Pyle III,,,No,64,3,85,152
+Laporte,MC 17,Straight Party,,DEM,Democratic Party,,,,90
+Laporte,MC 17,Straight Party,,LIB,Libertarian Party,,,,1
+Laporte,MC 17,Straight Party,,REP,Republican Party,,,,52
+Laporte,MC 18,Ballots Cast,,,,250,25,300,575
+Laporte,MC 18,Registered Voters,,,,,,,917
+Laporte,MC 18,Public Question-Const Amendment,,,Yes,139,8,127,274
+Laporte,MC 18,Public Question-Const Amendment,,,No,92,8,146,246
+Laporte,MC 18,President and Vice-President of the U.S.,,REP,Trump \ Vance,123,3,115,241
+Laporte,MC 18,President and Vice-President of the U.S.,,DEM,Harris \ Walz,123,22,180,325
+Laporte,MC 18,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,1,0,2,3
+Laporte,MC 18,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,2,0,1,3
+Laporte,MC 18,President and Vice-President of the U.S.,,,Write-In,0,0,2,2
+Laporte,MC 18,United States Senator,,REP,Jim Banks,105,3,112,220
+Laporte,MC 18,United States Senator,,DEM,Valerie McCray,114,22,159,295
+Laporte,MC 18,United States Senator,,LIB,Andrew Horning,12,0,6,18
+Laporte,MC 18,United States Senator,,,Write-In,0,0,0,0
+Laporte,MC 18,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,101,4,106,211
+Laporte,MC 18,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,116,21,168,305
+Laporte,MC 18,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,17,0,5,22
+Laporte,MC 18,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,MC 18,Attorney General,,REP,Todd Rokita,115,4,116,235
+Laporte,MC 18,Attorney General,,DEM,Destiny Wells,116,21,164,301
+Laporte,MC 18,United States Representative,1,REP,Randy Niemeyer,101,4,108,213
+Laporte,MC 18,United States Representative,1,DEM,Frank J. Mrvan,127,20,175,322
+Laporte,MC 18,United States Representative,1,LIB,Dakotah Miskus,10,1,5,16
+Laporte,MC 18,United States Representative,1,,Write-In,0,0,0,0
+Laporte,MC 18,State Representative,09,REP,Joel Florek,110,3,112,225
+Laporte,MC 18,State Representative,09,DEM,Patricia A. (Pat) Boy,128,21,172,321
+Laporte,MC 18,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,146,6,154,306
+Laporte,MC 18,Circuit Court Clerk,,REP,Heather Stevens,116,3,108,227
+Laporte,MC 18,Circuit Court Clerk,,DEM,Angela Henzman,111,21,164,296
+Laporte,MC 18,County Auditor,,REP,Mike Rosenbaum,154,5,164,323
+Laporte,MC 18,County Recorder,,REP,Elzbieta (Ela) Bilderback,109,3,119,231
+Laporte,MC 18,County Recorder,,DEM,Matthew Sikorski,121,21,162,304
+Laporte,MC 18,County Treasurer,,REP,Dan Barenie,102,6,107,215
+Laporte,MC 18,County Treasurer,,DEM,Joie Winski,132,18,177,327
+Laporte,MC 18,County Coroner,,REP,Lynn Swanson,109,3,131,243
+Laporte,MC 18,County Coroner,,DEM,Mark P. Baker,121,21,153,295
+Laporte,MC 18,County Surveyor,,REP,John Matwyshyn,96,4,101,201
+Laporte,MC 18,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,135,19,174,328
+Laporte,MC 18,County Commissioner District 2,,REP,Steve Holifield,105,3,108,216
+Laporte,MC 18,County Commissioner District 2,,DEM,Mike Kellems,126,21,172,319
+Laporte,MC 18,County Commissioner District 3,,REP,Joe Haney,89,4,106,199
+Laporte,MC 18,County Commissioner District 3,,DEM,Randy Novak,143,19,177,339
+Laporte,MC 18,County Council Member At Large,,REP,Brett H. Kessler,78,2,88,168
+Laporte,MC 18,County Council Member At Large,,REP,Adam Koronka,68,2,71,141
+Laporte,MC 18,County Council Member At Large,,REP,Heather Oake,63,2,74,139
+Laporte,MC 18,County Council Member At Large,,DEM,Scott (Scotty) Ford,86,17,152,255
+Laporte,MC 18,County Council Member At Large,,DEM,Mike Mollenhauer,119,17,159,295
+Laporte,MC 18,County Council Member At Large,,DEM,Johnny Stimley,130,19,176,325
+Laporte,MC 18,MC Area SB Civil City,,,Marty M. Corley,119,12,149,280
+Laporte,MC 18,MC Area SB Civil City,,,Rodney McCormick,85,6,89,180
+Laporte,MC 18,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,56,2,63,121
+Laporte,MC 18,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,34,4,57,95
+Laporte,MC 18,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,60,2,49,111
+Laporte,MC 18,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,38,8,55,101
+Laporte,MC 18,MC Area SB Michigan/Springfield Twps,,,James Stewart,177,10,203,390
+Laporte,MC 18,IN Supreme Court-Rush,,,Yes,123,10,148,281
+Laporte,MC 18,IN Supreme Court-Rush,,,No,81,9,88,178
+Laporte,MC 18,IN Supreme Court-Massa,,,Yes,116,6,142,264
+Laporte,MC 18,IN Supreme Court-Massa,,,No,84,12,93,189
+Laporte,MC 18,IN Supreme Court-Molter,,,Yes,115,7,140,262
+Laporte,MC 18,IN Supreme Court-Molter,,,No,89,11,91,191
+Laporte,MC 18,Court of Appeals Dist 4-Pyle III,,,Yes,113,10,141,264
+Laporte,MC 18,Court of Appeals Dist 4-Pyle III,,,No,90,9,87,186
+Laporte,MC 18,Straight Party,,DEM,Democratic Party,,,,100
+Laporte,MC 18,Straight Party,,REP,Republican Party,,,,89
+Laporte,MC 19,Ballots Cast,,,,289,17,203,509
+Laporte,MC 19,Registered Voters,,,,,,,973
+Laporte,MC 19,Public Question-Const Amendment,,,Yes,151,8,93,252
+Laporte,MC 19,Public Question-Const Amendment,,,No,110,4,80,194
+Laporte,MC 19,President and Vice-President of the U.S.,,REP,Trump \ Vance,134,1,92,227
+Laporte,MC 19,President and Vice-President of the U.S.,,DEM,Harris \ Walz,148,15,104,267
+Laporte,MC 19,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,1,1,2,4
+Laporte,MC 19,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,1,0,4,5
+Laporte,MC 19,President and Vice-President of the U.S.,,,Write-In,1,0,0,1
+Laporte,MC 19,United States Senator,,REP,Jim Banks,121,2,77,200
+Laporte,MC 19,United States Senator,,DEM,Valerie McCray,146,14,105,265
+Laporte,MC 19,United States Senator,,LIB,Andrew Horning,3,1,5,9
+Laporte,MC 19,United States Senator,,,Write-In,0,0,0,0
+Laporte,MC 19,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,115,2,79,196
+Laporte,MC 19,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,148,14,103,265
+Laporte,MC 19,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,10,1,5,16
+Laporte,MC 19,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,MC 19,Attorney General,,REP,Todd Rokita,127,1,81,209
+Laporte,MC 19,Attorney General,,DEM,Destiny Wells,145,16,108,269
+Laporte,MC 19,United States Representative,1,REP,Randy Niemeyer,111,1,74,186
+Laporte,MC 19,United States Representative,1,DEM,Frank J. Mrvan,160,16,115,291
+Laporte,MC 19,United States Representative,1,LIB,Dakotah Miskus,4,0,2,6
+Laporte,MC 19,United States Representative,1,,Write-In,0,0,0,0
+Laporte,MC 19,State Representative,09,REP,Joel Florek,130,1,83,214
+Laporte,MC 19,State Representative,09,DEM,Patricia A. (Pat) Boy,141,16,108,265
+Laporte,MC 19,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,159,7,103,269
+Laporte,MC 19,Circuit Court Clerk,,REP,Heather Stevens,125,2,81,208
+Laporte,MC 19,Circuit Court Clerk,,DEM,Angela Henzman,142,15,105,262
+Laporte,MC 19,County Auditor,,REP,Mike Rosenbaum,169,6,111,286
+Laporte,MC 19,County Recorder,,REP,Elzbieta (Ela) Bilderback,121,2,86,209
+Laporte,MC 19,County Recorder,,DEM,Matthew Sikorski,154,15,99,268
+Laporte,MC 19,County Treasurer,,REP,Dan Barenie,115,2,78,195
+Laporte,MC 19,County Treasurer,,DEM,Joie Winski,163,15,112,290
+Laporte,MC 19,County Coroner,,REP,Lynn Swanson,139,4,93,236
+Laporte,MC 19,County Coroner,,DEM,Mark P. Baker,135,13,96,244
+Laporte,MC 19,County Surveyor,,REP,John Matwyshyn,121,3,82,206
+Laporte,MC 19,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,152,14,107,273
+Laporte,MC 19,County Commissioner District 2,,REP,Steve Holifield,120,1,79,200
+Laporte,MC 19,County Commissioner District 2,,DEM,Mike Kellems,155,16,109,280
+Laporte,MC 19,County Commissioner District 3,,REP,Joe Haney,115,2,72,189
+Laporte,MC 19,County Commissioner District 3,,DEM,Randy Novak,159,15,118,292
+Laporte,MC 19,County Council Member At Large,,REP,Brett H. Kessler,96,1,66,163
+Laporte,MC 19,County Council Member At Large,,REP,Adam Koronka,70,2,57,129
+Laporte,MC 19,County Council Member At Large,,REP,Heather Oake,70,3,48,121
+Laporte,MC 19,County Council Member At Large,,DEM,Scott (Scotty) Ford,91,9,85,185
+Laporte,MC 19,County Council Member At Large,,DEM,Mike Mollenhauer,117,7,88,212
+Laporte,MC 19,County Council Member At Large,,DEM,Johnny Stimley,118,8,91,217
+Laporte,MC 19,MC Area SB Civil City,,,Marty M. Corley,128,6,96,230
+Laporte,MC 19,MC Area SB Civil City,,,Rodney McCormick,104,5,61,170
+Laporte,MC 19,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,70,3,44,117
+Laporte,MC 19,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,59,3,44,106
+Laporte,MC 19,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,50,1,33,84
+Laporte,MC 19,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,38,3,17,58
+Laporte,MC 19,MC Area SB Michigan/Springfield Twps,,,James Stewart,205,10,127,342
+Laporte,MC 19,IN Supreme Court-Rush,,,Yes,156,8,102,266
+Laporte,MC 19,IN Supreme Court-Rush,,,No,78,3,48,129
+Laporte,MC 19,IN Supreme Court-Massa,,,Yes,148,6,96,250
+Laporte,MC 19,IN Supreme Court-Massa,,,No,84,5,52,141
+Laporte,MC 19,IN Supreme Court-Molter,,,Yes,148,4,96,248
+Laporte,MC 19,IN Supreme Court-Molter,,,No,83,7,50,140
+Laporte,MC 19,Court of Appeals Dist 4-Pyle III,,,Yes,156,6,98,260
+Laporte,MC 19,Court of Appeals Dist 4-Pyle III,,,No,76,5,49,130
+Laporte,MC 19,Straight Party,,DEM,Democratic Party,,,,109
+Laporte,MC 19,Straight Party,,REP,Republican Party,,,,75
+Laporte,MC 20,Ballots Cast,,,,252,26,228,506
+Laporte,MC 20,Registered Voters,,,,,,,1048
+Laporte,MC 20,Public Question-Const Amendment,,,Yes,131,7,97,235
+Laporte,MC 20,Public Question-Const Amendment,,,No,93,11,91,195
+Laporte,MC 20,President and Vice-President of the U.S.,,REP,Trump \ Vance,96,7,75,178
+Laporte,MC 20,President and Vice-President of the U.S.,,DEM,Harris \ Walz,144,19,148,311
+Laporte,MC 20,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,2,0,1,3
+Laporte,MC 20,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,7,0,1,8
+Laporte,MC 20,President and Vice-President of the U.S.,,,Write-In,0,0,0,0
+Laporte,MC 20,United States Senator,,REP,Jim Banks,77,8,66,151
+Laporte,MC 20,United States Senator,,DEM,Valerie McCray,139,17,139,295
+Laporte,MC 20,United States Senator,,LIB,Andrew Horning,10,1,1,12
+Laporte,MC 20,United States Senator,,,Write-In,3,0,0,3
+Laporte,MC 20,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,73,8,67,148
+Laporte,MC 20,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,142,14,136,292
+Laporte,MC 20,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,16,2,1,19
+Laporte,MC 20,Governor And Lieutenant Governor,,,Write-In,2,0,0,2
+Laporte,MC 20,Attorney General,,REP,Todd Rokita,86,8,74,168
+Laporte,MC 20,Attorney General,,DEM,Destiny Wells,144,17,136,297
+Laporte,MC 20,United States Representative,1,REP,Randy Niemeyer,79,5,69,153
+Laporte,MC 20,United States Representative,1,DEM,Frank J. Mrvan,150,21,147,318
+Laporte,MC 20,United States Representative,1,LIB,Dakotah Miskus,11,0,2,13
+Laporte,MC 20,United States Representative,1,,Write-In,0,0,0,0
+Laporte,MC 20,State Representative,09,REP,Joel Florek,91,6,69,166
+Laporte,MC 20,State Representative,09,DEM,Patricia A. (Pat) Boy,141,20,138,299
+Laporte,MC 20,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,99,12,92,203
+Laporte,MC 20,Circuit Court Clerk,,REP,Heather Stevens,82,8,74,164
+Laporte,MC 20,Circuit Court Clerk,,DEM,Angela Henzman,144,17,128,289
+Laporte,MC 20,County Auditor,,REP,Mike Rosenbaum,121,12,99,232
+Laporte,MC 20,County Recorder,,REP,Elzbieta (Ela) Bilderback,87,7,68,162
+Laporte,MC 20,County Recorder,,DEM,Matthew Sikorski,151,18,147,316
+Laporte,MC 20,County Treasurer,,REP,Dan Barenie,80,8,66,154
+Laporte,MC 20,County Treasurer,,DEM,Joie Winski,158,18,150,326
+Laporte,MC 20,County Coroner,,REP,Lynn Swanson,93,8,86,187
+Laporte,MC 20,County Coroner,,DEM,Mark P. Baker,140,17,127,284
+Laporte,MC 20,County Surveyor,,REP,John Matwyshyn,81,6,61,148
+Laporte,MC 20,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,150,20,147,317
+Laporte,MC 20,County Commissioner District 2,,REP,Steve Holifield,81,5,66,152
+Laporte,MC 20,County Commissioner District 2,,DEM,Mike Kellems,149,21,144,314
+Laporte,MC 20,County Commissioner District 3,,REP,Joe Haney,80,8,60,148
+Laporte,MC 20,County Commissioner District 3,,DEM,Randy Novak,155,18,146,319
+Laporte,MC 20,County Council Member At Large,,REP,Brett H. Kessler,54,7,53,114
+Laporte,MC 20,County Council Member At Large,,REP,Adam Koronka,47,6,49,102
+Laporte,MC 20,County Council Member At Large,,REP,Heather Oake,41,5,45,91
+Laporte,MC 20,County Council Member At Large,,DEM,Scott (Scotty) Ford,93,10,100,203
+Laporte,MC 20,County Council Member At Large,,DEM,Mike Mollenhauer,110,14,112,236
+Laporte,MC 20,County Council Member At Large,,DEM,Johnny Stimley,112,9,117,238
+Laporte,MC 20,MC Area SB Civil City,,,Marty M. Corley,117,15,119,251
+Laporte,MC 20,MC Area SB Civil City,,,Rodney McCormick,93,10,60,163
+Laporte,MC 20,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,61,5,54,120
+Laporte,MC 20,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,62,6,51,119
+Laporte,MC 20,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,42,4,28,74
+Laporte,MC 20,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,27,5,26,58
+Laporte,MC 20,MC Area SB Michigan/Springfield Twps,,,James Stewart,185,18,154,357
+Laporte,MC 20,IN Supreme Court-Rush,,,Yes,133,17,105,255
+Laporte,MC 20,IN Supreme Court-Rush,,,No,67,5,60,132
+Laporte,MC 20,IN Supreme Court-Massa,,,Yes,121,15,97,233
+Laporte,MC 20,IN Supreme Court-Massa,,,No,78,5,64,147
+Laporte,MC 20,IN Supreme Court-Molter,,,Yes,129,16,97,242
+Laporte,MC 20,IN Supreme Court-Molter,,,No,71,6,66,143
+Laporte,MC 20,Court of Appeals Dist 4-Pyle III,,,Yes,124,16,102,242
+Laporte,MC 20,Court of Appeals Dist 4-Pyle III,,,No,76,5,65,146
+Laporte,MC 20,Straight Party,,DEM,Democratic Party,,,,151
+Laporte,MC 20,Straight Party,,REP,Republican Party,,,,55
+Laporte,MC 21,Ballots Cast,,,,67,0,32,99
+Laporte,MC 21,Registered Voters,,,,,,,297
+Laporte,MC 21,Public Question-Const Amendment,,,Yes,46,0,18,64
+Laporte,MC 21,Public Question-Const Amendment,,,No,20,0,12,32
+Laporte,MC 21,President and Vice-President of the U.S.,,REP,Trump \ Vance,17,0,5,22
+Laporte,MC 21,President and Vice-President of the U.S.,,DEM,Harris \ Walz,49,0,26,75
+Laporte,MC 21,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,0,0,0,0
+Laporte,MC 21,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,1,0,0,1
+Laporte,MC 21,President and Vice-President of the U.S.,,,Write-In,0,0,0,0
+Laporte,MC 21,United States Senator,,REP,Jim Banks,15,0,5,20
+Laporte,MC 21,United States Senator,,DEM,Valerie McCray,39,0,24,63
+Laporte,MC 21,United States Senator,,LIB,Andrew Horning,2,0,1,3
+Laporte,MC 21,United States Senator,,,Write-In,0,0,0,0
+Laporte,MC 21,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,15,0,7,22
+Laporte,MC 21,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,42,0,24,66
+Laporte,MC 21,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,1,0,0,1
+Laporte,MC 21,Governor And Lieutenant Governor,,,Write-In,1,0,0,1
+Laporte,MC 21,Attorney General,,REP,Todd Rokita,14,0,6,20
+Laporte,MC 21,Attorney General,,DEM,Destiny Wells,45,0,25,70
+Laporte,MC 21,United States Representative,1,REP,Randy Niemeyer,14,0,7,21
+Laporte,MC 21,United States Representative,1,DEM,Frank J. Mrvan,48,0,25,73
+Laporte,MC 21,United States Representative,1,LIB,Dakotah Miskus,1,0,0,1
+Laporte,MC 21,United States Representative,1,,Write-In,1,0,0,1
+Laporte,MC 21,State Representative,09,REP,Joel Florek,16,0,8,24
+Laporte,MC 21,State Representative,09,DEM,Patricia A. (Pat) Boy,43,0,24,67
+Laporte,MC 21,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,24,0,13,37
+Laporte,MC 21,Circuit Court Clerk,,REP,Heather Stevens,16,0,6,22
+Laporte,MC 21,Circuit Court Clerk,,DEM,Angela Henzman,43,0,25,68
+Laporte,MC 21,County Auditor,,REP,Mike Rosenbaum,27,0,12,39
+Laporte,MC 21,County Recorder,,REP,Elzbieta (Ela) Bilderback,14,0,7,21
+Laporte,MC 21,County Recorder,,DEM,Matthew Sikorski,47,0,24,71
+Laporte,MC 21,County Treasurer,,REP,Dan Barenie,16,0,5,21
+Laporte,MC 21,County Treasurer,,DEM,Joie Winski,48,0,27,75
+Laporte,MC 21,County Coroner,,REP,Lynn Swanson,19,0,7,26
+Laporte,MC 21,County Coroner,,DEM,Mark P. Baker,44,0,25,69
+Laporte,MC 21,County Surveyor,,REP,John Matwyshyn,16,0,7,23
+Laporte,MC 21,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,44,0,25,69
+Laporte,MC 21,County Commissioner District 2,,REP,Steve Holifield,18,0,7,25
+Laporte,MC 21,County Commissioner District 2,,DEM,Mike Kellems,42,0,24,66
+Laporte,MC 21,County Commissioner District 3,,REP,Joe Haney,16,0,7,23
+Laporte,MC 21,County Commissioner District 3,,DEM,Randy Novak,43,0,24,67
+Laporte,MC 21,County Council Member At Large,,REP,Brett H. Kessler,9,0,5,14
+Laporte,MC 21,County Council Member At Large,,REP,Adam Koronka,8,0,4,12
+Laporte,MC 21,County Council Member At Large,,REP,Heather Oake,11,0,6,17
+Laporte,MC 21,County Council Member At Large,,DEM,Scott (Scotty) Ford,33,0,14,47
+Laporte,MC 21,County Council Member At Large,,DEM,Mike Mollenhauer,30,0,19,49
+Laporte,MC 21,County Council Member At Large,,DEM,Johnny Stimley,32,0,18,50
+Laporte,MC 21,MC Area SB Civil City,,,Marty M. Corley,26,0,19,45
+Laporte,MC 21,MC Area SB Civil City,,,Rodney McCormick,23,0,9,32
+Laporte,MC 21,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,23,0,10,33
+Laporte,MC 21,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,8,0,7,15
+Laporte,MC 21,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,11,0,5,16
+Laporte,MC 21,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,6,0,6,12
+Laporte,MC 21,MC Area SB Michigan/Springfield Twps,,,James Stewart,40,0,27,67
+Laporte,MC 21,IN Supreme Court-Rush,,,Yes,34,0,23,57
+Laporte,MC 21,IN Supreme Court-Rush,,,No,17,0,7,24
+Laporte,MC 21,IN Supreme Court-Massa,,,Yes,35,0,16,51
+Laporte,MC 21,IN Supreme Court-Massa,,,No,15,0,13,28
+Laporte,MC 21,IN Supreme Court-Molter,,,Yes,32,0,18,50
+Laporte,MC 21,IN Supreme Court-Molter,,,No,21,0,11,32
+Laporte,MC 21,Court of Appeals Dist 4-Pyle III,,,Yes,35,0,17,52
+Laporte,MC 21,Court of Appeals Dist 4-Pyle III,,,No,17,0,13,30
+Laporte,MC 21,Straight Party,,DEM,Democratic Party,,,,34
+Laporte,MC 21,Straight Party,,REP,Republican Party,,,,11
+Laporte,MC 22,Ballots Cast,,,,296,39,404,739
+Laporte,MC 22,Registered Voters,,,,,,,1444
+Laporte,MC 22,Public Question-Const Amendment,,,Yes,175,21,182,378
+Laporte,MC 22,Public Question-Const Amendment,,,No,99,8,153,260
+Laporte,MC 22,President and Vice-President of the U.S.,,REP,Trump \ Vance,159,7,170,336
+Laporte,MC 22,President and Vice-President of the U.S.,,DEM,Harris \ Walz,122,32,222,376
+Laporte,MC 22,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,6,0,3,9
+Laporte,MC 22,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,3,0,6,9
+Laporte,MC 22,President and Vice-President of the U.S.,,,Write-In,0,0,1,1
+Laporte,MC 22,United States Senator,,REP,Jim Banks,136,11,154,301
+Laporte,MC 22,United States Senator,,DEM,Valerie McCray,118,25,208,351
+Laporte,MC 22,United States Senator,,LIB,Andrew Horning,17,1,6,24
+Laporte,MC 22,United States Senator,,,Write-In,0,0,0,0
+Laporte,MC 22,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,126,9,161,296
+Laporte,MC 22,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,124,28,207,359
+Laporte,MC 22,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,21,1,4,26
+Laporte,MC 22,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,MC 22,Attorney General,,REP,Todd Rokita,161,10,171,342
+Laporte,MC 22,Attorney General,,DEM,Destiny Wells,114,28,209,351
+Laporte,MC 22,United States Representative,1,REP,Randy Niemeyer,132,8,161,301
+Laporte,MC 22,United States Representative,1,DEM,Frank J. Mrvan,128,26,222,376
+Laporte,MC 22,United States Representative,1,LIB,Dakotah Miskus,18,1,5,24
+Laporte,MC 22,United States Representative,1,,Write-In,0,0,0,0
+Laporte,MC 22,State Representative,09,REP,Joel Florek,153,9,166,328
+Laporte,MC 22,State Representative,09,DEM,Patricia A. (Pat) Boy,119,29,215,363
+Laporte,MC 22,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,176,16,190,382
+Laporte,MC 22,Circuit Court Clerk,,REP,Heather Stevens,150,12,173,335
+Laporte,MC 22,Circuit Court Clerk,,DEM,Angela Henzman,118,25,203,346
+Laporte,MC 22,County Auditor,,REP,Mike Rosenbaum,185,16,208,409
+Laporte,MC 22,County Recorder,,REP,Elzbieta (Ela) Bilderback,143,11,164,318
+Laporte,MC 22,County Recorder,,DEM,Matthew Sikorski,123,26,217,366
+Laporte,MC 22,County Treasurer,,REP,Dan Barenie,142,12,163,317
+Laporte,MC 22,County Treasurer,,DEM,Joie Winski,128,25,223,376
+Laporte,MC 22,County Coroner,,REP,Lynn Swanson,156,12,180,348
+Laporte,MC 22,County Coroner,,DEM,Mark P. Baker,119,26,209,354
+Laporte,MC 22,County Surveyor,,REP,John Matwyshyn,137,11,154,302
+Laporte,MC 22,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,132,25,224,381
+Laporte,MC 22,County Commissioner District 2,,REP,Steve Holifield,139,10,160,309
+Laporte,MC 22,County Commissioner District 2,,DEM,Mike Kellems,128,26,217,371
+Laporte,MC 22,County Commissioner District 3,,REP,Joe Haney,137,10,153,300
+Laporte,MC 22,County Commissioner District 3,,DEM,Randy Novak,136,27,228,391
+Laporte,MC 22,County Council Member At Large,,REP,Brett H. Kessler,107,10,111,228
+Laporte,MC 22,County Council Member At Large,,REP,Adam Koronka,100,9,89,198
+Laporte,MC 22,County Council Member At Large,,REP,Heather Oake,95,10,97,202
+Laporte,MC 22,County Council Member At Large,,DEM,Scott (Scotty) Ford,87,12,152,251
+Laporte,MC 22,County Council Member At Large,,DEM,Mike Mollenhauer,101,16,168,285
+Laporte,MC 22,County Council Member At Large,,DEM,Johnny Stimley,101,16,171,288
+Laporte,MC 22,MC Area SB Civil City,,,Marty M. Corley,145,11,143,299
+Laporte,MC 22,MC Area SB Civil City,,,Rodney McCormick,84,9,118,211
+Laporte,MC 22,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,77,5,83,165
+Laporte,MC 22,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,44,4,54,102
+Laporte,MC 22,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,56,9,49,114
+Laporte,MC 22,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,37,4,67,108
+Laporte,MC 22,MC Area SB Michigan/Springfield Twps,,,James Stewart,212,14,232,458
+Laporte,MC 22,IN Supreme Court-Rush,,,Yes,156,19,164,339
+Laporte,MC 22,IN Supreme Court-Rush,,,No,86,7,98,191
+Laporte,MC 22,IN Supreme Court-Massa,,,Yes,158,18,154,330
+Laporte,MC 22,IN Supreme Court-Massa,,,No,80,8,109,197
+Laporte,MC 22,IN Supreme Court-Molter,,,Yes,157,18,162,337
+Laporte,MC 22,IN Supreme Court-Molter,,,No,83,8,98,189
+Laporte,MC 22,Court of Appeals Dist 4-Pyle III,,,Yes,146,19,163,328
+Laporte,MC 22,Court of Appeals Dist 4-Pyle III,,,No,92,6,101,199
+Laporte,MC 22,Straight Party,,DEM,Democratic Party,,,,171
+Laporte,MC 22,Straight Party,,REP,Republican Party,,,,164
+Laporte,MC 23,Ballots Cast,,,,249,49,511,809
+Laporte,MC 23,Registered Voters,,,,,,,1277
+Laporte,MC 23,Public Question-Const Amendment,,,Yes,122,19,251,392
+Laporte,MC 23,Public Question-Const Amendment,,,No,99,21,194,314
+Laporte,MC 23,President and Vice-President of the U.S.,,REP,Trump \ Vance,116,9,181,306
+Laporte,MC 23,President and Vice-President of the U.S.,,DEM,Harris \ Walz,125,37,321,483
+Laporte,MC 23,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,3,0,1,4
+Laporte,MC 23,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,3,0,5,8
+Laporte,MC 23,President and Vice-President of the U.S.,,,Write-In,0,1,0,1
+Laporte,MC 23,United States Senator,,REP,Jim Banks,107,8,176,291
+Laporte,MC 23,United States Senator,,DEM,Valerie McCray,105,37,297,439
+Laporte,MC 23,United States Senator,,LIB,Andrew Horning,5,1,4,10
+Laporte,MC 23,United States Senator,,,Write-In,0,0,1,1
+Laporte,MC 23,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,109,11,174,294
+Laporte,MC 23,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,104,35,302,441
+Laporte,MC 23,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,6,0,7,13
+Laporte,MC 23,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,MC 23,Attorney General,,REP,Todd Rokita,121,9,194,324
+Laporte,MC 23,Attorney General,,DEM,Destiny Wells,102,39,294,435
+Laporte,MC 23,United States Representative,1,REP,Randy Niemeyer,108,9,177,294
+Laporte,MC 23,United States Representative,1,DEM,Frank J. Mrvan,121,36,320,477
+Laporte,MC 23,United States Representative,1,LIB,Dakotah Miskus,4,1,2,7
+Laporte,MC 23,United States Representative,1,,Write-In,0,0,0,0
+Laporte,MC 23,State Representative,09,REP,Joel Florek,116,9,175,300
+Laporte,MC 23,State Representative,09,DEM,Patricia A. (Pat) Boy,112,38,317,467
+Laporte,MC 23,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,137,17,244,398
+Laporte,MC 23,Circuit Court Clerk,,REP,Heather Stevens,115,10,180,305
+Laporte,MC 23,Circuit Court Clerk,,DEM,Angela Henzman,101,38,298,437
+Laporte,MC 23,County Auditor,,REP,Mike Rosenbaum,147,18,245,410
+Laporte,MC 23,County Recorder,,REP,Elzbieta (Ela) Bilderback,118,8,189,315
+Laporte,MC 23,County Recorder,,DEM,Matthew Sikorski,107,39,300,446
+Laporte,MC 23,County Treasurer,,REP,Dan Barenie,103,9,163,275
+Laporte,MC 23,County Treasurer,,DEM,Joie Winski,131,39,331,501
+Laporte,MC 23,County Coroner,,REP,Lynn Swanson,124,13,211,348
+Laporte,MC 23,County Coroner,,DEM,Mark P. Baker,108,33,283,424
+Laporte,MC 23,County Surveyor,,REP,John Matwyshyn,93,10,170,273
+Laporte,MC 23,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,125,36,304,465
+Laporte,MC 23,County Commissioner District 2,,REP,Steve Holifield,102,9,171,282
+Laporte,MC 23,County Commissioner District 2,,DEM,Mike Kellems,116,37,311,464
+Laporte,MC 23,County Commissioner District 3,,REP,Joe Haney,106,8,150,264
+Laporte,MC 23,County Commissioner District 3,,DEM,Randy Novak,127,38,344,509
+Laporte,MC 23,County Council Member At Large,,REP,Brett H. Kessler,92,7,152,251
+Laporte,MC 23,County Council Member At Large,,REP,Adam Koronka,80,6,135,221
+Laporte,MC 23,County Council Member At Large,,REP,Heather Oake,72,7,138,217
+Laporte,MC 23,County Council Member At Large,,DEM,Scott (Scotty) Ford,81,34,233,348
+Laporte,MC 23,County Council Member At Large,,DEM,Mike Mollenhauer,114,33,261,408
+Laporte,MC 23,County Council Member At Large,,DEM,Johnny Stimley,105,33,257,395
+Laporte,MC 23,MC Area SB Civil City,,,Marty M. Corley,117,21,241,379
+Laporte,MC 23,MC Area SB Civil City,,,Rodney McCormick,72,9,130,211
+Laporte,MC 23,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,47,4,90,141
+Laporte,MC 23,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,33,5,77,115
+Laporte,MC 23,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,51,6,69,126
+Laporte,MC 23,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,34,6,90,130
+Laporte,MC 23,MC Area SB Michigan/Springfield Twps,,,James Stewart,160,21,300,481
+Laporte,MC 23,IN Supreme Court-Rush,,,Yes,128,23,222,373
+Laporte,MC 23,IN Supreme Court-Rush,,,No,55,10,158,223
+Laporte,MC 23,IN Supreme Court-Massa,,,Yes,127,15,219,361
+Laporte,MC 23,IN Supreme Court-Massa,,,No,54,16,153,223
+Laporte,MC 23,IN Supreme Court-Molter,,,Yes,130,14,217,361
+Laporte,MC 23,IN Supreme Court-Molter,,,No,52,18,159,229
+Laporte,MC 23,Court of Appeals Dist 4-Pyle III,,,Yes,132,19,217,368
+Laporte,MC 23,Court of Appeals Dist 4-Pyle III,,,No,51,13,157,221
+Laporte,MC 23,Straight Party,,DEM,Democratic Party,,,,175
+Laporte,MC 23,Straight Party,,REP,Republican Party,,,,122
+Laporte,MC 24 NV,Ballots Cast,,,,0,0,0,0
+Laporte,MC 24 NV,Registered Voters,,,,,,,0
+Laporte,MC 24 NV,Public Question-Const Amendment,,,Yes,0,0,0,0
+Laporte,MC 24 NV,Public Question-Const Amendment,,,No,0,0,0,0
+Laporte,MC 24 NV,President and Vice-President of the U.S.,,REP,Trump \ Vance,0,0,0,0
+Laporte,MC 24 NV,President and Vice-President of the U.S.,,DEM,Harris \ Walz,0,0,0,0
+Laporte,MC 24 NV,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,0,0,0,0
+Laporte,MC 24 NV,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,0,0,0,0
+Laporte,MC 24 NV,President and Vice-President of the U.S.,,,Write-In,0,0,0,0
+Laporte,MC 24 NV,United States Senator,,REP,Jim Banks,0,0,0,0
+Laporte,MC 24 NV,United States Senator,,DEM,Valerie McCray,0,0,0,0
+Laporte,MC 24 NV,United States Senator,,LIB,Andrew Horning,0,0,0,0
+Laporte,MC 24 NV,United States Senator,,,Write-In,0,0,0,0
+Laporte,MC 24 NV,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,0,0,0,0
+Laporte,MC 24 NV,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,0,0,0,0
+Laporte,MC 24 NV,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,0,0,0,0
+Laporte,MC 24 NV,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,MC 24 NV,Attorney General,,REP,Todd Rokita,0,0,0,0
+Laporte,MC 24 NV,Attorney General,,DEM,Destiny Wells,0,0,0,0
+Laporte,MC 24 NV,United States Representative,1,REP,Randy Niemeyer,0,0,0,0
+Laporte,MC 24 NV,United States Representative,1,DEM,Frank J. Mrvan,0,0,0,0
+Laporte,MC 24 NV,United States Representative,1,LIB,Dakotah Miskus,0,0,0,0
+Laporte,MC 24 NV,United States Representative,1,,Write-In,0,0,0,0
+Laporte,MC 24 NV,State Representative,09,REP,Joel Florek,0,0,0,0
+Laporte,MC 24 NV,State Representative,09,DEM,Patricia A. (Pat) Boy,0,0,0,0
+Laporte,MC 24 NV,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,0,0,0,0
+Laporte,MC 24 NV,Circuit Court Clerk,,REP,Heather Stevens,0,0,0,0
+Laporte,MC 24 NV,Circuit Court Clerk,,DEM,Angela Henzman,0,0,0,0
+Laporte,MC 24 NV,County Auditor,,REP,Mike Rosenbaum,0,0,0,0
+Laporte,MC 24 NV,County Recorder,,REP,Elzbieta (Ela) Bilderback,0,0,0,0
+Laporte,MC 24 NV,County Recorder,,DEM,Matthew Sikorski,0,0,0,0
+Laporte,MC 24 NV,County Treasurer,,REP,Dan Barenie,0,0,0,0
+Laporte,MC 24 NV,County Treasurer,,DEM,Joie Winski,0,0,0,0
+Laporte,MC 24 NV,County Coroner,,REP,Lynn Swanson,0,0,0,0
+Laporte,MC 24 NV,County Coroner,,DEM,Mark P. Baker,0,0,0,0
+Laporte,MC 24 NV,County Surveyor,,REP,John Matwyshyn,0,0,0,0
+Laporte,MC 24 NV,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,0,0,0,0
+Laporte,MC 24 NV,County Commissioner District 2,,REP,Steve Holifield,0,0,0,0
+Laporte,MC 24 NV,County Commissioner District 2,,DEM,Mike Kellems,0,0,0,0
+Laporte,MC 24 NV,County Commissioner District 3,,REP,Joe Haney,0,0,0,0
+Laporte,MC 24 NV,County Commissioner District 3,,DEM,Randy Novak,0,0,0,0
+Laporte,MC 24 NV,County Council Member At Large,,REP,Brett H. Kessler,0,0,0,0
+Laporte,MC 24 NV,County Council Member At Large,,REP,Adam Koronka,0,0,0,0
+Laporte,MC 24 NV,County Council Member At Large,,REP,Heather Oake,0,0,0,0
+Laporte,MC 24 NV,County Council Member At Large,,DEM,Scott (Scotty) Ford,0,0,0,0
+Laporte,MC 24 NV,County Council Member At Large,,DEM,Mike Mollenhauer,0,0,0,0
+Laporte,MC 24 NV,County Council Member At Large,,DEM,Johnny Stimley,0,0,0,0
+Laporte,MC 24 NV,MC Area SB Civil City,,,Marty M. Corley,0,0,0,0
+Laporte,MC 24 NV,MC Area SB Civil City,,,Rodney McCormick,0,0,0,0
+Laporte,MC 24 NV,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,0,0,0,0
+Laporte,MC 24 NV,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,0,0,0,0
+Laporte,MC 24 NV,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,0,0,0,0
+Laporte,MC 24 NV,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,0,0,0,0
+Laporte,MC 24 NV,MC Area SB Michigan/Springfield Twps,,,James Stewart,0,0,0,0
+Laporte,MC 24 NV,IN Supreme Court-Rush,,,Yes,0,0,0,0
+Laporte,MC 24 NV,IN Supreme Court-Rush,,,No,0,0,0,0
+Laporte,MC 24 NV,IN Supreme Court-Massa,,,Yes,0,0,0,0
+Laporte,MC 24 NV,IN Supreme Court-Massa,,,No,0,0,0,0
+Laporte,MC 24 NV,IN Supreme Court-Molter,,,Yes,0,0,0,0
+Laporte,MC 24 NV,IN Supreme Court-Molter,,,No,0,0,0,0
+Laporte,MC 24 NV,Court of Appeals Dist 4-Pyle III,,,Yes,0,0,0,0
+Laporte,MC 24 NV,Court of Appeals Dist 4-Pyle III,,,No,0,0,0,0
+Laporte,MC 45,Ballots Cast,,,,23,5,31,59
+Laporte,MC 45,Registered Voters,,,,,,,154
+Laporte,MC 45,Public Question-Const Amendment,,,Yes,13,1,13,27
+Laporte,MC 45,Public Question-Const Amendment,,,No,8,2,14,24
+Laporte,MC 45,President and Vice-President of the U.S.,,REP,Trump \ Vance,4,0,3,7
+Laporte,MC 45,President and Vice-President of the U.S.,,DEM,Harris \ Walz,19,3,28,50
+Laporte,MC 45,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,0,0,0,0
+Laporte,MC 45,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,0,0,0,0
+Laporte,MC 45,President and Vice-President of the U.S.,,,Write-In,0,2,0,2
+Laporte,MC 45,United States Senator,,REP,Jim Banks,3,0,1,4
+Laporte,MC 45,United States Senator,,DEM,Valerie McCray,20,5,24,49
+Laporte,MC 45,United States Senator,,LIB,Andrew Horning,0,0,1,1
+Laporte,MC 45,United States Senator,,,Write-In,0,0,0,0
+Laporte,MC 45,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,3,0,1,4
+Laporte,MC 45,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,20,5,25,50
+Laporte,MC 45,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,0,0,2,2
+Laporte,MC 45,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,MC 45,Attorney General,,REP,Todd Rokita,3,0,2,5
+Laporte,MC 45,Attorney General,,DEM,Destiny Wells,20,5,23,48
+Laporte,MC 45,United States Representative,1,REP,Randy Niemeyer,4,0,2,6
+Laporte,MC 45,United States Representative,1,DEM,Frank J. Mrvan,19,5,23,47
+Laporte,MC 45,United States Representative,1,LIB,Dakotah Miskus,0,0,2,2
+Laporte,MC 45,United States Representative,1,,Write-In,0,0,0,0
+Laporte,MC 45,State Representative,09,REP,Joel Florek,5,0,3,8
+Laporte,MC 45,State Representative,09,DEM,Patricia A. (Pat) Boy,18,5,25,48
+Laporte,MC 45,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,6,0,5,11
+Laporte,MC 45,Circuit Court Clerk,,REP,Heather Stevens,4,0,2,6
+Laporte,MC 45,Circuit Court Clerk,,DEM,Angela Henzman,18,5,26,49
+Laporte,MC 45,County Auditor,,REP,Mike Rosenbaum,8,0,7,15
+Laporte,MC 45,County Recorder,,REP,Elzbieta (Ela) Bilderback,3,2,2,7
+Laporte,MC 45,County Recorder,,DEM,Matthew Sikorski,20,3,26,49
+Laporte,MC 45,County Treasurer,,REP,Dan Barenie,3,0,1,4
+Laporte,MC 45,County Treasurer,,DEM,Joie Winski,20,5,27,52
+Laporte,MC 45,County Coroner,,REP,Lynn Swanson,4,0,6,10
+Laporte,MC 45,County Coroner,,DEM,Mark P. Baker,19,5,23,47
+Laporte,MC 45,County Surveyor,,REP,John Matwyshyn,3,2,1,6
+Laporte,MC 45,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,20,3,27,50
+Laporte,MC 45,County Commissioner District 2,,REP,Steve Holifield,3,0,3,6
+Laporte,MC 45,County Commissioner District 2,,DEM,Mike Kellems,20,5,26,51
+Laporte,MC 45,County Commissioner District 3,,REP,Joe Haney,4,0,1,5
+Laporte,MC 45,County Commissioner District 3,,DEM,Randy Novak,19,5,27,51
+Laporte,MC 45,County Council Member At Large,,REP,Brett H. Kessler,2,0,1,3
+Laporte,MC 45,County Council Member At Large,,REP,Adam Koronka,4,0,1,5
+Laporte,MC 45,County Council Member At Large,,REP,Heather Oake,2,0,3,5
+Laporte,MC 45,County Council Member At Large,,DEM,Scott (Scotty) Ford,16,4,18,38
+Laporte,MC 45,County Council Member At Large,,DEM,Mike Mollenhauer,11,4,15,30
+Laporte,MC 45,County Council Member At Large,,DEM,Johnny Stimley,11,3,16,30
+Laporte,MC 45,MC Area SB Civil City,,,Marty M. Corley,11,0,15,26
+Laporte,MC 45,MC Area SB Civil City,,,Rodney McCormick,7,4,13,24
+Laporte,MC 45,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,5,1,12,18
+Laporte,MC 45,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,9,0,10,19
+Laporte,MC 45,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,3,0,2,5
+Laporte,MC 45,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,1,1,2,4
+Laporte,MC 45,MC Area SB Michigan/Springfield Twps,,,James Stewart,19,2,18,39
+Laporte,MC 45,IN Supreme Court-Rush,,,Yes,11,1,17,29
+Laporte,MC 45,IN Supreme Court-Rush,,,No,7,3,7,17
+Laporte,MC 45,IN Supreme Court-Massa,,,Yes,9,1,16,26
+Laporte,MC 45,IN Supreme Court-Massa,,,No,9,2,8,19
+Laporte,MC 45,IN Supreme Court-Molter,,,Yes,11,0,17,28
+Laporte,MC 45,IN Supreme Court-Molter,,,No,7,4,7,18
+Laporte,MC 45,Court of Appeals Dist 4-Pyle III,,,Yes,11,1,17,29
+Laporte,MC 45,Court of Appeals Dist 4-Pyle III,,,No,7,3,7,17
+Laporte,MC 45,Straight Party,,DEM,Democratic Party,,,,23
+Laporte,MC 45,Straight Party,,REP,Republican Party,,,,3
+Laporte,MICHIANA SHORES 01,Ballots Cast,,,,62,8,76,146
+Laporte,MICHIANA SHORES 01,Registered Voters,,,,,,,206
+Laporte,MICHIANA SHORES 01,Public Question-Const Amendment,,,Yes,33,4,43,80
+Laporte,MICHIANA SHORES 01,Public Question-Const Amendment,,,No,25,3,25,53
+Laporte,MICHIANA SHORES 01,President and Vice-President of the U.S.,,REP,Trump \ Vance,29,2,21,52
+Laporte,MICHIANA SHORES 01,President and Vice-President of the U.S.,,DEM,Harris \ Walz,32,6,52,90
+Laporte,MICHIANA SHORES 01,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,0,0,1,1
+Laporte,MICHIANA SHORES 01,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,1,0,0,1
+Laporte,MICHIANA SHORES 01,President and Vice-President of the U.S.,,,Write-In,0,0,0,0
+Laporte,MICHIANA SHORES 01,United States Senator,,REP,Jim Banks,32,2,23,57
+Laporte,MICHIANA SHORES 01,United States Senator,,DEM,Valerie McCray,28,6,51,85
+Laporte,MICHIANA SHORES 01,United States Senator,,LIB,Andrew Horning,0,0,1,1
+Laporte,MICHIANA SHORES 01,United States Senator,,,Write-In,0,0,0,0
+Laporte,MICHIANA SHORES 01,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,30,2,23,55
+Laporte,MICHIANA SHORES 01,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,29,6,52,87
+Laporte,MICHIANA SHORES 01,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,0,0,0,0
+Laporte,MICHIANA SHORES 01,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,MICHIANA SHORES 01,Attorney General,,REP,Todd Rokita,28,2,26,56
+Laporte,MICHIANA SHORES 01,Attorney General,,DEM,Destiny Wells,31,6,49,86
+Laporte,MICHIANA SHORES 01,United States Representative,1,REP,Randy Niemeyer,25,2,25,52
+Laporte,MICHIANA SHORES 01,United States Representative,1,DEM,Frank J. Mrvan,33,6,50,89
+Laporte,MICHIANA SHORES 01,United States Representative,1,LIB,Dakotah Miskus,1,0,0,1
+Laporte,MICHIANA SHORES 01,United States Representative,1,,Write-In,0,0,0,0
+Laporte,MICHIANA SHORES 01,State Representative,09,REP,Joel Florek,31,3,24,58
+Laporte,MICHIANA SHORES 01,State Representative,09,DEM,Patricia A. (Pat) Boy,28,5,51,84
+Laporte,MICHIANA SHORES 01,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,34,3,37,74
+Laporte,MICHIANA SHORES 01,Circuit Court Clerk,,REP,Heather Stevens,30,3,27,60
+Laporte,MICHIANA SHORES 01,Circuit Court Clerk,,DEM,Angela Henzman,28,5,46,79
+Laporte,MICHIANA SHORES 01,County Auditor,,REP,Mike Rosenbaum,36,3,42,81
+Laporte,MICHIANA SHORES 01,County Recorder,,REP,Elzbieta (Ela) Bilderback,29,3,29,61
+Laporte,MICHIANA SHORES 01,County Recorder,,DEM,Matthew Sikorski,30,5,45,80
+Laporte,MICHIANA SHORES 01,County Treasurer,,REP,Dan Barenie,25,2,27,54
+Laporte,MICHIANA SHORES 01,County Treasurer,,DEM,Joie Winski,33,6,47,86
+Laporte,MICHIANA SHORES 01,County Coroner,,REP,Lynn Swanson,30,2,30,62
+Laporte,MICHIANA SHORES 01,County Coroner,,DEM,Mark P. Baker,28,6,45,79
+Laporte,MICHIANA SHORES 01,County Surveyor,,REP,John Matwyshyn,28,3,24,55
+Laporte,MICHIANA SHORES 01,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,30,5,49,84
+Laporte,MICHIANA SHORES 01,County Commissioner District 2,,REP,Steve Holifield,26,2,25,53
+Laporte,MICHIANA SHORES 01,County Commissioner District 2,,DEM,Mike Kellems,31,6,46,83
+Laporte,MICHIANA SHORES 01,County Commissioner District 3,,REP,Joe Haney,22,2,23,47
+Laporte,MICHIANA SHORES 01,County Commissioner District 3,,DEM,Randy Novak,37,6,50,93
+Laporte,MICHIANA SHORES 01,County Council Member At Large,,REP,Brett H. Kessler,24,0,25,49
+Laporte,MICHIANA SHORES 01,County Council Member At Large,,REP,Adam Koronka,22,1,22,45
+Laporte,MICHIANA SHORES 01,County Council Member At Large,,REP,Heather Oake,18,2,23,43
+Laporte,MICHIANA SHORES 01,County Council Member At Large,,DEM,Scott (Scotty) Ford,25,6,38,69
+Laporte,MICHIANA SHORES 01,County Council Member At Large,,DEM,Mike Mollenhauer,29,5,41,75
+Laporte,MICHIANA SHORES 01,County Council Member At Large,,DEM,Johnny Stimley,29,6,38,73
+Laporte,MICHIANA SHORES 01,MC Area SB Civil City,,,Marty M. Corley,22,1,33,56
+Laporte,MICHIANA SHORES 01,MC Area SB Civil City,,,Rodney McCormick,23,2,12,37
+Laporte,MICHIANA SHORES 01,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,9,2,14,25
+Laporte,MICHIANA SHORES 01,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,11,0,8,19
+Laporte,MICHIANA SHORES 01,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,5,0,14,19
+Laporte,MICHIANA SHORES 01,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,17,2,7,26
+Laporte,MICHIANA SHORES 01,MC Area SB Michigan/Springfield Twps,,,James Stewart,39,2,43,84
+Laporte,MICHIANA SHORES 01,IN Supreme Court-Rush,,,Yes,30,4,37,71
+Laporte,MICHIANA SHORES 01,IN Supreme Court-Rush,,,No,16,1,23,40
+Laporte,MICHIANA SHORES 01,IN Supreme Court-Massa,,,Yes,32,3,33,68
+Laporte,MICHIANA SHORES 01,IN Supreme Court-Massa,,,No,14,1,24,39
+Laporte,MICHIANA SHORES 01,IN Supreme Court-Molter,,,Yes,27,3,32,62
+Laporte,MICHIANA SHORES 01,IN Supreme Court-Molter,,,No,17,1,27,45
+Laporte,MICHIANA SHORES 01,Court of Appeals Dist 4-Pyle III,,,Yes,29,4,31,64
+Laporte,MICHIANA SHORES 01,Court of Appeals Dist 4-Pyle III,,,No,16,0,28,44
+Laporte,MICHIANA SHORES 01,Straight Party,,DEM,Democratic Party,,,,38
+Laporte,MICHIANA SHORES 01,Straight Party,,REP,Republican Party,,,,19
+Laporte,MICHIANA SHORES 02,Ballots Cast,,,,50,11,30,91
+Laporte,MICHIANA SHORES 02,Registered Voters,,,,,,,127
+Laporte,MICHIANA SHORES 02,Public Question-Const Amendment,,,Yes,23,5,19,47
+Laporte,MICHIANA SHORES 02,Public Question-Const Amendment,,,No,21,2,10,33
+Laporte,MICHIANA SHORES 02,President and Vice-President of the U.S.,,REP,Trump \ Vance,14,3,9,26
+Laporte,MICHIANA SHORES 02,President and Vice-President of the U.S.,,DEM,Harris \ Walz,34,8,20,62
+Laporte,MICHIANA SHORES 02,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,1,0,0,1
+Laporte,MICHIANA SHORES 02,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,0,0,0,0
+Laporte,MICHIANA SHORES 02,President and Vice-President of the U.S.,,,Write-In,0,0,0,0
+Laporte,MICHIANA SHORES 02,United States Senator,,REP,Jim Banks,17,3,10,30
+Laporte,MICHIANA SHORES 02,United States Senator,,DEM,Valerie McCray,30,7,20,57
+Laporte,MICHIANA SHORES 02,United States Senator,,LIB,Andrew Horning,1,0,0,1
+Laporte,MICHIANA SHORES 02,United States Senator,,,Write-In,0,0,0,0
+Laporte,MICHIANA SHORES 02,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,17,3,8,28
+Laporte,MICHIANA SHORES 02,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,31,7,21,59
+Laporte,MICHIANA SHORES 02,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,1,0,0,1
+Laporte,MICHIANA SHORES 02,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,MICHIANA SHORES 02,Attorney General,,REP,Todd Rokita,20,3,10,33
+Laporte,MICHIANA SHORES 02,Attorney General,,DEM,Destiny Wells,28,7,20,55
+Laporte,MICHIANA SHORES 02,United States Representative,1,REP,Randy Niemeyer,18,3,8,29
+Laporte,MICHIANA SHORES 02,United States Representative,1,DEM,Frank J. Mrvan,32,6,22,60
+Laporte,MICHIANA SHORES 02,United States Representative,1,LIB,Dakotah Miskus,0,1,0,1
+Laporte,MICHIANA SHORES 02,United States Representative,1,,Write-In,0,0,0,0
+Laporte,MICHIANA SHORES 02,State Senator District 8,,REP,Mike Bohacek,23,5,13,41
+Laporte,MICHIANA SHORES 02,State Senator District 8,,DEM,Leon P. Smith,27,4,17,48
+Laporte,MICHIANA SHORES 02,State Representative,09,REP,Joel Florek,20,3,9,32
+Laporte,MICHIANA SHORES 02,State Representative,09,DEM,Patricia A. (Pat) Boy,29,7,20,56
+Laporte,MICHIANA SHORES 02,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,31,5,14,50
+Laporte,MICHIANA SHORES 02,Circuit Court Clerk,,REP,Heather Stevens,19,4,10,33
+Laporte,MICHIANA SHORES 02,Circuit Court Clerk,,DEM,Angela Henzman,30,5,19,54
+Laporte,MICHIANA SHORES 02,County Auditor,,REP,Mike Rosenbaum,38,5,10,53
+Laporte,MICHIANA SHORES 02,County Recorder,,REP,Elzbieta (Ela) Bilderback,21,3,10,34
+Laporte,MICHIANA SHORES 02,County Recorder,,DEM,Matthew Sikorski,28,6,19,53
+Laporte,MICHIANA SHORES 02,County Treasurer,,REP,Dan Barenie,17,3,6,26
+Laporte,MICHIANA SHORES 02,County Treasurer,,DEM,Joie Winski,33,7,23,63
+Laporte,MICHIANA SHORES 02,County Coroner,,REP,Lynn Swanson,18,3,11,32
+Laporte,MICHIANA SHORES 02,County Coroner,,DEM,Mark P. Baker,31,5,18,54
+Laporte,MICHIANA SHORES 02,County Surveyor,,REP,John Matwyshyn,15,3,5,23
+Laporte,MICHIANA SHORES 02,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,35,6,24,65
+Laporte,MICHIANA SHORES 02,County Commissioner District 2,,REP,Steve Holifield,18,3,9,30
+Laporte,MICHIANA SHORES 02,County Commissioner District 2,,DEM,Mike Kellems,32,6,19,57
+Laporte,MICHIANA SHORES 02,County Commissioner District 3,,REP,Joe Haney,16,3,6,25
+Laporte,MICHIANA SHORES 02,County Commissioner District 3,,DEM,Randy Novak,34,7,23,64
+Laporte,MICHIANA SHORES 02,County Council Member At Large,,REP,Brett H. Kessler,18,1,10,29
+Laporte,MICHIANA SHORES 02,County Council Member At Large,,REP,Adam Koronka,17,1,9,27
+Laporte,MICHIANA SHORES 02,County Council Member At Large,,REP,Heather Oake,11,2,5,18
+Laporte,MICHIANA SHORES 02,County Council Member At Large,,DEM,Scott (Scotty) Ford,29,3,17,49
+Laporte,MICHIANA SHORES 02,County Council Member At Large,,DEM,Mike Mollenhauer,28,5,17,50
+Laporte,MICHIANA SHORES 02,County Council Member At Large,,DEM,Johnny Stimley,31,4,13,48
+Laporte,MICHIANA SHORES 02,MC Area SB Civil City,,,Marty M. Corley,16,2,12,30
+Laporte,MICHIANA SHORES 02,MC Area SB Civil City,,,Rodney McCormick,18,1,5,24
+Laporte,MICHIANA SHORES 02,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,6,1,4,11
+Laporte,MICHIANA SHORES 02,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,4,0,1,5
+Laporte,MICHIANA SHORES 02,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,12,1,4,17
+Laporte,MICHIANA SHORES 02,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,12,1,6,19
+Laporte,MICHIANA SHORES 02,MC Area SB Michigan/Springfield Twps,,,James Stewart,34,2,15,51
+Laporte,MICHIANA SHORES 02,IN Supreme Court-Rush,,,Yes,25,2,9,36
+Laporte,MICHIANA SHORES 02,IN Supreme Court-Rush,,,No,14,1,9,24
+Laporte,MICHIANA SHORES 02,IN Supreme Court-Massa,,,Yes,24,2,7,33
+Laporte,MICHIANA SHORES 02,IN Supreme Court-Massa,,,No,16,1,11,28
+Laporte,MICHIANA SHORES 02,IN Supreme Court-Molter,,,Yes,25,2,7,34
+Laporte,MICHIANA SHORES 02,IN Supreme Court-Molter,,,No,15,1,11,27
+Laporte,MICHIANA SHORES 02,Court of Appeals Dist 4-Pyle III,,,Yes,25,2,7,34
+Laporte,MICHIANA SHORES 02,Court of Appeals Dist 4-Pyle III,,,No,15,1,9,25
+Laporte,MICHIANA SHORES 02,Straight Party,,DEM,Democratic Party,,,,19
+Laporte,MICHIANA SHORES 02,Straight Party,,REP,Republican Party,,,,11
+Laporte,NEW DURHAM 01,Ballots Cast,,,,398,47,552,997
+Laporte,NEW DURHAM 01,Registered Voters,,,,,,,1534
+Laporte,NEW DURHAM 01,Public Question-Const Amendment,,,Yes,235,13,231,479
+Laporte,NEW DURHAM 01,Public Question-Const Amendment,,,No,134,22,238,394
+Laporte,NEW DURHAM 01,President and Vice-President of the U.S.,,REP,Trump \ Vance,276,18,347,641
+Laporte,NEW DURHAM 01,President and Vice-President of the U.S.,,DEM,Harris \ Walz,111,29,193,333
+Laporte,NEW DURHAM 01,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,3,0,3,6
+Laporte,NEW DURHAM 01,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,3,0,1,4
+Laporte,NEW DURHAM 01,President and Vice-President of the U.S.,,,Write-In,1,0,1,2
+Laporte,NEW DURHAM 01,United States Senator,,REP,Jim Banks,242,18,320,580
+Laporte,NEW DURHAM 01,United States Senator,,DEM,Valerie McCray,102,28,181,311
+Laporte,NEW DURHAM 01,United States Senator,,LIB,Andrew Horning,16,1,13,30
+Laporte,NEW DURHAM 01,United States Senator,,,Write-In,0,0,0,0
+Laporte,NEW DURHAM 01,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,230,19,310,559
+Laporte,NEW DURHAM 01,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,111,28,199,338
+Laporte,NEW DURHAM 01,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,23,0,15,38
+Laporte,NEW DURHAM 01,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,NEW DURHAM 01,Attorney General,,REP,Todd Rokita,266,20,340,626
+Laporte,NEW DURHAM 01,Attorney General,,DEM,Destiny Wells,110,27,187,324
+Laporte,NEW DURHAM 01,United States Representative,1,REP,Randy Niemeyer,230,17,313,560
+Laporte,NEW DURHAM 01,United States Representative,1,DEM,Frank J. Mrvan,138,30,211,379
+Laporte,NEW DURHAM 01,United States Representative,1,LIB,Dakotah Miskus,12,0,12,24
+Laporte,NEW DURHAM 01,United States Representative,1,,Write-In,0,0,0,0
+Laporte,NEW DURHAM 01,State Representative,20,REP,Jim Pressel,301,30,391,722
+Laporte,NEW DURHAM 01,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,277,29,360,666
+Laporte,NEW DURHAM 01,Circuit Court Clerk,,REP,Heather Stevens,249,23,331,603
+Laporte,NEW DURHAM 01,Circuit Court Clerk,,DEM,Angela Henzman,102,24,176,302
+Laporte,NEW DURHAM 01,County Auditor,,REP,Mike Rosenbaum,308,30,386,724
+Laporte,NEW DURHAM 01,County Recorder,,REP,Elzbieta (Ela) Bilderback,257,19,338,614
+Laporte,NEW DURHAM 01,County Recorder,,DEM,Matthew Sikorski,110,28,181,319
+Laporte,NEW DURHAM 01,County Treasurer,,REP,Dan Barenie,260,18,316,594
+Laporte,NEW DURHAM 01,County Treasurer,,DEM,Joie Winski,110,29,208,347
+Laporte,NEW DURHAM 01,County Coroner,,REP,Lynn Swanson,270,22,339,631
+Laporte,NEW DURHAM 01,County Coroner,,DEM,Mark P. Baker,100,25,181,306
+Laporte,NEW DURHAM 01,County Surveyor,,REP,John Matwyshyn,247,17,305,569
+Laporte,NEW DURHAM 01,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,122,30,214,366
+Laporte,NEW DURHAM 01,County Commissioner District 2,,REP,Steve Holifield,244,19,318,581
+Laporte,NEW DURHAM 01,County Commissioner District 2,,DEM,Mike Kellems,124,28,199,351
+Laporte,NEW DURHAM 01,County Commissioner District 3,,REP,Joe Haney,243,19,313,575
+Laporte,NEW DURHAM 01,County Commissioner District 3,,DEM,Randy Novak,125,28,205,358
+Laporte,NEW DURHAM 01,County Council Member At Large,,REP,Brett H. Kessler,213,13,266,492
+Laporte,NEW DURHAM 01,County Council Member At Large,,REP,Adam Koronka,160,13,227,400
+Laporte,NEW DURHAM 01,County Council Member At Large,,REP,Heather Oake,173,15,224,412
+Laporte,NEW DURHAM 01,County Council Member At Large,,DEM,Scott (Scotty) Ford,87,19,149,255
+Laporte,NEW DURHAM 01,County Council Member At Large,,DEM,Mike Mollenhauer,99,22,181,302
+Laporte,NEW DURHAM 01,County Council Member At Large,,DEM,Johnny Stimley,87,23,149,259
+Laporte,NEW DURHAM 01,MC Area SB Civil City,,,Marty M. Corley,0,0,1,1
+Laporte,NEW DURHAM 01,MC Area SB Civil City,,,Rodney McCormick,1,0,1,2
+Laporte,NEW DURHAM 01,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,0,0,0,0
+Laporte,NEW DURHAM 01,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,0,0,0,0
+Laporte,NEW DURHAM 01,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,0,0,0,0
+Laporte,NEW DURHAM 01,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,1,0,2,3
+Laporte,NEW DURHAM 01,MC Area SB Michigan/Springfield Twps,,,James Stewart,1,0,2,3
+Laporte,NEW DURHAM 01,Msd of New Durham Township At Large,,,Philip Burdine,275,6,358,639
+Laporte,NEW DURHAM 01,Msd of New Durham Township At Large,,,Karen Jedrysek,223,6,297,526
+Laporte,NEW DURHAM 01,IN Supreme Court-Rush,,,Yes,231,21,266,518
+Laporte,NEW DURHAM 01,IN Supreme Court-Rush,,,No,97,16,157,270
+Laporte,NEW DURHAM 01,IN Supreme Court-Massa,,,Yes,230,17,259,506
+Laporte,NEW DURHAM 01,IN Supreme Court-Massa,,,No,94,19,156,269
+Laporte,NEW DURHAM 01,IN Supreme Court-Molter,,,Yes,236,19,259,514
+Laporte,NEW DURHAM 01,IN Supreme Court-Molter,,,No,91,18,157,266
+Laporte,NEW DURHAM 01,Court of Appeals Dist 4-Pyle III,,,Yes,236,21,261,518
+Laporte,NEW DURHAM 01,Court of Appeals Dist 4-Pyle III,,,No,90,16,154,260
+Laporte,NEW DURHAM 01,Straight Party,,DEM,Democratic Party,,,,111
+Laporte,NEW DURHAM 01,Straight Party,,REP,Republican Party,,,,289
+Laporte,NEW DURHAM 02,Ballots Cast,,,,219,33,331,583
+Laporte,NEW DURHAM 02,Registered Voters,,,,,,,805
+Laporte,NEW DURHAM 02,Public Question-Const Amendment,,,Yes,110,7,148,265
+Laporte,NEW DURHAM 02,Public Question-Const Amendment,,,No,88,19,138,245
+Laporte,NEW DURHAM 02,President and Vice-President of the U.S.,,REP,Trump \ Vance,161,12,232,405
+Laporte,NEW DURHAM 02,President and Vice-President of the U.S.,,DEM,Harris \ Walz,53,18,96,167
+Laporte,NEW DURHAM 02,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,2,2,0,4
+Laporte,NEW DURHAM 02,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,1,0,2,3
+Laporte,NEW DURHAM 02,President and Vice-President of the U.S.,,,Write-In,0,0,0,0
+Laporte,NEW DURHAM 02,United States Senator,,REP,Jim Banks,143,13,214,370
+Laporte,NEW DURHAM 02,United States Senator,,DEM,Valerie McCray,52,17,82,151
+Laporte,NEW DURHAM 02,United States Senator,,LIB,Andrew Horning,7,1,8,16
+Laporte,NEW DURHAM 02,United States Senator,,,Write-In,0,1,0,1
+Laporte,NEW DURHAM 02,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,133,14,201,348
+Laporte,NEW DURHAM 02,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,60,19,93,172
+Laporte,NEW DURHAM 02,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,11,0,15,26
+Laporte,NEW DURHAM 02,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,NEW DURHAM 02,Attorney General,,REP,Todd Rokita,135,14,234,383
+Laporte,NEW DURHAM 02,Attorney General,,DEM,Destiny Wells,67,19,84,170
+Laporte,NEW DURHAM 02,United States Representative,1,REP,Randy Niemeyer,128,13,214,355
+Laporte,NEW DURHAM 02,United States Representative,1,DEM,Frank J. Mrvan,76,19,100,195
+Laporte,NEW DURHAM 02,United States Representative,1,LIB,Dakotah Miskus,7,1,6,14
+Laporte,NEW DURHAM 02,United States Representative,1,,Write-In,0,0,0,0
+Laporte,NEW DURHAM 02,State Representative,20,REP,Jim Pressel,173,20,248,441
+Laporte,NEW DURHAM 02,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,161,20,223,404
+Laporte,NEW DURHAM 02,Circuit Court Clerk,,REP,Heather Stevens,142,16,221,379
+Laporte,NEW DURHAM 02,Circuit Court Clerk,,DEM,Angela Henzman,57,17,81,155
+Laporte,NEW DURHAM 02,County Auditor,,REP,Mike Rosenbaum,174,17,255,446
+Laporte,NEW DURHAM 02,County Recorder,,REP,Elzbieta (Ela) Bilderback,147,18,213,378
+Laporte,NEW DURHAM 02,County Recorder,,DEM,Matthew Sikorski,59,15,94,168
+Laporte,NEW DURHAM 02,County Treasurer,,REP,Dan Barenie,138,13,209,360
+Laporte,NEW DURHAM 02,County Treasurer,,DEM,Joie Winski,66,20,102,188
+Laporte,NEW DURHAM 02,County Coroner,,REP,Lynn Swanson,143,16,217,376
+Laporte,NEW DURHAM 02,County Coroner,,DEM,Mark P. Baker,60,17,98,175
+Laporte,NEW DURHAM 02,County Surveyor,,REP,John Matwyshyn,133,12,199,344
+Laporte,NEW DURHAM 02,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,68,19,108,195
+Laporte,NEW DURHAM 02,County Commissioner District 2,,REP,Steve Holifield,124,12,197,333
+Laporte,NEW DURHAM 02,County Commissioner District 2,,DEM,Mike Kellems,78,21,114,213
+Laporte,NEW DURHAM 02,County Commissioner District 3,,REP,Joe Haney,132,15,200,347
+Laporte,NEW DURHAM 02,County Commissioner District 3,,DEM,Randy Novak,70,18,106,194
+Laporte,NEW DURHAM 02,County Council Member At Large,,REP,Brett H. Kessler,114,12,168,294
+Laporte,NEW DURHAM 02,County Council Member At Large,,REP,Adam Koronka,94,14,153,261
+Laporte,NEW DURHAM 02,County Council Member At Large,,REP,Heather Oake,88,13,138,239
+Laporte,NEW DURHAM 02,County Council Member At Large,,DEM,Scott (Scotty) Ford,58,14,81,153
+Laporte,NEW DURHAM 02,County Council Member At Large,,DEM,Mike Mollenhauer,79,21,105,205
+Laporte,NEW DURHAM 02,County Council Member At Large,,DEM,Johnny Stimley,51,14,65,130
+Laporte,NEW DURHAM 02,Msd of New Durham Township At Large,,,Philip Burdine,156,20,238,414
+Laporte,NEW DURHAM 02,Msd of New Durham Township At Large,,,Karen Jedrysek,115,16,205,336
+Laporte,NEW DURHAM 02,IN Supreme Court-Rush,,,Yes,111,18,169,298
+Laporte,NEW DURHAM 02,IN Supreme Court-Rush,,,No,64,6,94,164
+Laporte,NEW DURHAM 02,IN Supreme Court-Massa,,,Yes,117,19,161,297
+Laporte,NEW DURHAM 02,IN Supreme Court-Massa,,,No,58,6,98,162
+Laporte,NEW DURHAM 02,IN Supreme Court-Molter,,,Yes,113,19,169,301
+Laporte,NEW DURHAM 02,IN Supreme Court-Molter,,,No,62,6,92,160
+Laporte,NEW DURHAM 02,Court of Appeals Dist 4-Pyle III,,,Yes,115,21,167,303
+Laporte,NEW DURHAM 02,Court of Appeals Dist 4-Pyle III,,,No,60,5,92,157
+Laporte,NEW DURHAM 02,Straight Party,,DEM,Democratic Party,,,,56
+Laporte,NEW DURHAM 02,Straight Party,,REP,Republican Party,,,,142
+Laporte,NOBLE,Ballots Cast,,,,524,42,340,906
+Laporte,NOBLE,Registered Voters,,,,,,,1285
+Laporte,NOBLE,Public Question-Const Amendment,,,Yes,285,9,190,484
+Laporte,NOBLE,Public Question-Const Amendment,,,No,191,17,110,318
+Laporte,NOBLE,President and Vice-President of the U.S.,,REP,Trump \ Vance,397,23,266,686
+Laporte,NOBLE,President and Vice-President of the U.S.,,DEM,Harris \ Walz,107,18,66,191
+Laporte,NOBLE,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,12,0,2,14
+Laporte,NOBLE,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,4,1,5,10
+Laporte,NOBLE,President and Vice-President of the U.S.,,,Write-In,1,0,0,1
+Laporte,NOBLE,United States Senator,,REP,Jim Banks,355,23,241,619
+Laporte,NOBLE,United States Senator,,DEM,Valerie McCray,109,18,64,191
+Laporte,NOBLE,United States Senator,,LIB,Andrew Horning,18,0,7,25
+Laporte,NOBLE,United States Senator,,,Write-In,0,0,0,0
+Laporte,NOBLE,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,334,22,238,594
+Laporte,NOBLE,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,121,19,75,215
+Laporte,NOBLE,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,39,0,9,48
+Laporte,NOBLE,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,NOBLE,Attorney General,,REP,Todd Rokita,374,21,258,653
+Laporte,NOBLE,Attorney General,,DEM,Destiny Wells,116,18,67,201
+Laporte,NOBLE,United States Representative,2,REP,Rudy Yakym,347,20,247,614
+Laporte,NOBLE,United States Representative,2,DEM,Lori A. Camp,120,18,67,205
+Laporte,NOBLE,United States Representative,2,LIB,William E. Henry,28,2,8,38
+Laporte,NOBLE,United States Representative,2,,Write-In,0,0,0,0
+Laporte,NOBLE,State Senator District 8,,REP,Mike Bohacek,396,26,270,692
+Laporte,NOBLE,State Senator District 8,,DEM,Leon P. Smith,101,14,58,173
+Laporte,NOBLE,State Representative,20,REP,Jim Pressel,434,34,278,746
+Laporte,NOBLE,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,403,33,245,681
+Laporte,NOBLE,Circuit Court Clerk,,REP,Heather Stevens,369,28,242,639
+Laporte,NOBLE,Circuit Court Clerk,,DEM,Angela Henzman,118,13,70,201
+Laporte,NOBLE,County Auditor,,REP,Mike Rosenbaum,429,35,277,741
+Laporte,NOBLE,County Recorder,,REP,Elzbieta (Ela) Bilderback,346,25,239,610
+Laporte,NOBLE,County Recorder,,DEM,Matthew Sikorski,132,14,75,221
+Laporte,NOBLE,County Treasurer,,REP,Dan Barenie,343,23,237,603
+Laporte,NOBLE,County Treasurer,,DEM,Joie Winski,143,17,82,242
+Laporte,NOBLE,County Coroner,,REP,Lynn Swanson,362,28,259,649
+Laporte,NOBLE,County Coroner,,DEM,Mark P. Baker,129,13,64,206
+Laporte,NOBLE,County Surveyor,,REP,John Matwyshyn,320,18,219,557
+Laporte,NOBLE,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,158,20,93,271
+Laporte,NOBLE,County Commissioner District 2,,REP,Steve Holifield,298,20,212,530
+Laporte,NOBLE,County Commissioner District 2,,DEM,Mike Kellems,189,20,108,317
+Laporte,NOBLE,County Commissioner District 3,,REP,Joe Haney,335,20,218,573
+Laporte,NOBLE,County Commissioner District 3,,DEM,Randy Novak,159,20,93,272
+Laporte,NOBLE,County Council Member At Large,,REP,Brett H. Kessler,303,10,203,516
+Laporte,NOBLE,County Council Member At Large,,REP,Adam Koronka,276,8,181,465
+Laporte,NOBLE,County Council Member At Large,,REP,Heather Oake,238,14,162,414
+Laporte,NOBLE,County Council Member At Large,,DEM,Scott (Scotty) Ford,103,19,67,189
+Laporte,NOBLE,County Council Member At Large,,DEM,Mike Mollenhauer,169,19,91,279
+Laporte,NOBLE,County Council Member At Large,,DEM,Johnny Stimley,80,12,54,146
+Laporte,NOBLE,South Central School Board At Large,,,Jacob Wade,352,20,233,605
+Laporte,NOBLE,South Central SB Hanna Township,,,Cheryl Lynn (Sherry) Shei,294,18,192,504
+Laporte,NOBLE,South Central SB Hanna Township,,,Michael Sullivan,129,5,75,209
+Laporte,NOBLE,South Central SB Noble Township,,,Geraldine (Gerrie) Grott,366,21,231,618
+Laporte,NOBLE,IN Supreme Court-Rush,,,Yes,291,16,176,483
+Laporte,NOBLE,IN Supreme Court-Rush,,,No,119,6,87,212
+Laporte,NOBLE,IN Supreme Court-Massa,,,Yes,289,14,174,477
+Laporte,NOBLE,IN Supreme Court-Massa,,,No,121,6,90,217
+Laporte,NOBLE,IN Supreme Court-Molter,,,Yes,295,14,172,481
+Laporte,NOBLE,IN Supreme Court-Molter,,,No,114,7,85,206
+Laporte,NOBLE,Court of Appeals Dist 4-Pyle III,,,Yes,286,15,174,475
+Laporte,NOBLE,Court of Appeals Dist 4-Pyle III,,,No,123,6,85,214
+Laporte,NOBLE,Straight Party,,DEM,Democratic Party,,,,43
+Laporte,NOBLE,Straight Party,,REP,Republican Party,,,,209
+Laporte,PLEASANT,Ballots Cast,,,,543,54,475,1072
+Laporte,PLEASANT,Registered Voters,,,,,,,1511
+Laporte,PLEASANT,Public Question-Const Amendment,,,Yes,305,17,207,529
+Laporte,PLEASANT,Public Question-Const Amendment,,,No,193,16,215,424
+Laporte,PLEASANT,President and Vice-President of the U.S.,,REP,Trump \ Vance,409,24,301,734
+Laporte,PLEASANT,President and Vice-President of the U.S.,,DEM,Harris \ Walz,117,28,162,307
+Laporte,PLEASANT,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,4,0,5,9
+Laporte,PLEASANT,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,11,0,1,12
+Laporte,PLEASANT,President and Vice-President of the U.S.,,,Write-In,0,1,3,4
+Laporte,PLEASANT,United States Senator,,REP,Jim Banks,361,24,288,673
+Laporte,PLEASANT,United States Senator,,DEM,Valerie McCray,111,28,157,296
+Laporte,PLEASANT,United States Senator,,LIB,Andrew Horning,19,0,5,24
+Laporte,PLEASANT,United States Senator,,,Write-In,0,0,1,1
+Laporte,PLEASANT,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,314,25,279,618
+Laporte,PLEASANT,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,140,28,167,335
+Laporte,PLEASANT,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,44,0,10,54
+Laporte,PLEASANT,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,PLEASANT,Attorney General,,REP,Todd Rokita,388,26,305,719
+Laporte,PLEASANT,Attorney General,,DEM,Destiny Wells,121,26,162,309
+Laporte,PLEASANT,United States Representative,2,REP,Rudy Yakym,364,28,296,688
+Laporte,PLEASANT,United States Representative,2,DEM,Lori A. Camp,111,25,156,292
+Laporte,PLEASANT,United States Representative,2,LIB,William E. Henry,29,0,9,38
+Laporte,PLEASANT,United States Representative,2,,Write-In,0,0,0,0
+Laporte,PLEASANT,State Senator District 8,,REP,Mike Bohacek,413,28,322,763
+Laporte,PLEASANT,State Senator District 8,,DEM,Leon P. Smith,97,25,141,263
+Laporte,PLEASANT,State Representative,20,REP,Jim Pressel,444,33,356,833
+Laporte,PLEASANT,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,410,30,337,777
+Laporte,PLEASANT,Circuit Court Clerk,,REP,Heather Stevens,374,25,301,700
+Laporte,PLEASANT,Circuit Court Clerk,,DEM,Angela Henzman,106,26,143,275
+Laporte,PLEASANT,County Auditor,,REP,Mike Rosenbaum,444,31,370,845
+Laporte,PLEASANT,County Recorder,,REP,Elzbieta (Ela) Bilderback,366,25,292,683
+Laporte,PLEASANT,County Recorder,,DEM,Matthew Sikorski,128,26,167,321
+Laporte,PLEASANT,County Treasurer,,REP,Dan Barenie,348,23,270,641
+Laporte,PLEASANT,County Treasurer,,DEM,Joie Winski,152,28,190,370
+Laporte,PLEASANT,County Coroner,,REP,Lynn Swanson,379,26,298,703
+Laporte,PLEASANT,County Coroner,,DEM,Mark P. Baker,129,24,168,321
+Laporte,PLEASANT,County Surveyor,,REP,John Matwyshyn,324,24,273,621
+Laporte,PLEASANT,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,166,26,189,381
+Laporte,PLEASANT,County Commissioner District 2,,REP,Steve Holifield,357,23,268,648
+Laporte,PLEASANT,County Commissioner District 2,,DEM,Mike Kellems,152,27,198,377
+Laporte,PLEASANT,County Commissioner District 3,,REP,Joe Haney,327,20,266,613
+Laporte,PLEASANT,County Commissioner District 3,,DEM,Randy Novak,171,29,193,393
+Laporte,PLEASANT,County Council Member At Large,,REP,Brett H. Kessler,314,15,258,587
+Laporte,PLEASANT,County Council Member At Large,,REP,Adam Koronka,252,16,237,505
+Laporte,PLEASANT,County Council Member At Large,,REP,Heather Oake,257,16,205,478
+Laporte,PLEASANT,County Council Member At Large,,DEM,Scott (Scotty) Ford,140,21,158,319
+Laporte,PLEASANT,County Council Member At Large,,DEM,Mike Mollenhauer,162,23,177,362
+Laporte,PLEASANT,County Council Member At Large,,DEM,Johnny Stimley,96,23,118,237
+Laporte,PLEASANT,Laporte Community School Board At Large,,,Jim Arnold,314,20,252,586
+Laporte,PLEASANT,Laporte Community School Board At Large,,,Monica L. Beaty,211,19,209,439
+Laporte,PLEASANT,Laporte Community School Board At Large,,,Maria L. Ria Carpenter,186,18,194,398
+Laporte,PLEASANT,Laporte Community School Board At Large,,,Ed Gilliland,231,14,177,422
+Laporte,PLEASANT,Laporte Community School Board At Large,,,Tucker King,259,11,228,498
+Laporte,PLEASANT,IN Supreme Court-Rush,,,Yes,339,24,264,627
+Laporte,PLEASANT,IN Supreme Court-Rush,,,No,117,12,135,264
+Laporte,PLEASANT,IN Supreme Court-Massa,,,Yes,328,23,266,617
+Laporte,PLEASANT,IN Supreme Court-Massa,,,No,126,11,131,268
+Laporte,PLEASANT,IN Supreme Court-Molter,,,Yes,335,23,263,621
+Laporte,PLEASANT,IN Supreme Court-Molter,,,No,119,12,128,259
+Laporte,PLEASANT,Court of Appeals Dist 4-Pyle III,,,Yes,328,22,265,615
+Laporte,PLEASANT,Court of Appeals Dist 4-Pyle III,,,No,121,12,126,259
+Laporte,PLEASANT,Straight Party,,DEM,Democratic Party,,,,84
+Laporte,PLEASANT,Straight Party,,REP,Republican Party,,,,247
+Laporte,POTTAWATTAMIE PARK,Ballots Cast,,,,81,7,68,156
+Laporte,POTTAWATTAMIE PARK,Registered Voters,,,,,,,219
+Laporte,POTTAWATTAMIE PARK,Public Question-Const Amendment,,,Yes,44,1,21,66
+Laporte,POTTAWATTAMIE PARK,Public Question-Const Amendment,,,No,34,3,38,75
+Laporte,POTTAWATTAMIE PARK,President and Vice-President of the U.S.,,REP,Trump \ Vance,37,2,21,60
+Laporte,POTTAWATTAMIE PARK,President and Vice-President of the U.S.,,DEM,Harris \ Walz,40,5,46,91
+Laporte,POTTAWATTAMIE PARK,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,1,0,0,1
+Laporte,POTTAWATTAMIE PARK,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,1,0,1,2
+Laporte,POTTAWATTAMIE PARK,President and Vice-President of the U.S.,,,Write-In,0,0,0,0
+Laporte,POTTAWATTAMIE PARK,United States Senator,,REP,Jim Banks,40,2,22,64
+Laporte,POTTAWATTAMIE PARK,United States Senator,,DEM,Valerie McCray,37,5,44,86
+Laporte,POTTAWATTAMIE PARK,United States Senator,,LIB,Andrew Horning,1,0,1,2
+Laporte,POTTAWATTAMIE PARK,United States Senator,,,Write-In,0,0,0,0
+Laporte,POTTAWATTAMIE PARK,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,38,2,20,60
+Laporte,POTTAWATTAMIE PARK,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,37,5,46,88
+Laporte,POTTAWATTAMIE PARK,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,1,0,1,2
+Laporte,POTTAWATTAMIE PARK,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,POTTAWATTAMIE PARK,Attorney General,,REP,Todd Rokita,39,2,23,64
+Laporte,POTTAWATTAMIE PARK,Attorney General,,DEM,Destiny Wells,39,5,45,89
+Laporte,POTTAWATTAMIE PARK,United States Representative,1,REP,Randy Niemeyer,36,2,20,58
+Laporte,POTTAWATTAMIE PARK,United States Representative,1,DEM,Frank J. Mrvan,39,5,45,89
+Laporte,POTTAWATTAMIE PARK,United States Representative,1,LIB,Dakotah Miskus,3,0,0,3
+Laporte,POTTAWATTAMIE PARK,United States Representative,1,,Write-In,0,0,0,0
+Laporte,POTTAWATTAMIE PARK,State Representative,09,REP,Joel Florek,36,2,21,59
+Laporte,POTTAWATTAMIE PARK,State Representative,09,DEM,Patricia A. (Pat) Boy,43,5,46,94
+Laporte,POTTAWATTAMIE PARK,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,52,4,28,84
+Laporte,POTTAWATTAMIE PARK,Circuit Court Clerk,,REP,Heather Stevens,40,2,22,64
+Laporte,POTTAWATTAMIE PARK,Circuit Court Clerk,,DEM,Angela Henzman,37,5,44,86
+Laporte,POTTAWATTAMIE PARK,County Auditor,,REP,Mike Rosenbaum,52,4,29,85
+Laporte,POTTAWATTAMIE PARK,County Recorder,,REP,Elzbieta (Ela) Bilderback,39,2,24,65
+Laporte,POTTAWATTAMIE PARK,County Recorder,,DEM,Matthew Sikorski,37,5,42,84
+Laporte,POTTAWATTAMIE PARK,County Treasurer,,REP,Dan Barenie,29,2,22,53
+Laporte,POTTAWATTAMIE PARK,County Treasurer,,DEM,Joie Winski,49,5,44,98
+Laporte,POTTAWATTAMIE PARK,County Coroner,,REP,Lynn Swanson,44,2,25,71
+Laporte,POTTAWATTAMIE PARK,County Coroner,,DEM,Mark P. Baker,34,5,41,80
+Laporte,POTTAWATTAMIE PARK,County Surveyor,,REP,John Matwyshyn,35,2,22,59
+Laporte,POTTAWATTAMIE PARK,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,42,5,43,90
+Laporte,POTTAWATTAMIE PARK,County Commissioner District 2,,REP,Steve Holifield,38,2,22,62
+Laporte,POTTAWATTAMIE PARK,County Commissioner District 2,,DEM,Mike Kellems,40,5,43,88
+Laporte,POTTAWATTAMIE PARK,County Commissioner District 3,,REP,Joe Haney,31,2,22,55
+Laporte,POTTAWATTAMIE PARK,County Commissioner District 3,,DEM,Randy Novak,47,5,45,97
+Laporte,POTTAWATTAMIE PARK,County Council Member At Large,,REP,Brett H. Kessler,33,1,15,49
+Laporte,POTTAWATTAMIE PARK,County Council Member At Large,,REP,Adam Koronka,36,0,15,51
+Laporte,POTTAWATTAMIE PARK,County Council Member At Large,,REP,Heather Oake,31,1,12,44
+Laporte,POTTAWATTAMIE PARK,County Council Member At Large,,DEM,Scott (Scotty) Ford,26,2,36,64
+Laporte,POTTAWATTAMIE PARK,County Council Member At Large,,DEM,Mike Mollenhauer,31,3,38,72
+Laporte,POTTAWATTAMIE PARK,County Council Member At Large,,DEM,Johnny Stimley,34,4,38,76
+Laporte,POTTAWATTAMIE PARK,Pottawattomie Park Town Clerk Treasurer,,DEM,Susan Tochell,62,5,45,112
+Laporte,POTTAWATTAMIE PARK,Pottawattomie Park Town Council At Large,,REP,Robert Wisthoff,57,5,28,90
+Laporte,POTTAWATTAMIE PARK,MC Area SB Civil City,,,Marty M. Corley,44,3,37,84
+Laporte,POTTAWATTAMIE PARK,MC Area SB Civil City,,,Rodney McCormick,23,0,13,36
+Laporte,POTTAWATTAMIE PARK,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,18,0,15,33
+Laporte,POTTAWATTAMIE PARK,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,8,0,15,23
+Laporte,POTTAWATTAMIE PARK,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,16,0,6,22
+Laporte,POTTAWATTAMIE PARK,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,18,2,8,28
+Laporte,POTTAWATTAMIE PARK,MC Area SB Michigan/Springfield Twps,,,James Stewart,60,2,34,96
+Laporte,POTTAWATTAMIE PARK,IN Supreme Court-Rush,,,Yes,46,3,24,73
+Laporte,POTTAWATTAMIE PARK,IN Supreme Court-Rush,,,No,20,1,25,46
+Laporte,POTTAWATTAMIE PARK,IN Supreme Court-Massa,,,Yes,42,2,18,62
+Laporte,POTTAWATTAMIE PARK,IN Supreme Court-Massa,,,No,23,2,30,55
+Laporte,POTTAWATTAMIE PARK,IN Supreme Court-Molter,,,Yes,45,2,20,67
+Laporte,POTTAWATTAMIE PARK,IN Supreme Court-Molter,,,No,21,2,28,51
+Laporte,POTTAWATTAMIE PARK,Court of Appeals Dist 4-Pyle III,,,Yes,43,3,20,66
+Laporte,POTTAWATTAMIE PARK,Court of Appeals Dist 4-Pyle III,,,No,22,1,28,51
+Laporte,POTTAWATTAMIE PARK,Straight Party,,DEM,Democratic Party,,,,28
+Laporte,POTTAWATTAMIE PARK,Straight Party,,REP,Republican Party,,,,16
+Laporte,PRAIRIE,Ballots Cast,,,,77,3,47,127
+Laporte,PRAIRIE,Registered Voters,,,,,,,179
+Laporte,PRAIRIE,Public Question-Const Amendment,,,Yes,36,1,28,65
+Laporte,PRAIRIE,Public Question-Const Amendment,,,No,28,1,18,47
+Laporte,PRAIRIE,President and Vice-President of the U.S.,,REP,Trump \ Vance,51,1,29,81
+Laporte,PRAIRIE,President and Vice-President of the U.S.,,DEM,Harris \ Walz,22,2,17,41
+Laporte,PRAIRIE,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,0,0,0,0
+Laporte,PRAIRIE,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,2,0,0,2
+Laporte,PRAIRIE,President and Vice-President of the U.S.,,,Write-In,0,0,0,0
+Laporte,PRAIRIE,United States Senator,,REP,Jim Banks,48,1,28,77
+Laporte,PRAIRIE,United States Senator,,DEM,Valerie McCray,21,2,15,38
+Laporte,PRAIRIE,United States Senator,,LIB,Andrew Horning,2,0,0,2
+Laporte,PRAIRIE,United States Senator,,,Write-In,0,0,0,0
+Laporte,PRAIRIE,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,40,1,23,64
+Laporte,PRAIRIE,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,29,2,20,51
+Laporte,PRAIRIE,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,4,0,2,6
+Laporte,PRAIRIE,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,PRAIRIE,Attorney General,,REP,Todd Rokita,50,1,29,80
+Laporte,PRAIRIE,Attorney General,,DEM,Destiny Wells,24,2,16,42
+Laporte,PRAIRIE,United States Representative,2,REP,Rudy Yakym,42,1,30,73
+Laporte,PRAIRIE,United States Representative,2,DEM,Lori A. Camp,27,2,14,43
+Laporte,PRAIRIE,United States Representative,2,LIB,William E. Henry,4,0,1,5
+Laporte,PRAIRIE,United States Representative,2,,Write-In,0,0,0,0
+Laporte,PRAIRIE,State Senator District 8,,REP,Mike Bohacek,52,1,30,83
+Laporte,PRAIRIE,State Senator District 8,,DEM,Leon P. Smith,22,2,15,39
+Laporte,PRAIRIE,State Representative,20,REP,Jim Pressel,66,2,36,104
+Laporte,PRAIRIE,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,56,2,35,93
+Laporte,PRAIRIE,Circuit Court Clerk,,REP,Heather Stevens,55,0,26,81
+Laporte,PRAIRIE,Circuit Court Clerk,,DEM,Angela Henzman,18,3,17,38
+Laporte,PRAIRIE,County Auditor,,REP,Mike Rosenbaum,65,2,34,101
+Laporte,PRAIRIE,County Recorder,,REP,Elzbieta (Ela) Bilderback,47,1,31,79
+Laporte,PRAIRIE,County Recorder,,DEM,Matthew Sikorski,24,2,12,38
+Laporte,PRAIRIE,County Treasurer,,REP,Dan Barenie,47,1,29,77
+Laporte,PRAIRIE,County Treasurer,,DEM,Joie Winski,25,2,14,41
+Laporte,PRAIRIE,County Coroner,,REP,Lynn Swanson,54,2,33,89
+Laporte,PRAIRIE,County Coroner,,DEM,Mark P. Baker,17,1,11,29
+Laporte,PRAIRIE,County Surveyor,,REP,John Matwyshyn,42,1,26,69
+Laporte,PRAIRIE,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,31,2,19,52
+Laporte,PRAIRIE,County Commissioner District 2,,REP,Steve Holifield,42,1,26,69
+Laporte,PRAIRIE,County Commissioner District 2,,DEM,Mike Kellems,31,2,19,52
+Laporte,PRAIRIE,County Commissioner District 3,,REP,Joe Haney,45,1,25,71
+Laporte,PRAIRIE,County Commissioner District 3,,DEM,Randy Novak,28,2,17,47
+Laporte,PRAIRIE,County Council Member At Large,,REP,Brett H. Kessler,44,1,27,72
+Laporte,PRAIRIE,County Council Member At Large,,REP,Adam Koronka,35,1,26,62
+Laporte,PRAIRIE,County Council Member At Large,,REP,Heather Oake,33,2,24,59
+Laporte,PRAIRIE,County Council Member At Large,,DEM,Scott (Scotty) Ford,20,2,10,32
+Laporte,PRAIRIE,County Council Member At Large,,DEM,Mike Mollenhauer,26,2,18,46
+Laporte,PRAIRIE,County Council Member At Large,,DEM,Johnny Stimley,18,1,10,29
+Laporte,PRAIRIE,IN Supreme Court-Rush,,,Yes,47,2,28,77
+Laporte,PRAIRIE,IN Supreme Court-Rush,,,No,14,0,13,27
+Laporte,PRAIRIE,IN Supreme Court-Massa,,,Yes,44,2,27,73
+Laporte,PRAIRIE,IN Supreme Court-Massa,,,No,16,0,13,29
+Laporte,PRAIRIE,IN Supreme Court-Molter,,,Yes,44,1,29,74
+Laporte,PRAIRIE,IN Supreme Court-Molter,,,No,16,1,12,29
+Laporte,PRAIRIE,Court of Appeals Dist 4-Pyle III,,,Yes,44,2,28,74
+Laporte,PRAIRIE,Court of Appeals Dist 4-Pyle III,,,No,16,0,13,29
+Laporte,PRAIRIE,Straight Party,,DEM,Democratic Party,,,,9
+Laporte,PRAIRIE,Straight Party,,REP,Republican Party,,,,26
+Laporte,SCIPIO 01,Ballots Cast,,,,415,62,569,1046
+Laporte,SCIPIO 01,Registered Voters,,,,,,,1433
+Laporte,SCIPIO 01,Public Question-Const Amendment,,,Yes,212,19,270,501
+Laporte,SCIPIO 01,Public Question-Const Amendment,,,No,158,30,230,418
+Laporte,SCIPIO 01,President and Vice-President of the U.S.,,REP,Trump \ Vance,307,25,385,717
+Laporte,SCIPIO 01,President and Vice-President of the U.S.,,DEM,Harris \ Walz,99,36,167,302
+Laporte,SCIPIO 01,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,3,0,7,10
+Laporte,SCIPIO 01,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,4,0,4,8
+Laporte,SCIPIO 01,President and Vice-President of the U.S.,,,Write-In,0,0,3,3
+Laporte,SCIPIO 01,United States Senator,,REP,Jim Banks,296,31,363,690
+Laporte,SCIPIO 01,United States Senator,,DEM,Valerie McCray,82,30,162,274
+Laporte,SCIPIO 01,United States Senator,,LIB,Andrew Horning,7,1,8,16
+Laporte,SCIPIO 01,United States Senator,,,Write-In,0,0,0,0
+Laporte,SCIPIO 01,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,274,25,344,643
+Laporte,SCIPIO 01,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,104,37,179,320
+Laporte,SCIPIO 01,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,13,0,16,29
+Laporte,SCIPIO 01,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,SCIPIO 01,Attorney General,,REP,Todd Rokita,296,26,374,696
+Laporte,SCIPIO 01,Attorney General,,DEM,Destiny Wells,101,33,167,301
+Laporte,SCIPIO 01,United States Representative,1,REP,Randy Niemeyer,273,26,358,657
+Laporte,SCIPIO 01,United States Representative,1,DEM,Frank J. Mrvan,115,35,179,329
+Laporte,SCIPIO 01,United States Representative,1,LIB,Dakotah Miskus,8,1,10,19
+Laporte,SCIPIO 01,United States Representative,1,,Write-In,0,0,0,0
+Laporte,SCIPIO 01,State Senator District 8,,REP,Mike Bohacek,305,32,405,742
+Laporte,SCIPIO 01,State Senator District 8,,DEM,Leon P. Smith,86,28,136,250
+Laporte,SCIPIO 01,State Representative,20,REP,Jim Pressel,337,42,423,802
+Laporte,SCIPIO 01,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,312,41,405,758
+Laporte,SCIPIO 01,Circuit Court Clerk,,REP,Heather Stevens,286,28,368,682
+Laporte,SCIPIO 01,Circuit Court Clerk,,DEM,Angela Henzman,87,30,147,264
+Laporte,SCIPIO 01,County Auditor,,REP,Mike Rosenbaum,342,37,435,814
+Laporte,SCIPIO 01,County Recorder,,REP,Elzbieta (Ela) Bilderback,284,28,372,684
+Laporte,SCIPIO 01,County Recorder,,DEM,Matthew Sikorski,100,31,160,291
+Laporte,SCIPIO 01,County Treasurer,,REP,Dan Barenie,274,24,337,635
+Laporte,SCIPIO 01,County Treasurer,,DEM,Joie Winski,122,35,200,357
+Laporte,SCIPIO 01,County Coroner,,REP,Lynn Swanson,296,35,373,704
+Laporte,SCIPIO 01,County Coroner,,DEM,Mark P. Baker,99,25,172,296
+Laporte,SCIPIO 01,County Surveyor,,REP,John Matwyshyn,245,22,316,583
+Laporte,SCIPIO 01,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,135,36,219,390
+Laporte,SCIPIO 01,County Commissioner District 2,,REP,Steve Holifield,239,27,332,598
+Laporte,SCIPIO 01,County Commissioner District 2,,DEM,Mike Kellems,154,31,207,392
+Laporte,SCIPIO 01,County Commissioner District 3,,REP,Joe Haney,271,25,338,634
+Laporte,SCIPIO 01,County Commissioner District 3,,DEM,Randy Novak,119,35,198,352
+Laporte,SCIPIO 01,County Council Member At Large,,REP,Brett H. Kessler,256,29,321,606
+Laporte,SCIPIO 01,County Council Member At Large,,REP,Adam Koronka,229,24,324,577
+Laporte,SCIPIO 01,County Council Member At Large,,REP,Heather Oake,198,18,279,495
+Laporte,SCIPIO 01,County Council Member At Large,,DEM,Scott (Scotty) Ford,90,29,153,272
+Laporte,SCIPIO 01,County Council Member At Large,,DEM,Mike Mollenhauer,135,33,183,351
+Laporte,SCIPIO 01,County Council Member At Large,,DEM,Johnny Stimley,78,24,132,234
+Laporte,SCIPIO 01,Laporte Community School Board At Large,,,Jim Arnold,233,32,294,559
+Laporte,SCIPIO 01,Laporte Community School Board At Large,,,Monica L. Beaty,184,28,258,470
+Laporte,SCIPIO 01,Laporte Community School Board At Large,,,Maria L. Ria Carpenter,156,21,243,420
+Laporte,SCIPIO 01,Laporte Community School Board At Large,,,Ed Gilliland,171,30,222,423
+Laporte,SCIPIO 01,Laporte Community School Board At Large,,,Tucker King,202,23,261,486
+Laporte,SCIPIO 01,IN Supreme Court-Rush,,,Yes,239,30,314,583
+Laporte,SCIPIO 01,IN Supreme Court-Rush,,,No,101,19,149,269
+Laporte,SCIPIO 01,IN Supreme Court-Massa,,,Yes,242,27,306,575
+Laporte,SCIPIO 01,IN Supreme Court-Massa,,,No,93,17,153,263
+Laporte,SCIPIO 01,IN Supreme Court-Molter,,,Yes,246,28,308,582
+Laporte,SCIPIO 01,IN Supreme Court-Molter,,,No,91,19,150,260
+Laporte,SCIPIO 01,Court of Appeals Dist 4-Pyle III,,,Yes,247,26,311,584
+Laporte,SCIPIO 01,Court of Appeals Dist 4-Pyle III,,,No,91,21,149,261
+Laporte,SCIPIO 01,Straight Party,,DEM,Democratic Party,,,,73
+Laporte,SCIPIO 01,Straight Party,,REP,Republican Party,,,,220
+Laporte,SCIPIO 02,Ballots Cast,,,,246,58,525,829
+Laporte,SCIPIO 02,Registered Voters,,,,,,,1193
+Laporte,SCIPIO 02,Public Question-Const Amendment,,,Yes,134,23,253,410
+Laporte,SCIPIO 02,Public Question-Const Amendment,,,No,101,23,214,338
+Laporte,SCIPIO 02,President and Vice-President of the U.S.,,REP,Trump \ Vance,161,25,306,492
+Laporte,SCIPIO 02,President and Vice-President of the U.S.,,DEM,Harris \ Walz,72,32,210,314
+Laporte,SCIPIO 02,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,5,0,0,5
+Laporte,SCIPIO 02,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,4,1,2,7
+Laporte,SCIPIO 02,President and Vice-President of the U.S.,,,Write-In,0,0,1,1
+Laporte,SCIPIO 02,United States Senator,,REP,Jim Banks,151,23,289,463
+Laporte,SCIPIO 02,United States Senator,,DEM,Valerie McCray,71,34,195,300
+Laporte,SCIPIO 02,United States Senator,,LIB,Andrew Horning,11,0,8,19
+Laporte,SCIPIO 02,United States Senator,,,Write-In,0,0,0,0
+Laporte,SCIPIO 02,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,136,24,279,439
+Laporte,SCIPIO 02,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,82,31,209,322
+Laporte,SCIPIO 02,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,16,2,13,31
+Laporte,SCIPIO 02,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,SCIPIO 02,Attorney General,,REP,Todd Rokita,159,23,302,484
+Laporte,SCIPIO 02,Attorney General,,DEM,Destiny Wells,78,34,207,319
+Laporte,SCIPIO 02,United States Representative,1,REP,Randy Niemeyer,149,24,274,447
+Laporte,SCIPIO 02,United States Representative,1,DEM,Frank J. Mrvan,78,33,224,335
+Laporte,SCIPIO 02,United States Representative,1,LIB,Dakotah Miskus,10,0,8,18
+Laporte,SCIPIO 02,United States Representative,1,,Write-In,0,0,0,0
+Laporte,SCIPIO 02,State Senator District 8,,REP,Mike Bohacek,169,24,336,529
+Laporte,SCIPIO 02,State Senator District 8,,DEM,Leon P. Smith,67,32,172,271
+Laporte,SCIPIO 02,State Representative,20,REP,Jim Pressel,193,37,372,602
+Laporte,SCIPIO 02,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,186,36,340,562
+Laporte,SCIPIO 02,Circuit Court Clerk,,REP,Heather Stevens,161,30,302,493
+Laporte,SCIPIO 02,Circuit Court Clerk,,DEM,Angela Henzman,67,26,182,275
+Laporte,SCIPIO 02,County Auditor,,REP,Mike Rosenbaum,194,38,382,614
+Laporte,SCIPIO 02,County Recorder,,REP,Elzbieta (Ela) Bilderback,161,28,308,497
+Laporte,SCIPIO 02,County Recorder,,DEM,Matthew Sikorski,72,28,186,286
+Laporte,SCIPIO 02,County Treasurer,,REP,Dan Barenie,139,24,275,438
+Laporte,SCIPIO 02,County Treasurer,,DEM,Joie Winski,94,34,231,359
+Laporte,SCIPIO 02,County Coroner,,REP,Lynn Swanson,163,26,326,515
+Laporte,SCIPIO 02,County Coroner,,DEM,Mark P. Baker,72,30,183,285
+Laporte,SCIPIO 02,County Surveyor,,REP,John Matwyshyn,134,25,253,412
+Laporte,SCIPIO 02,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,95,31,245,371
+Laporte,SCIPIO 02,County Commissioner District 2,,REP,Steve Holifield,133,21,260,414
+Laporte,SCIPIO 02,County Commissioner District 2,,DEM,Mike Kellems,99,37,244,380
+Laporte,SCIPIO 02,County Commissioner District 3,,REP,Joe Haney,143,22,266,431
+Laporte,SCIPIO 02,County Commissioner District 3,,DEM,Randy Novak,91,36,239,366
+Laporte,SCIPIO 02,County Council Member At Large,,REP,Brett H. Kessler,130,17,253,400
+Laporte,SCIPIO 02,County Council Member At Large,,REP,Adam Koronka,123,17,233,373
+Laporte,SCIPIO 02,County Council Member At Large,,REP,Heather Oake,111,16,203,330
+Laporte,SCIPIO 02,County Council Member At Large,,DEM,Scott (Scotty) Ford,66,29,169,264
+Laporte,SCIPIO 02,County Council Member At Large,,DEM,Mike Mollenhauer,92,34,228,354
+Laporte,SCIPIO 02,County Council Member At Large,,DEM,Johnny Stimley,55,28,159,242
+Laporte,SCIPIO 02,Laporte Community School Board At Large,,,Jim Arnold,142,31,269,442
+Laporte,SCIPIO 02,Laporte Community School Board At Large,,,Monica L. Beaty,116,27,244,387
+Laporte,SCIPIO 02,Laporte Community School Board At Large,,,Maria L. Ria Carpenter,95,22,198,315
+Laporte,SCIPIO 02,Laporte Community School Board At Large,,,Ed Gilliland,104,25,208,337
+Laporte,SCIPIO 02,Laporte Community School Board At Large,,,Tucker King,125,19,237,381
+Laporte,SCIPIO 02,IN Supreme Court-Rush,,,Yes,156,27,245,428
+Laporte,SCIPIO 02,IN Supreme Court-Rush,,,No,60,19,177,256
+Laporte,SCIPIO 02,IN Supreme Court-Massa,,,Yes,153,26,251,430
+Laporte,SCIPIO 02,IN Supreme Court-Massa,,,No,62,20,174,256
+Laporte,SCIPIO 02,IN Supreme Court-Molter,,,Yes,155,25,250,430
+Laporte,SCIPIO 02,IN Supreme Court-Molter,,,No,61,21,172,254
+Laporte,SCIPIO 02,Court of Appeals Dist 4-Pyle III,,,Yes,156,27,252,435
+Laporte,SCIPIO 02,Court of Appeals Dist 4-Pyle III,,,No,59,20,171,250
+Laporte,SCIPIO 02,Straight Party,,DEM,Democratic Party,,,,76
+Laporte,SCIPIO 02,Straight Party,,REP,Republican Party,,,,182
+Laporte,SPRINGFIELD 01,Ballots Cast,,,,364,38,223,625
+Laporte,SPRINGFIELD 01,Registered Voters,,,,,,,1005
+Laporte,SPRINGFIELD 01,Public Question-Const Amendment,,,Yes,187,13,93,293
+Laporte,SPRINGFIELD 01,Public Question-Const Amendment,,,No,138,18,100,256
+Laporte,SPRINGFIELD 01,President and Vice-President of the U.S.,,REP,Trump \ Vance,257,16,131,404
+Laporte,SPRINGFIELD 01,President and Vice-President of the U.S.,,DEM,Harris \ Walz,96,22,87,205
+Laporte,SPRINGFIELD 01,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,2,0,0,2
+Laporte,SPRINGFIELD 01,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,6,0,2,8
+Laporte,SPRINGFIELD 01,President and Vice-President of the U.S.,,,Write-In,0,0,0,0
+Laporte,SPRINGFIELD 01,United States Senator,,REP,Jim Banks,223,15,123,361
+Laporte,SPRINGFIELD 01,United States Senator,,DEM,Valerie McCray,95,22,80,197
+Laporte,SPRINGFIELD 01,United States Senator,,LIB,Andrew Horning,12,0,5,17
+Laporte,SPRINGFIELD 01,United States Senator,,,Write-In,0,0,0,0
+Laporte,SPRINGFIELD 01,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,212,13,116,341
+Laporte,SPRINGFIELD 01,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,103,24,86,213
+Laporte,SPRINGFIELD 01,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,20,0,10,30
+Laporte,SPRINGFIELD 01,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,SPRINGFIELD 01,Attorney General,,REP,Todd Rokita,245,13,132,390
+Laporte,SPRINGFIELD 01,Attorney General,,DEM,Destiny Wells,95,24,82,201
+Laporte,SPRINGFIELD 01,United States Representative,1,REP,Randy Niemeyer,222,13,117,352
+Laporte,SPRINGFIELD 01,United States Representative,1,DEM,Frank J. Mrvan,111,22,93,226
+Laporte,SPRINGFIELD 01,United States Representative,1,LIB,Dakotah Miskus,13,2,6,21
+Laporte,SPRINGFIELD 01,United States Representative,1,,Write-In,0,0,0,0
+Laporte,SPRINGFIELD 01,State Senator District 8,,REP,Mike Bohacek,255,13,138,406
+Laporte,SPRINGFIELD 01,State Senator District 8,,DEM,Leon P. Smith,89,23,76,188
+Laporte,SPRINGFIELD 01,State Representative,09,REP,Joel Florek,242,14,130,386
+Laporte,SPRINGFIELD 01,State Representative,09,DEM,Patricia A. (Pat) Boy,100,23,81,204
+Laporte,SPRINGFIELD 01,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,263,17,147,427
+Laporte,SPRINGFIELD 01,Circuit Court Clerk,,REP,Heather Stevens,243,14,126,383
+Laporte,SPRINGFIELD 01,Circuit Court Clerk,,DEM,Angela Henzman,93,22,78,193
+Laporte,SPRINGFIELD 01,County Auditor,,REP,Mike Rosenbaum,278,16,155,449
+Laporte,SPRINGFIELD 01,County Recorder,,REP,Elzbieta (Ela) Bilderback,231,17,130,378
+Laporte,SPRINGFIELD 01,County Recorder,,DEM,Matthew Sikorski,113,21,80,214
+Laporte,SPRINGFIELD 01,County Treasurer,,REP,Dan Barenie,225,14,124,363
+Laporte,SPRINGFIELD 01,County Treasurer,,DEM,Joie Winski,120,24,92,236
+Laporte,SPRINGFIELD 01,County Coroner,,REP,Lynn Swanson,248,16,140,404
+Laporte,SPRINGFIELD 01,County Coroner,,DEM,Mark P. Baker,101,21,78,200
+Laporte,SPRINGFIELD 01,County Surveyor,,REP,John Matwyshyn,225,13,121,359
+Laporte,SPRINGFIELD 01,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,115,23,88,226
+Laporte,SPRINGFIELD 01,County Commissioner District 2,,REP,Steve Holifield,228,15,121,364
+Laporte,SPRINGFIELD 01,County Commissioner District 2,,DEM,Mike Kellems,112,22,86,220
+Laporte,SPRINGFIELD 01,County Commissioner District 3,,REP,Joe Haney,222,9,118,349
+Laporte,SPRINGFIELD 01,County Commissioner District 3,,DEM,Randy Novak,122,28,92,242
+Laporte,SPRINGFIELD 01,County Council Member At Large,,REP,Brett H. Kessler,182,15,97,294
+Laporte,SPRINGFIELD 01,County Council Member At Large,,REP,Adam Koronka,147,12,92,251
+Laporte,SPRINGFIELD 01,County Council Member At Large,,REP,Heather Oake,142,12,81,235
+Laporte,SPRINGFIELD 01,County Council Member At Large,,DEM,Scott (Scotty) Ford,73,18,66,157
+Laporte,SPRINGFIELD 01,County Council Member At Large,,DEM,Mike Mollenhauer,106,17,76,199
+Laporte,SPRINGFIELD 01,County Council Member At Large,,DEM,Johnny Stimley,97,18,76,191
+Laporte,SPRINGFIELD 01,MC Area SB Civil City,,,Marty M. Corley,153,15,81,249
+Laporte,SPRINGFIELD 01,MC Area SB Civil City,,,Rodney McCormick,113,10,67,190
+Laporte,SPRINGFIELD 01,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,98,3,49,150
+Laporte,SPRINGFIELD 01,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,27,3,24,54
+Laporte,SPRINGFIELD 01,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,71,6,28,105
+Laporte,SPRINGFIELD 01,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,44,5,27,76
+Laporte,SPRINGFIELD 01,MC Area SB Michigan/Springfield Twps,,,James Stewart,254,22,130,406
+Laporte,SPRINGFIELD 01,IN Supreme Court-Rush,,,Yes,185,22,100,307
+Laporte,SPRINGFIELD 01,IN Supreme Court-Rush,,,No,98,8,56,162
+Laporte,SPRINGFIELD 01,IN Supreme Court-Massa,,,Yes,184,18,95,297
+Laporte,SPRINGFIELD 01,IN Supreme Court-Massa,,,No,98,14,58,170
+Laporte,SPRINGFIELD 01,IN Supreme Court-Molter,,,Yes,184,19,95,298
+Laporte,SPRINGFIELD 01,IN Supreme Court-Molter,,,No,99,12,56,167
+Laporte,SPRINGFIELD 01,Court of Appeals Dist 4-Pyle III,,,Yes,193,22,94,309
+Laporte,SPRINGFIELD 01,Court of Appeals Dist 4-Pyle III,,,No,88,8,59,155
+Laporte,SPRINGFIELD 01,Straight Party,,DEM,Democratic Party,,,,69
+Laporte,SPRINGFIELD 01,Straight Party,,REP,Republican Party,,,,175
+Laporte,SPRINGFIELD 02,Ballots Cast,,,,300,28,306,634
+Laporte,SPRINGFIELD 02,Registered Voters,,,,,,,1053
+Laporte,SPRINGFIELD 02,Public Question-Const Amendment,,,Yes,130,8,145,283
+Laporte,SPRINGFIELD 02,Public Question-Const Amendment,,,No,120,13,118,251
+Laporte,SPRINGFIELD 02,President and Vice-President of the U.S.,,REP,Trump \ Vance,220,9,187,416
+Laporte,SPRINGFIELD 02,President and Vice-President of the U.S.,,DEM,Harris \ Walz,72,18,113,203
+Laporte,SPRINGFIELD 02,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,1,0,2,3
+Laporte,SPRINGFIELD 02,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,2,1,1,4
+Laporte,SPRINGFIELD 02,President and Vice-President of the U.S.,,,Write-In,1,0,0,1
+Laporte,SPRINGFIELD 02,United States Senator,,REP,Jim Banks,186,9,177,372
+Laporte,SPRINGFIELD 02,United States Senator,,DEM,Valerie McCray,79,18,110,207
+Laporte,SPRINGFIELD 02,United States Senator,,LIB,Andrew Horning,8,0,7,15
+Laporte,SPRINGFIELD 02,United States Senator,,,Write-In,0,0,0,0
+Laporte,SPRINGFIELD 02,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,185,9,176,370
+Laporte,SPRINGFIELD 02,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,79,18,111,208
+Laporte,SPRINGFIELD 02,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,10,0,10,20
+Laporte,SPRINGFIELD 02,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,SPRINGFIELD 02,Attorney General,,REP,Todd Rokita,196,11,186,393
+Laporte,SPRINGFIELD 02,Attorney General,,DEM,Destiny Wells,83,17,111,211
+Laporte,SPRINGFIELD 02,United States Representative,1,REP,Randy Niemeyer,179,9,172,360
+Laporte,SPRINGFIELD 02,United States Representative,1,DEM,Frank J. Mrvan,90,18,119,227
+Laporte,SPRINGFIELD 02,United States Representative,1,LIB,Dakotah Miskus,8,1,7,16
+Laporte,SPRINGFIELD 02,United States Representative,1,,Write-In,0,0,0,0
+Laporte,SPRINGFIELD 02,State Senator District 8,,REP,Mike Bohacek,202,11,190,403
+Laporte,SPRINGFIELD 02,State Senator District 8,,DEM,Leon P. Smith,77,17,106,200
+Laporte,SPRINGFIELD 02,State Representative,09,REP,Joel Florek,190,11,181,382
+Laporte,SPRINGFIELD 02,State Representative,09,DEM,Patricia A. (Pat) Boy,86,17,117,220
+Laporte,SPRINGFIELD 02,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,211,18,206,435
+Laporte,SPRINGFIELD 02,Circuit Court Clerk,,REP,Heather Stevens,193,11,186,390
+Laporte,SPRINGFIELD 02,Circuit Court Clerk,,DEM,Angela Henzman,79,17,104,200
+Laporte,SPRINGFIELD 02,County Auditor,,REP,Mike Rosenbaum,224,18,213,455
+Laporte,SPRINGFIELD 02,County Recorder,,REP,Elzbieta (Ela) Bilderback,167,11,182,360
+Laporte,SPRINGFIELD 02,County Recorder,,DEM,Matthew Sikorski,102,17,116,235
+Laporte,SPRINGFIELD 02,County Treasurer,,REP,Dan Barenie,181,10,176,367
+Laporte,SPRINGFIELD 02,County Treasurer,,DEM,Joie Winski,95,18,120,233
+Laporte,SPRINGFIELD 02,County Coroner,,REP,Lynn Swanson,179,11,190,380
+Laporte,SPRINGFIELD 02,County Coroner,,DEM,Mark P. Baker,96,17,108,221
+Laporte,SPRINGFIELD 02,County Surveyor,,REP,John Matwyshyn,173,8,167,348
+Laporte,SPRINGFIELD 02,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,102,20,125,247
+Laporte,SPRINGFIELD 02,County Commissioner District 2,,REP,Steve Holifield,173,10,177,360
+Laporte,SPRINGFIELD 02,County Commissioner District 2,,DEM,Mike Kellems,99,18,114,231
+Laporte,SPRINGFIELD 02,County Commissioner District 3,,REP,Joe Haney,181,9,174,364
+Laporte,SPRINGFIELD 02,County Commissioner District 3,,DEM,Randy Novak,90,19,121,230
+Laporte,SPRINGFIELD 02,County Council Member At Large,,REP,Brett H. Kessler,164,10,151,325
+Laporte,SPRINGFIELD 02,County Council Member At Large,,REP,Adam Koronka,119,9,129,257
+Laporte,SPRINGFIELD 02,County Council Member At Large,,REP,Heather Oake,119,7,118,244
+Laporte,SPRINGFIELD 02,County Council Member At Large,,DEM,Scott (Scotty) Ford,69,15,96,180
+Laporte,SPRINGFIELD 02,County Council Member At Large,,DEM,Mike Mollenhauer,94,16,110,220
+Laporte,SPRINGFIELD 02,County Council Member At Large,,DEM,Johnny Stimley,80,18,96,194
+Laporte,SPRINGFIELD 02,MC Area SB Civil City,,,Marty M. Corley,97,7,122,226
+Laporte,SPRINGFIELD 02,MC Area SB Civil City,,,Rodney McCormick,102,7,81,190
+Laporte,SPRINGFIELD 02,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,72,0,61,133
+Laporte,SPRINGFIELD 02,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,29,0,27,56
+Laporte,SPRINGFIELD 02,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,58,5,53,116
+Laporte,SPRINGFIELD 02,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,32,6,46,84
+Laporte,SPRINGFIELD 02,MC Area SB Michigan/Springfield Twps,,,James Stewart,190,12,184,386
+Laporte,SPRINGFIELD 02,IN Supreme Court-Rush,,,Yes,135,13,151,299
+Laporte,SPRINGFIELD 02,IN Supreme Court-Rush,,,No,83,9,75,167
+Laporte,SPRINGFIELD 02,IN Supreme Court-Massa,,,Yes,130,12,142,284
+Laporte,SPRINGFIELD 02,IN Supreme Court-Massa,,,No,88,9,82,179
+Laporte,SPRINGFIELD 02,IN Supreme Court-Molter,,,Yes,139,12,149,300
+Laporte,SPRINGFIELD 02,IN Supreme Court-Molter,,,No,81,9,78,168
+Laporte,SPRINGFIELD 02,Court of Appeals Dist 4-Pyle III,,,Yes,137,14,143,294
+Laporte,SPRINGFIELD 02,Court of Appeals Dist 4-Pyle III,,,No,81,7,81,169
+Laporte,SPRINGFIELD 02,Straight Party,,DEM,Democratic Party,,,,68
+Laporte,SPRINGFIELD 02,Straight Party,,REP,Republican Party,,,,193
+Laporte,SPRINGFIELD 03,Ballots Cast,,,,210,32,223,465
+Laporte,SPRINGFIELD 03,Registered Voters,,,,,,,724
+Laporte,SPRINGFIELD 03,Public Question-Const Amendment,,,Yes,102,6,103,211
+Laporte,SPRINGFIELD 03,Public Question-Const Amendment,,,No,88,15,100,203
+Laporte,SPRINGFIELD 03,President and Vice-President of the U.S.,,REP,Trump \ Vance,128,16,124,268
+Laporte,SPRINGFIELD 03,President and Vice-President of the U.S.,,DEM,Harris \ Walz,71,16,97,184
+Laporte,SPRINGFIELD 03,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,1,0,1,2
+Laporte,SPRINGFIELD 03,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,5,0,0,5
+Laporte,SPRINGFIELD 03,President and Vice-President of the U.S.,,,Write-In,1,0,0,1
+Laporte,SPRINGFIELD 03,United States Senator,,REP,Jim Banks,114,14,112,240
+Laporte,SPRINGFIELD 03,United States Senator,,DEM,Valerie McCray,71,16,92,179
+Laporte,SPRINGFIELD 03,United States Senator,,LIB,Andrew Horning,8,1,0,9
+Laporte,SPRINGFIELD 03,United States Senator,,,Write-In,0,0,0,0
+Laporte,SPRINGFIELD 03,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,113,14,119,246
+Laporte,SPRINGFIELD 03,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,71,16,88,175
+Laporte,SPRINGFIELD 03,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,11,0,2,13
+Laporte,SPRINGFIELD 03,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,SPRINGFIELD 03,Attorney General,,REP,Todd Rokita,129,15,121,265
+Laporte,SPRINGFIELD 03,Attorney General,,DEM,Destiny Wells,69,16,93,178
+Laporte,SPRINGFIELD 03,United States Representative,1,REP,Randy Niemeyer,103,14,122,239
+Laporte,SPRINGFIELD 03,United States Representative,1,DEM,Frank J. Mrvan,88,15,97,200
+Laporte,SPRINGFIELD 03,United States Representative,1,LIB,Dakotah Miskus,6,2,1,9
+Laporte,SPRINGFIELD 03,United States Representative,1,,Write-In,0,0,0,0
+Laporte,SPRINGFIELD 03,State Senator District 8,,REP,Mike Bohacek,134,14,129,277
+Laporte,SPRINGFIELD 03,State Senator District 8,,DEM,Leon P. Smith,62,17,84,163
+Laporte,SPRINGFIELD 03,State Representative,09,REP,Joel Florek,120,15,114,249
+Laporte,SPRINGFIELD 03,State Representative,09,DEM,Patricia A. (Pat) Boy,77,16,102,195
+Laporte,SPRINGFIELD 03,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,149,17,133,299
+Laporte,SPRINGFIELD 03,Circuit Court Clerk,,REP,Heather Stevens,123,14,120,257
+Laporte,SPRINGFIELD 03,Circuit Court Clerk,,DEM,Angela Henzman,65,17,90,172
+Laporte,SPRINGFIELD 03,County Auditor,,REP,Mike Rosenbaum,157,17,141,315
+Laporte,SPRINGFIELD 03,County Recorder,,REP,Elzbieta (Ela) Bilderback,117,13,120,250
+Laporte,SPRINGFIELD 03,County Recorder,,DEM,Matthew Sikorski,76,17,91,184
+Laporte,SPRINGFIELD 03,County Treasurer,,REP,Dan Barenie,113,12,115,240
+Laporte,SPRINGFIELD 03,County Treasurer,,DEM,Joie Winski,83,18,100,201
+Laporte,SPRINGFIELD 03,County Coroner,,REP,Lynn Swanson,129,12,123,264
+Laporte,SPRINGFIELD 03,County Coroner,,DEM,Mark P. Baker,70,18,91,179
+Laporte,SPRINGFIELD 03,County Surveyor,,REP,John Matwyshyn,98,11,112,221
+Laporte,SPRINGFIELD 03,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,89,19,100,208
+Laporte,SPRINGFIELD 03,County Commissioner District 2,,REP,Steve Holifield,113,15,113,241
+Laporte,SPRINGFIELD 03,County Commissioner District 2,,DEM,Mike Kellems,76,15,97,188
+Laporte,SPRINGFIELD 03,County Commissioner District 3,,REP,Joe Haney,107,12,112,231
+Laporte,SPRINGFIELD 03,County Commissioner District 3,,DEM,Randy Novak,85,17,104,206
+Laporte,SPRINGFIELD 03,County Council Member At Large,,REP,Brett H. Kessler,97,9,81,187
+Laporte,SPRINGFIELD 03,County Council Member At Large,,REP,Adam Koronka,83,9,76,168
+Laporte,SPRINGFIELD 03,County Council Member At Large,,REP,Heather Oake,86,8,80,174
+Laporte,SPRINGFIELD 03,County Council Member At Large,,DEM,Scott (Scotty) Ford,64,10,74,148
+Laporte,SPRINGFIELD 03,County Council Member At Large,,DEM,Mike Mollenhauer,72,13,83,168
+Laporte,SPRINGFIELD 03,County Council Member At Large,,DEM,Johnny Stimley,76,11,74,161
+Laporte,SPRINGFIELD 03,MC Area SB Civil City,,,Marty M. Corley,99,6,93,198
+Laporte,SPRINGFIELD 03,MC Area SB Civil City,,,Rodney McCormick,63,8,58,129
+Laporte,SPRINGFIELD 03,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,52,3,50,105
+Laporte,SPRINGFIELD 03,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,30,3,34,67
+Laporte,SPRINGFIELD 03,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,35,4,40,79
+Laporte,SPRINGFIELD 03,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,36,4,19,59
+Laporte,SPRINGFIELD 03,MC Area SB Michigan/Springfield Twps,,,James Stewart,158,10,140,308
+Laporte,SPRINGFIELD 03,IN Supreme Court-Rush,,,Yes,104,7,106,217
+Laporte,SPRINGFIELD 03,IN Supreme Court-Rush,,,No,58,10,65,133
+Laporte,SPRINGFIELD 03,IN Supreme Court-Massa,,,Yes,106,5,100,211
+Laporte,SPRINGFIELD 03,IN Supreme Court-Massa,,,No,54,11,68,133
+Laporte,SPRINGFIELD 03,IN Supreme Court-Molter,,,Yes,105,7,100,212
+Laporte,SPRINGFIELD 03,IN Supreme Court-Molter,,,No,59,10,67,136
+Laporte,SPRINGFIELD 03,Court of Appeals Dist 4-Pyle III,,,Yes,108,8,96,212
+Laporte,SPRINGFIELD 03,Court of Appeals Dist 4-Pyle III,,,No,57,9,69,135
+Laporte,SPRINGFIELD 03,Straight Party,,DEM,Democratic Party,,,,65
+Laporte,SPRINGFIELD 03,Straight Party,,REP,Republican Party,,,,114
+Laporte,TRAIL CREEK 01,Ballots Cast,,,,324,24,338,686
+Laporte,TRAIL CREEK 01,Registered Voters,,,,,,,1033
+Laporte,TRAIL CREEK 01,Public Question-Const Amendment,,,Yes,167,9,148,324
+Laporte,TRAIL CREEK 01,Public Question-Const Amendment,,,No,134,11,147,292
+Laporte,TRAIL CREEK 01,President and Vice-President of the U.S.,,REP,Trump \ Vance,182,9,163,354
+Laporte,TRAIL CREEK 01,President and Vice-President of the U.S.,,DEM,Harris \ Walz,132,15,170,317
+Laporte,TRAIL CREEK 01,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,5,0,1,6
+Laporte,TRAIL CREEK 01,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,4,0,1,5
+Laporte,TRAIL CREEK 01,President and Vice-President of the U.S.,,,Write-In,0,0,0,0
+Laporte,TRAIL CREEK 01,United States Senator,,REP,Jim Banks,156,12,148,316
+Laporte,TRAIL CREEK 01,United States Senator,,DEM,Valerie McCray,134,12,162,308
+Laporte,TRAIL CREEK 01,United States Senator,,LIB,Andrew Horning,12,0,4,16
+Laporte,TRAIL CREEK 01,United States Senator,,,Write-In,0,0,0,0
+Laporte,TRAIL CREEK 01,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,152,12,151,315
+Laporte,TRAIL CREEK 01,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,138,12,160,310
+Laporte,TRAIL CREEK 01,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,14,0,6,20
+Laporte,TRAIL CREEK 01,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,TRAIL CREEK 01,Attorney General,,REP,Todd Rokita,161,10,160,331
+Laporte,TRAIL CREEK 01,Attorney General,,DEM,Destiny Wells,148,14,160,322
+Laporte,TRAIL CREEK 01,United States Representative,1,REP,Randy Niemeyer,148,8,135,291
+Laporte,TRAIL CREEK 01,United States Representative,1,DEM,Frank J. Mrvan,148,16,185,349
+Laporte,TRAIL CREEK 01,United States Representative,1,LIB,Dakotah Miskus,18,0,4,22
+Laporte,TRAIL CREEK 01,United States Representative,1,,Write-In,0,0,0,0
+Laporte,TRAIL CREEK 01,State Representative,09,REP,Joel Florek,168,10,159,337
+Laporte,TRAIL CREEK 01,State Representative,09,DEM,Patricia A. (Pat) Boy,143,13,166,322
+Laporte,TRAIL CREEK 01,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,210,16,182,408
+Laporte,TRAIL CREEK 01,Circuit Court Clerk,,REP,Heather Stevens,155,13,163,331
+Laporte,TRAIL CREEK 01,Circuit Court Clerk,,DEM,Angela Henzman,138,11,150,299
+Laporte,TRAIL CREEK 01,County Auditor,,REP,Mike Rosenbaum,224,16,192,432
+Laporte,TRAIL CREEK 01,County Recorder,,REP,Elzbieta (Ela) Bilderback,161,11,154,326
+Laporte,TRAIL CREEK 01,County Recorder,,DEM,Matthew Sikorski,142,13,159,314
+Laporte,TRAIL CREEK 01,County Treasurer,,REP,Dan Barenie,153,9,139,301
+Laporte,TRAIL CREEK 01,County Treasurer,,DEM,Joie Winski,158,15,185,358
+Laporte,TRAIL CREEK 01,County Coroner,,REP,Lynn Swanson,177,11,171,359
+Laporte,TRAIL CREEK 01,County Coroner,,DEM,Mark P. Baker,129,12,153,294
+Laporte,TRAIL CREEK 01,County Surveyor,,REP,John Matwyshyn,143,11,135,289
+Laporte,TRAIL CREEK 01,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,157,13,180,350
+Laporte,TRAIL CREEK 01,County Commissioner District 2,,REP,Steve Holifield,159,11,142,312
+Laporte,TRAIL CREEK 01,County Commissioner District 2,,DEM,Mike Kellems,141,13,171,325
+Laporte,TRAIL CREEK 01,County Commissioner District 3,,REP,Joe Haney,145,7,140,292
+Laporte,TRAIL CREEK 01,County Commissioner District 3,,DEM,Randy Novak,158,17,180,355
+Laporte,TRAIL CREEK 01,County Council Member At Large,,REP,Brett H. Kessler,125,8,117,250
+Laporte,TRAIL CREEK 01,County Council Member At Large,,REP,Adam Koronka,107,8,105,220
+Laporte,TRAIL CREEK 01,County Council Member At Large,,REP,Heather Oake,103,6,102,211
+Laporte,TRAIL CREEK 01,County Council Member At Large,,DEM,Scott (Scotty) Ford,108,10,126,244
+Laporte,TRAIL CREEK 01,County Council Member At Large,,DEM,Mike Mollenhauer,128,15,148,291
+Laporte,TRAIL CREEK 01,County Council Member At Large,,DEM,Johnny Stimley,135,14,160,309
+Laporte,TRAIL CREEK 01,MC Area SB Civil City,,,Marty M. Corley,152,13,181,346
+Laporte,TRAIL CREEK 01,MC Area SB Civil City,,,Rodney McCormick,112,4,82,198
+Laporte,TRAIL CREEK 01,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,83,2,72,157
+Laporte,TRAIL CREEK 01,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,55,3,56,114
+Laporte,TRAIL CREEK 01,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,68,8,51,127
+Laporte,TRAIL CREEK 01,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,46,1,62,109
+Laporte,TRAIL CREEK 01,MC Area SB Michigan/Springfield Twps,,,James Stewart,242,13,218,473
+Laporte,TRAIL CREEK 01,IN Supreme Court-Rush,,,Yes,166,16,168,350
+Laporte,TRAIL CREEK 01,IN Supreme Court-Rush,,,No,99,1,88,188
+Laporte,TRAIL CREEK 01,IN Supreme Court-Massa,,,Yes,161,13,160,334
+Laporte,TRAIL CREEK 01,IN Supreme Court-Massa,,,No,104,3,92,199
+Laporte,TRAIL CREEK 01,IN Supreme Court-Molter,,,Yes,163,11,157,331
+Laporte,TRAIL CREEK 01,IN Supreme Court-Molter,,,No,103,3,97,203
+Laporte,TRAIL CREEK 01,Court of Appeals Dist 4-Pyle III,,,Yes,163,13,155,331
+Laporte,TRAIL CREEK 01,Court of Appeals Dist 4-Pyle III,,,No,102,2,97,201
+Laporte,TRAIL CREEK 01,Straight Party,,DEM,Democratic Party,,,,109
+Laporte,TRAIL CREEK 01,Straight Party,,REP,Republican Party,,,,118
+Laporte,TRAIL CREEK 02,Ballots Cast,,,,187,36,206,429
+Laporte,TRAIL CREEK 02,Registered Voters,,,,,,,672
+Laporte,TRAIL CREEK 02,Public Question-Const Amendment,,,Yes,107,15,91,213
+Laporte,TRAIL CREEK 02,Public Question-Const Amendment,,,No,68,10,100,178
+Laporte,TRAIL CREEK 02,President and Vice-President of the U.S.,,REP,Trump \ Vance,104,16,97,217
+Laporte,TRAIL CREEK 02,President and Vice-President of the U.S.,,DEM,Harris \ Walz,77,20,99,196
+Laporte,TRAIL CREEK 02,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,2,0,0,2
+Laporte,TRAIL CREEK 02,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,2,0,5,7
+Laporte,TRAIL CREEK 02,President and Vice-President of the U.S.,,,Write-In,2,0,0,2
+Laporte,TRAIL CREEK 02,United States Senator,,REP,Jim Banks,89,14,90,193
+Laporte,TRAIL CREEK 02,United States Senator,,DEM,Valerie McCray,78,19,98,195
+Laporte,TRAIL CREEK 02,United States Senator,,LIB,Andrew Horning,6,0,5,11
+Laporte,TRAIL CREEK 02,United States Senator,,,Write-In,0,0,0,0
+Laporte,TRAIL CREEK 02,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,81,13,92,186
+Laporte,TRAIL CREEK 02,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,85,20,90,195
+Laporte,TRAIL CREEK 02,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,12,0,8,20
+Laporte,TRAIL CREEK 02,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,TRAIL CREEK 02,Attorney General,,REP,Todd Rokita,98,14,99,211
+Laporte,TRAIL CREEK 02,Attorney General,,DEM,Destiny Wells,76,19,98,193
+Laporte,TRAIL CREEK 02,United States Representative,1,REP,Randy Niemeyer,88,13,88,189
+Laporte,TRAIL CREEK 02,United States Representative,1,DEM,Frank J. Mrvan,82,19,111,212
+Laporte,TRAIL CREEK 02,United States Representative,1,LIB,Dakotah Miskus,8,0,1,9
+Laporte,TRAIL CREEK 02,United States Representative,1,,Write-In,0,0,0,0
+Laporte,TRAIL CREEK 02,State Representative,09,REP,Joel Florek,89,14,95,198
+Laporte,TRAIL CREEK 02,State Representative,09,DEM,Patricia A. (Pat) Boy,89,19,101,209
+Laporte,TRAIL CREEK 02,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,123,17,113,253
+Laporte,TRAIL CREEK 02,Circuit Court Clerk,,REP,Heather Stevens,95,15,101,211
+Laporte,TRAIL CREEK 02,Circuit Court Clerk,,DEM,Angela Henzman,74,18,93,185
+Laporte,TRAIL CREEK 02,County Auditor,,REP,Mike Rosenbaum,129,18,125,272
+Laporte,TRAIL CREEK 02,County Recorder,,REP,Elzbieta (Ela) Bilderback,95,14,100,209
+Laporte,TRAIL CREEK 02,County Recorder,,DEM,Matthew Sikorski,79,19,99,197
+Laporte,TRAIL CREEK 02,County Treasurer,,REP,Dan Barenie,80,14,89,183
+Laporte,TRAIL CREEK 02,County Treasurer,,DEM,Joie Winski,99,19,110,228
+Laporte,TRAIL CREEK 02,County Coroner,,REP,Lynn Swanson,100,14,101,215
+Laporte,TRAIL CREEK 02,County Coroner,,DEM,Mark P. Baker,78,15,99,192
+Laporte,TRAIL CREEK 02,County Surveyor,,REP,John Matwyshyn,83,17,89,189
+Laporte,TRAIL CREEK 02,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,86,16,105,207
+Laporte,TRAIL CREEK 02,County Commissioner District 2,,REP,Steve Holifield,79,14,86,179
+Laporte,TRAIL CREEK 02,County Commissioner District 2,,DEM,Mike Kellems,90,19,107,216
+Laporte,TRAIL CREEK 02,County Commissioner District 3,,REP,Joe Haney,90,13,83,186
+Laporte,TRAIL CREEK 02,County Commissioner District 3,,DEM,Randy Novak,87,20,110,217
+Laporte,TRAIL CREEK 02,County Council Member At Large,,REP,Brett H. Kessler,68,12,74,154
+Laporte,TRAIL CREEK 02,County Council Member At Large,,REP,Adam Koronka,60,11,72,143
+Laporte,TRAIL CREEK 02,County Council Member At Large,,REP,Heather Oake,54,12,66,132
+Laporte,TRAIL CREEK 02,County Council Member At Large,,DEM,Scott (Scotty) Ford,59,10,86,155
+Laporte,TRAIL CREEK 02,County Council Member At Large,,DEM,Mike Mollenhauer,74,9,96,179
+Laporte,TRAIL CREEK 02,County Council Member At Large,,DEM,Johnny Stimley,82,11,96,189
+Laporte,TRAIL CREEK 02,MC Area SB Civil City,,,Marty M. Corley,94,13,89,196
+Laporte,TRAIL CREEK 02,MC Area SB Civil City,,,Rodney McCormick,59,10,70,139
+Laporte,TRAIL CREEK 02,MC Area SB Coolspring/Pine Twps,,,Jackie Allison,51,7,44,102
+Laporte,TRAIL CREEK 02,MC Area SB Coolspring/Pine Twps,,,Stasi Benning,23,3,27,53
+Laporte,TRAIL CREEK 02,MC Area SB Coolspring/Pine Twps,,,Donald J. Dulaney,28,5,42,75
+Laporte,TRAIL CREEK 02,MC Area SB Coolspring/Pine Twps,,,Susan Fazekas,37,6,36,79
+Laporte,TRAIL CREEK 02,MC Area SB Michigan/Springfield Twps,,,James Stewart,134,15,139,288
+Laporte,TRAIL CREEK 02,IN Supreme Court-Rush,,,Yes,99,18,98,215
+Laporte,TRAIL CREEK 02,IN Supreme Court-Rush,,,No,43,4,63,110
+Laporte,TRAIL CREEK 02,IN Supreme Court-Massa,,,Yes,94,16,96,206
+Laporte,TRAIL CREEK 02,IN Supreme Court-Massa,,,No,47,3,65,115
+Laporte,TRAIL CREEK 02,IN Supreme Court-Molter,,,Yes,99,16,97,212
+Laporte,TRAIL CREEK 02,IN Supreme Court-Molter,,,No,44,3,64,111
+Laporte,TRAIL CREEK 02,Court of Appeals Dist 4-Pyle III,,,Yes,98,15,105,218
+Laporte,TRAIL CREEK 02,Court of Appeals Dist 4-Pyle III,,,No,45,4,59,108
+Laporte,TRAIL CREEK 02,Straight Party,,DEM,Democratic Party,,,,71
+Laporte,TRAIL CREEK 02,Straight Party,,REP,Republican Party,,,,79
+Laporte,UNION,Ballots Cast,,,,256,14,144,414
+Laporte,UNION,Registered Voters,,,,,,,640
+Laporte,UNION,Public Question-Const Amendment,,,Yes,131,6,63,200
+Laporte,UNION,Public Question-Const Amendment,,,No,108,6,63,177
+Laporte,UNION,President and Vice-President of the U.S.,,REP,Trump \ Vance,180,8,90,278
+Laporte,UNION,President and Vice-President of the U.S.,,DEM,Harris \ Walz,63,6,54,123
+Laporte,UNION,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,3,0,0,3
+Laporte,UNION,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,7,0,0,7
+Laporte,UNION,President and Vice-President of the U.S.,,,Write-In,1,0,0,1
+Laporte,UNION,United States Senator,,REP,Jim Banks,165,8,91,264
+Laporte,UNION,United States Senator,,DEM,Valerie McCray,63,6,46,115
+Laporte,UNION,United States Senator,,LIB,Andrew Horning,9,0,3,12
+Laporte,UNION,United States Senator,,,Write-In,0,0,0,0
+Laporte,UNION,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,150,8,83,241
+Laporte,UNION,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,72,6,52,130
+Laporte,UNION,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,23,0,4,27
+Laporte,UNION,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,UNION,Attorney General,,REP,Todd Rokita,156,8,90,254
+Laporte,UNION,Attorney General,,DEM,Destiny Wells,81,6,52,139
+Laporte,UNION,United States Representative,2,REP,Rudy Yakym,153,7,82,242
+Laporte,UNION,United States Representative,2,DEM,Lori A. Camp,71,6,55,132
+Laporte,UNION,United States Representative,2,LIB,William E. Henry,16,1,4,21
+Laporte,UNION,United States Representative,2,,Write-In,0,0,0,0
+Laporte,UNION,State Senator District 8,,REP,Mike Bohacek,187,9,92,288
+Laporte,UNION,State Senator District 8,,DEM,Leon P. Smith,56,5,51,112
+Laporte,UNION,State Representative,20,REP,Jim Pressel,197,8,95,300
+Laporte,UNION,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,184,10,95,289
+Laporte,UNION,Circuit Court Clerk,,REP,Heather Stevens,172,7,83,262
+Laporte,UNION,Circuit Court Clerk,,DEM,Angela Henzman,62,7,51,120
+Laporte,UNION,County Auditor,,REP,Mike Rosenbaum,197,10,100,307
+Laporte,UNION,County Recorder,,REP,Elzbieta (Ela) Bilderback,164,7,87,258
+Laporte,UNION,County Recorder,,DEM,Matthew Sikorski,71,7,52,130
+Laporte,UNION,County Treasurer,,REP,Dan Barenie,165,8,87,260
+Laporte,UNION,County Treasurer,,DEM,Joie Winski,71,6,54,131
+Laporte,UNION,County Coroner,,REP,Lynn Swanson,168,7,90,265
+Laporte,UNION,County Coroner,,DEM,Mark P. Baker,73,6,53,132
+Laporte,UNION,County Surveyor,,REP,John Matwyshyn,148,5,82,235
+Laporte,UNION,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,89,8,59,156
+Laporte,UNION,County Commissioner District 2,,REP,Steve Holifield,158,7,82,247
+Laporte,UNION,County Commissioner District 2,,DEM,Mike Kellems,83,7,58,148
+Laporte,UNION,County Commissioner District 3,,REP,Joe Haney,160,7,84,251
+Laporte,UNION,County Commissioner District 3,,DEM,Randy Novak,84,7,54,145
+Laporte,UNION,County Council Member At Large,,REP,Brett H. Kessler,135,6,68,209
+Laporte,UNION,County Council Member At Large,,REP,Adam Koronka,113,6,64,183
+Laporte,UNION,County Council Member At Large,,REP,Heather Oake,123,6,61,190
+Laporte,UNION,County Council Member At Large,,DEM,Scott (Scotty) Ford,62,6,46,114
+Laporte,UNION,County Council Member At Large,,DEM,Mike Mollenhauer,72,7,58,137
+Laporte,UNION,County Council Member At Large,,DEM,Johnny Stimley,50,5,37,92
+Laporte,UNION,Laporte Community School Board At Large,,,Jim Arnold,140,9,67,216
+Laporte,UNION,Laporte Community School Board At Large,,,Monica L. Beaty,139,7,83,229
+Laporte,UNION,Laporte Community School Board At Large,,,Maria L. Ria Carpenter,90,6,60,156
+Laporte,UNION,Laporte Community School Board At Large,,,Ed Gilliland,74,3,43,120
+Laporte,UNION,Laporte Community School Board At Large,,,Tucker King,112,8,71,191
+Laporte,UNION,IN Supreme Court-Rush,,,Yes,151,8,77,236
+Laporte,UNION,IN Supreme Court-Rush,,,No,68,4,40,112
+Laporte,UNION,IN Supreme Court-Massa,,,Yes,150,6,74,230
+Laporte,UNION,IN Supreme Court-Massa,,,No,67,6,42,115
+Laporte,UNION,IN Supreme Court-Molter,,,Yes,153,6,80,239
+Laporte,UNION,IN Supreme Court-Molter,,,No,64,6,37,107
+Laporte,UNION,Court of Appeals Dist 4-Pyle III,,,Yes,145,6,74,225
+Laporte,UNION,Court of Appeals Dist 4-Pyle III,,,No,69,6,42,117
+Laporte,UNION,Straight Party,,DEM,Democratic Party,,,,48
+Laporte,UNION,Straight Party,,LIB,Libertarian Party,,,,1
+Laporte,UNION,Straight Party,,REP,Republican Party,,,,111
+Laporte,WANATAH 01,Ballots Cast,,,,117,11,222,350
+Laporte,WANATAH 01,Registered Voters,,,,,,,492
+Laporte,WANATAH 01,Public Question-Const Amendment,,,Yes,52,7,110,169
+Laporte,WANATAH 01,Public Question-Const Amendment,,,No,59,2,90,151
+Laporte,WANATAH 01,President and Vice-President of the U.S.,,REP,Trump \ Vance,63,5,132,200
+Laporte,WANATAH 01,President and Vice-President of the U.S.,,DEM,Harris \ Walz,48,6,81,135
+Laporte,WANATAH 01,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,1,0,1,2
+Laporte,WANATAH 01,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,4,0,3,7
+Laporte,WANATAH 01,President and Vice-President of the U.S.,,,Write-In,1,0,1,2
+Laporte,WANATAH 01,United States Senator,,REP,Jim Banks,58,6,134,198
+Laporte,WANATAH 01,United States Senator,,DEM,Valerie McCray,48,4,74,126
+Laporte,WANATAH 01,United States Senator,,LIB,Andrew Horning,3,0,4,7
+Laporte,WANATAH 01,United States Senator,,,Write-In,0,0,0,0
+Laporte,WANATAH 01,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,57,4,121,182
+Laporte,WANATAH 01,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,49,5,85,139
+Laporte,WANATAH 01,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,6,1,7,14
+Laporte,WANATAH 01,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,WANATAH 01,Attorney General,,REP,Todd Rokita,65,6,133,204
+Laporte,WANATAH 01,Attorney General,,DEM,Destiny Wells,47,4,80,131
+Laporte,WANATAH 01,United States Representative,2,REP,Rudy Yakym,60,8,124,192
+Laporte,WANATAH 01,United States Representative,2,DEM,Lori A. Camp,48,3,81,132
+Laporte,WANATAH 01,United States Representative,2,LIB,William E. Henry,4,0,9,13
+Laporte,WANATAH 01,United States Representative,2,,Write-In,0,0,0,0
+Laporte,WANATAH 01,State Senator District 8,,REP,Mike Bohacek,76,9,136,221
+Laporte,WANATAH 01,State Senator District 8,,DEM,Leon P. Smith,38,2,79,119
+Laporte,WANATAH 01,State Representative,20,REP,Jim Pressel,82,8,153,243
+Laporte,WANATAH 01,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,75,10,143,228
+Laporte,WANATAH 01,Circuit Court Clerk,,REP,Heather Stevens,65,8,134,207
+Laporte,WANATAH 01,Circuit Court Clerk,,DEM,Angela Henzman,42,3,76,121
+Laporte,WANATAH 01,County Auditor,,REP,Mike Rosenbaum,84,10,154,248
+Laporte,WANATAH 01,County Recorder,,REP,Elzbieta (Ela) Bilderback,67,10,126,203
+Laporte,WANATAH 01,County Recorder,,DEM,Matthew Sikorski,43,1,84,128
+Laporte,WANATAH 01,County Treasurer,,REP,Dan Barenie,66,5,123,194
+Laporte,WANATAH 01,County Treasurer,,DEM,Joie Winski,44,4,88,136
+Laporte,WANATAH 01,County Coroner,,REP,Lynn Swanson,71,8,131,210
+Laporte,WANATAH 01,County Coroner,,DEM,Mark P. Baker,39,3,82,124
+Laporte,WANATAH 01,County Surveyor,,REP,John Matwyshyn,61,6,116,183
+Laporte,WANATAH 01,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,48,5,96,149
+Laporte,WANATAH 01,County Commissioner District 2,,REP,Steve Holifield,56,6,113,175
+Laporte,WANATAH 01,County Commissioner District 2,,DEM,Mike Kellems,54,5,100,159
+Laporte,WANATAH 01,County Commissioner District 3,,REP,Joe Haney,58,5,116,179
+Laporte,WANATAH 01,County Commissioner District 3,,DEM,Randy Novak,51,6,96,153
+Laporte,WANATAH 01,County Council Member At Large,,REP,Brett H. Kessler,59,8,108,175
+Laporte,WANATAH 01,County Council Member At Large,,REP,Adam Koronka,48,6,96,150
+Laporte,WANATAH 01,County Council Member At Large,,REP,Heather Oake,46,8,96,150
+Laporte,WANATAH 01,County Council Member At Large,,DEM,Scott (Scotty) Ford,32,3,62,97
+Laporte,WANATAH 01,County Council Member At Large,,DEM,Mike Mollenhauer,44,3,87,134
+Laporte,WANATAH 01,County Council Member At Large,,DEM,Johnny Stimley,32,2,62,96
+Laporte,WANATAH 01,IN Supreme Court-Rush,,,Yes,67,6,124,197
+Laporte,WANATAH 01,IN Supreme Court-Rush,,,No,31,3,56,90
+Laporte,WANATAH 01,IN Supreme Court-Massa,,,Yes,64,7,124,195
+Laporte,WANATAH 01,IN Supreme Court-Massa,,,No,33,2,55,90
+Laporte,WANATAH 01,IN Supreme Court-Molter,,,Yes,64,6,124,194
+Laporte,WANATAH 01,IN Supreme Court-Molter,,,No,33,3,57,93
+Laporte,WANATAH 01,Court of Appeals Dist 4-Pyle III,,,Yes,64,7,124,195
+Laporte,WANATAH 01,Court of Appeals Dist 4-Pyle III,,,No,34,1,57,92
+Laporte,WANATAH 01,Straight Party,,DEM,Democratic Party,,,,51
+Laporte,WANATAH 01,Straight Party,,REP,Republican Party,,,,77
+Laporte,WANATAH 02,Ballots Cast,,,,69,8,135,212
+Laporte,WANATAH 02,Registered Voters,,,,,,,298
+Laporte,WANATAH 02,Public Question-Const Amendment,,,Yes,33,3,63,99
+Laporte,WANATAH 02,Public Question-Const Amendment,,,No,33,1,49,83
+Laporte,WANATAH 02,President and Vice-President of the U.S.,,REP,Trump \ Vance,49,3,98,150
+Laporte,WANATAH 02,President and Vice-President of the U.S.,,DEM,Harris \ Walz,18,4,34,56
+Laporte,WANATAH 02,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,1,1,0,2
+Laporte,WANATAH 02,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,0,0,0,0
+Laporte,WANATAH 02,President and Vice-President of the U.S.,,,Write-In,0,0,1,1
+Laporte,WANATAH 02,United States Senator,,REP,Jim Banks,45,2,89,136
+Laporte,WANATAH 02,United States Senator,,DEM,Valerie McCray,18,4,35,57
+Laporte,WANATAH 02,United States Senator,,LIB,Andrew Horning,3,1,1,5
+Laporte,WANATAH 02,United States Senator,,,Write-In,0,0,0,0
+Laporte,WANATAH 02,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,41,2,86,129
+Laporte,WANATAH 02,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,20,5,33,58
+Laporte,WANATAH 02,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,6,0,3,9
+Laporte,WANATAH 02,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,WANATAH 02,Attorney General,,REP,Todd Rokita,47,2,95,144
+Laporte,WANATAH 02,Attorney General,,DEM,Destiny Wells,19,5,31,55
+Laporte,WANATAH 02,United States Representative,2,REP,Rudy Yakym,44,2,90,136
+Laporte,WANATAH 02,United States Representative,2,DEM,Lori A. Camp,18,5,34,57
+Laporte,WANATAH 02,United States Representative,2,LIB,William E. Henry,4,0,3,7
+Laporte,WANATAH 02,United States Representative,2,,Write-In,0,0,0,0
+Laporte,WANATAH 02,State Senator District 8,,REP,Mike Bohacek,48,2,97,147
+Laporte,WANATAH 02,State Senator District 8,,DEM,Leon P. Smith,17,5,28,50
+Laporte,WANATAH 02,State Representative,20,REP,Jim Pressel,57,3,103,163
+Laporte,WANATAH 02,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,52,3,103,158
+Laporte,WANATAH 02,Circuit Court Clerk,,REP,Heather Stevens,44,2,92,138
+Laporte,WANATAH 02,Circuit Court Clerk,,DEM,Angela Henzman,17,5,31,53
+Laporte,WANATAH 02,County Auditor,,REP,Mike Rosenbaum,58,3,107,168
+Laporte,WANATAH 02,County Recorder,,REP,Elzbieta (Ela) Bilderback,45,3,93,141
+Laporte,WANATAH 02,County Recorder,,DEM,Matthew Sikorski,20,4,30,54
+Laporte,WANATAH 02,County Treasurer,,REP,Dan Barenie,47,2,91,140
+Laporte,WANATAH 02,County Treasurer,,DEM,Joie Winski,19,5,34,58
+Laporte,WANATAH 02,County Coroner,,REP,Lynn Swanson,46,2,95,143
+Laporte,WANATAH 02,County Coroner,,DEM,Mark P. Baker,20,5,31,56
+Laporte,WANATAH 02,County Surveyor,,REP,John Matwyshyn,45,2,85,132
+Laporte,WANATAH 02,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,21,5,40,66
+Laporte,WANATAH 02,County Commissioner District 2,,REP,Steve Holifield,46,2,92,140
+Laporte,WANATAH 02,County Commissioner District 2,,DEM,Mike Kellems,21,5,34,60
+Laporte,WANATAH 02,County Commissioner District 3,,REP,Joe Haney,48,3,90,141
+Laporte,WANATAH 02,County Commissioner District 3,,DEM,Randy Novak,18,4,34,56
+Laporte,WANATAH 02,County Council Member At Large,,REP,Brett H. Kessler,40,2,68,110
+Laporte,WANATAH 02,County Council Member At Large,,REP,Adam Koronka,34,1,62,97
+Laporte,WANATAH 02,County Council Member At Large,,REP,Heather Oake,32,2,59,93
+Laporte,WANATAH 02,County Council Member At Large,,DEM,Scott (Scotty) Ford,19,4,28,51
+Laporte,WANATAH 02,County Council Member At Large,,DEM,Mike Mollenhauer,20,5,29,54
+Laporte,WANATAH 02,County Council Member At Large,,DEM,Johnny Stimley,14,4,24,42
+Laporte,WANATAH 02,South Central School Board At Large,,,Jacob Wade,48,2,80,130
+Laporte,WANATAH 02,South Central SB Hanna Township,,,Cheryl Lynn (Sherry) Shei,33,2,49,84
+Laporte,WANATAH 02,South Central SB Hanna Township,,,Michael Sullivan,20,1,38,59
+Laporte,WANATAH 02,South Central SB Noble Township,,,Geraldine (Gerrie) Grott,48,2,76,126
+Laporte,WANATAH 02,IN Supreme Court-Rush,,,Yes,40,3,68,111
+Laporte,WANATAH 02,IN Supreme Court-Rush,,,No,16,3,19,38
+Laporte,WANATAH 02,IN Supreme Court-Massa,,,Yes,39,2,70,111
+Laporte,WANATAH 02,IN Supreme Court-Massa,,,No,16,4,17,37
+Laporte,WANATAH 02,IN Supreme Court-Molter,,,Yes,40,2,66,108
+Laporte,WANATAH 02,IN Supreme Court-Molter,,,No,17,4,19,40
+Laporte,WANATAH 02,Court of Appeals Dist 4-Pyle III,,,Yes,39,3,69,111
+Laporte,WANATAH 02,Court of Appeals Dist 4-Pyle III,,,No,17,3,18,38
+Laporte,WANATAH 02,Straight Party,,DEM,Democratic Party,,,,13
+Laporte,WANATAH 02,Straight Party,,REP,Republican Party,,,,72
+Laporte,WASHINGTON,Ballots Cast,,,,41,21,228,290
+Laporte,WASHINGTON,Registered Voters,,,,,,,774
+Laporte,WASHINGTON,Public Question-Const Amendment,,,Yes,24,6,96,126
+Laporte,WASHINGTON,Public Question-Const Amendment,,,No,13,8,103,124
+Laporte,WASHINGTON,President and Vice-President of the U.S.,,REP,Trump \ Vance,28,11,146,185
+Laporte,WASHINGTON,President and Vice-President of the U.S.,,DEM,Harris \ Walz,12,10,79,101
+Laporte,WASHINGTON,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,0,0,0,0
+Laporte,WASHINGTON,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,0,0,2,2
+Laporte,WASHINGTON,President and Vice-President of the U.S.,,,Write-In,0,0,0,0
+Laporte,WASHINGTON,United States Senator,,REP,Jim Banks,22,9,138,169
+Laporte,WASHINGTON,United States Senator,,DEM,Valerie McCray,13,9,68,90
+Laporte,WASHINGTON,United States Senator,,LIB,Andrew Horning,2,0,3,5
+Laporte,WASHINGTON,United States Senator,,,Write-In,0,0,0,0
+Laporte,WASHINGTON,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,23,10,129,162
+Laporte,WASHINGTON,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,12,9,80,101
+Laporte,WASHINGTON,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,2,0,6,8
+Laporte,WASHINGTON,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,WASHINGTON,Attorney General,,REP,Todd Rokita,27,10,146,183
+Laporte,WASHINGTON,Attorney General,,DEM,Destiny Wells,11,9,71,91
+Laporte,WASHINGTON,United States Representative,2,REP,Rudy Yakym,26,9,137,172
+Laporte,WASHINGTON,United States Representative,2,DEM,Lori A. Camp,11,9,75,95
+Laporte,WASHINGTON,United States Representative,2,LIB,William E. Henry,3,0,3,6
+Laporte,WASHINGTON,United States Representative,2,,Write-In,0,0,0,0
+Laporte,WASHINGTON,State Senator District 8,,REP,Mike Bohacek,27,11,150,188
+Laporte,WASHINGTON,State Senator District 8,,DEM,Leon P. Smith,12,8,64,84
+Laporte,WASHINGTON,State Representative,20,REP,Jim Pressel,30,11,171,212
+Laporte,WASHINGTON,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,28,10,161,199
+Laporte,WASHINGTON,Circuit Court Clerk,,REP,Heather Stevens,28,9,144,181
+Laporte,WASHINGTON,Circuit Court Clerk,,DEM,Angela Henzman,9,9,63,81
+Laporte,WASHINGTON,County Auditor,,REP,Mike Rosenbaum,31,10,169,210
+Laporte,WASHINGTON,County Recorder,,REP,Elzbieta (Ela) Bilderback,25,9,138,172
+Laporte,WASHINGTON,County Recorder,,DEM,Matthew Sikorski,13,9,73,95
+Laporte,WASHINGTON,County Treasurer,,REP,Dan Barenie,25,9,131,165
+Laporte,WASHINGTON,County Treasurer,,DEM,Joie Winski,13,9,78,100
+Laporte,WASHINGTON,County Coroner,,REP,Lynn Swanson,28,10,138,176
+Laporte,WASHINGTON,County Coroner,,DEM,Mark P. Baker,11,8,73,92
+Laporte,WASHINGTON,County Surveyor,,REP,John Matwyshyn,29,9,124,162
+Laporte,WASHINGTON,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,10,9,86,105
+Laporte,WASHINGTON,County Commissioner District 2,,REP,Steve Holifield,26,9,129,164
+Laporte,WASHINGTON,County Commissioner District 2,,DEM,Mike Kellems,13,10,82,105
+Laporte,WASHINGTON,County Commissioner District 3,,REP,Joe Haney,29,9,129,167
+Laporte,WASHINGTON,County Commissioner District 3,,DEM,Randy Novak,8,9,85,102
+Laporte,WASHINGTON,County Council Member At Large,,REP,Brett H. Kessler,21,8,120,149
+Laporte,WASHINGTON,County Council Member At Large,,REP,Adam Koronka,18,5,116,139
+Laporte,WASHINGTON,County Council Member At Large,,REP,Heather Oake,17,5,105,127
+Laporte,WASHINGTON,County Council Member At Large,,DEM,Scott (Scotty) Ford,11,8,71,90
+Laporte,WASHINGTON,County Council Member At Large,,DEM,Mike Mollenhauer,10,10,73,93
+Laporte,WASHINGTON,County Council Member At Large,,DEM,Johnny Stimley,11,8,55,74
+Laporte,WASHINGTON,Laporte Community School Board At Large,,,Jim Arnold,21,9,119,149
+Laporte,WASHINGTON,Laporte Community School Board At Large,,,Monica L. Beaty,21,7,112,140
+Laporte,WASHINGTON,Laporte Community School Board At Large,,,Maria L. Ria Carpenter,18,5,106,129
+Laporte,WASHINGTON,Laporte Community School Board At Large,,,Ed Gilliland,14,6,78,98
+Laporte,WASHINGTON,Laporte Community School Board At Large,,,Tucker King,16,5,91,112
+Laporte,WASHINGTON,IN Supreme Court-Rush,,,Yes,20,6,121,147
+Laporte,WASHINGTON,IN Supreme Court-Rush,,,No,13,8,59,80
+Laporte,WASHINGTON,IN Supreme Court-Massa,,,Yes,18,9,120,147
+Laporte,WASHINGTON,IN Supreme Court-Massa,,,No,13,5,60,78
+Laporte,WASHINGTON,IN Supreme Court-Molter,,,Yes,18,7,117,142
+Laporte,WASHINGTON,IN Supreme Court-Molter,,,No,14,7,63,84
+Laporte,WASHINGTON,Court of Appeals Dist 4-Pyle III,,,Yes,20,9,115,144
+Laporte,WASHINGTON,Court of Appeals Dist 4-Pyle III,,,No,13,4,63,80
+Laporte,WASHINGTON,Straight Party,,DEM,Democratic Party,,,,26
+Laporte,WASHINGTON,Straight Party,,REP,Republican Party,,,,74
+Laporte,WESTVILLE,Ballots Cast,,,,572,40,394,1006
+Laporte,WESTVILLE,Registered Voters,,,,,,,1620
+Laporte,WESTVILLE,Public Question-Const Amendment,,,Yes,311,11,187,509
+Laporte,WESTVILLE,Public Question-Const Amendment,,,No,210,19,160,389
+Laporte,WESTVILLE,President and Vice-President of the U.S.,,REP,Trump \ Vance,395,8,238,641
+Laporte,WESTVILLE,President and Vice-President of the U.S.,,DEM,Harris \ Walz,152,32,144,328
+Laporte,WESTVILLE,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,4,0,5,9
+Laporte,WESTVILLE,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,13,0,1,14
+Laporte,WESTVILLE,President and Vice-President of the U.S.,,,Write-In,4,0,0,4
+Laporte,WESTVILLE,United States Senator,,REP,Jim Banks,352,9,211,572
+Laporte,WESTVILLE,United States Senator,,DEM,Valerie McCray,161,30,148,339
+Laporte,WESTVILLE,United States Senator,,LIB,Andrew Horning,17,0,8,25
+Laporte,WESTVILLE,United States Senator,,,Write-In,0,0,0,0
+Laporte,WESTVILLE,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,337,8,206,551
+Laporte,WESTVILLE,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,162,31,154,347
+Laporte,WESTVILLE,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,29,0,12,41
+Laporte,WESTVILLE,Governor And Lieutenant Governor,,,Write-In,0,0,0,0
+Laporte,WESTVILLE,Attorney General,,REP,Todd Rokita,376,8,233,617
+Laporte,WESTVILLE,Attorney General,,DEM,Destiny Wells,167,31,144,342
+Laporte,WESTVILLE,United States Representative,1,REP,Randy Niemeyer,346,11,207,564
+Laporte,WESTVILLE,United States Representative,1,DEM,Frank J. Mrvan,181,28,163,372
+Laporte,WESTVILLE,United States Representative,1,LIB,Dakotah Miskus,20,0,8,28
+Laporte,WESTVILLE,United States Representative,1,,Write-In,0,0,0,0
+Laporte,WESTVILLE,State Representative,20,REP,Jim Pressel,436,17,262,715
+Laporte,WESTVILLE,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,412,17,243,672
+Laporte,WESTVILLE,Circuit Court Clerk,,REP,Heather Stevens,365,10,217,592
+Laporte,WESTVILLE,Circuit Court Clerk,,DEM,Angela Henzman,164,29,138,331
+Laporte,WESTVILLE,County Auditor,,REP,Mike Rosenbaum,450,17,266,733
+Laporte,WESTVILLE,County Recorder,,REP,Elzbieta (Ela) Bilderback,362,12,214,588
+Laporte,WESTVILLE,County Recorder,,DEM,Matthew Sikorski,169,27,147,343
+Laporte,WESTVILLE,County Treasurer,,REP,Dan Barenie,363,8,220,591
+Laporte,WESTVILLE,County Treasurer,,DEM,Joie Winski,177,31,152,360
+Laporte,WESTVILLE,County Coroner,,REP,Lynn Swanson,369,11,230,610
+Laporte,WESTVILLE,County Coroner,,DEM,Mark P. Baker,166,28,141,335
+Laporte,WESTVILLE,County Surveyor,,REP,John Matwyshyn,363,10,203,576
+Laporte,WESTVILLE,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,168,29,159,356
+Laporte,WESTVILLE,County Commissioner District 2,,REP,Steve Holifield,350,9,214,573
+Laporte,WESTVILLE,County Commissioner District 2,,DEM,Mike Kellems,179,30,150,359
+Laporte,WESTVILLE,County Commissioner District 3,,REP,Joe Haney,355,11,210,576
+Laporte,WESTVILLE,County Commissioner District 3,,DEM,Randy Novak,181,28,156,365
+Laporte,WESTVILLE,County Council Member At Large,,REP,Brett H. Kessler,294,6,178,478
+Laporte,WESTVILLE,County Council Member At Large,,REP,Adam Koronka,238,5,148,391
+Laporte,WESTVILLE,County Council Member At Large,,REP,Heather Oake,227,6,154,387
+Laporte,WESTVILLE,County Council Member At Large,,DEM,Scott (Scotty) Ford,131,22,109,262
+Laporte,WESTVILLE,County Council Member At Large,,DEM,Mike Mollenhauer,168,23,125,316
+Laporte,WESTVILLE,County Council Member At Large,,DEM,Johnny Stimley,133,20,101,254
+Laporte,WESTVILLE,Msd of New Durham Township At Large,,,Philip Burdine,381,17,232,630
+Laporte,WESTVILLE,Msd of New Durham Township At Large,,,Karen Jedrysek,344,19,210,573
+Laporte,WESTVILLE,IN Supreme Court-Rush,,,Yes,329,10,208,547
+Laporte,WESTVILLE,IN Supreme Court-Rush,,,No,144,15,92,251
+Laporte,WESTVILLE,IN Supreme Court-Massa,,,Yes,329,13,199,541
+Laporte,WESTVILLE,IN Supreme Court-Massa,,,No,144,12,92,248
+Laporte,WESTVILLE,IN Supreme Court-Molter,,,Yes,332,14,201,547
+Laporte,WESTVILLE,IN Supreme Court-Molter,,,No,140,11,100,251
+Laporte,WESTVILLE,Court of Appeals Dist 4-Pyle III,,,Yes,332,14,194,540
+Laporte,WESTVILLE,Court of Appeals Dist 4-Pyle III,,,No,135,11,103,249
+Laporte,WESTVILLE,Straight Party,,DEM,Democratic Party,,,,124
+Laporte,WESTVILLE,Straight Party,,LIB,Libertarian Party,,,,1
+Laporte,WESTVILLE,Straight Party,,REP,Republican Party,,,,297
+Laporte,WILLS,Ballots Cast,,,,474,39,728,1241
+Laporte,WILLS,Registered Voters,,,,,,,1734
+Laporte,WILLS,Public Question-Const Amendment,,,Yes,218,8,302,528
+Laporte,WILLS,Public Question-Const Amendment,,,No,214,21,315,550
+Laporte,WILLS,President and Vice-President of the U.S.,,REP,Trump \ Vance,368,15,483,866
+Laporte,WILLS,President and Vice-President of the U.S.,,DEM,Harris \ Walz,93,24,226,343
+Laporte,WILLS,President and Vice-President of the U.S.,,LIB,Oliver \ Ter Maat,3,0,3,6
+Laporte,WILLS,President and Vice-President of the U.S.,,WTP,Kennedy Jr. \ Shanahan,5,0,6,11
+Laporte,WILLS,President and Vice-President of the U.S.,,,Write-In,0,0,3,3
+Laporte,WILLS,United States Senator,,REP,Jim Banks,339,15,465,819
+Laporte,WILLS,United States Senator,,DEM,Valerie McCray,92,24,213,329
+Laporte,WILLS,United States Senator,,LIB,Andrew Horning,20,0,10,30
+Laporte,WILLS,United States Senator,,,Write-In,0,0,0,0
+Laporte,WILLS,Governor And Lieutenant Governor,,REP,Braun \ Beckwith,322,15,428,765
+Laporte,WILLS,Governor And Lieutenant Governor,,DEM,Mccormick \ Goodin,113,24,238,375
+Laporte,WILLS,Governor And Lieutenant Governor,,LIB,Rainwater \ Hudson,24,0,26,50
+Laporte,WILLS,Governor And Lieutenant Governor,,,Write-In,0,0,1,1
+Laporte,WILLS,Attorney General,,REP,Todd Rokita,351,16,480,847
+Laporte,WILLS,Attorney General,,DEM,Destiny Wells,103,22,229,354
+Laporte,WILLS,United States Representative,2,REP,Rudy Yakym,340,16,466,822
+Laporte,WILLS,United States Representative,2,DEM,Lori A. Camp,94,23,226,343
+Laporte,WILLS,United States Representative,2,LIB,William E. Henry,23,0,13,36
+Laporte,WILLS,United States Representative,2,,Write-In,0,0,0,0
+Laporte,WILLS,State Senator District 8,,REP,Mike Bohacek,366,16,479,861
+Laporte,WILLS,State Senator District 8,,DEM,Leon P. Smith,92,22,218,332
+Laporte,WILLS,State Representative,20,REP,Jim Pressel,390,21,517,928
+Laporte,WILLS,Judge of the Circuit Court 32nd Circuit,,REP,Julianne K. Havens,365,22,491,878
+Laporte,WILLS,Circuit Court Clerk,,REP,Heather Stevens,337,15,462,814
+Laporte,WILLS,Circuit Court Clerk,,DEM,Angela Henzman,93,24,217,334
+Laporte,WILLS,County Auditor,,REP,Mike Rosenbaum,387,21,528,936
+Laporte,WILLS,County Recorder,,REP,Elzbieta (Ela) Bilderback,326,15,449,790
+Laporte,WILLS,County Recorder,,DEM,Matthew Sikorski,112,24,236,372
+Laporte,WILLS,County Treasurer,,REP,Dan Barenie,329,14,452,795
+Laporte,WILLS,County Treasurer,,DEM,Joie Winski,117,22,241,380
+Laporte,WILLS,County Coroner,,REP,Lynn Swanson,350,14,468,832
+Laporte,WILLS,County Coroner,,DEM,Mark P. Baker,100,25,229,354
+Laporte,WILLS,County Surveyor,,REP,John Matwyshyn,318,15,422,755
+Laporte,WILLS,County Surveyor,,DEM,Anthony Charles (Tony) Hendricks,120,24,265,409
+Laporte,WILLS,County Commissioner District 2,,REP,Steve Holifield,316,15,457,788
+Laporte,WILLS,County Commissioner District 2,,DEM,Mike Kellems,132,24,236,392
+Laporte,WILLS,County Commissioner District 3,,REP,Joe Haney,306,13,438,757
+Laporte,WILLS,County Commissioner District 3,,DEM,Randy Novak,133,26,252,411
+Laporte,WILLS,County Council Member At Large,,REP,Brett H. Kessler,269,9,410,688
+Laporte,WILLS,County Council Member At Large,,REP,Adam Koronka,222,9,335,566
+Laporte,WILLS,County Council Member At Large,,REP,Heather Oake,219,9,359,587
+Laporte,WILLS,County Council Member At Large,,DEM,Scott (Scotty) Ford,104,20,197,321
+Laporte,WILLS,County Council Member At Large,,DEM,Mike Mollenhauer,129,23,224,376
+Laporte,WILLS,County Council Member At Large,,DEM,Johnny Stimley,86,21,158,265
+Laporte,WILLS,New Prairie United School Corp At Lg,,,Jill Smith,225,19,350,594
+Laporte,WILLS,New Prairie United School Corp At Lg,,,Mike Yacullo,157,6,209,372
+Laporte,WILLS,New Prairie United School Corp Dist 1,,,Rich Shail,312,20,474,806
+Laporte,WILLS,New Prairie United School Corp Dist 3,,,Phillip J. King,171,14,247,432
+Laporte,WILLS,New Prairie United School Corp Dist 3,,,Andrew Oake,194,9,289,492
+Laporte,WILLS,IN Supreme Court-Rush,,,Yes,251,12,362,625
+Laporte,WILLS,IN Supreme Court-Rush,,,No,110,13,187,310
+Laporte,WILLS,IN Supreme Court-Massa,,,Yes,247,9,362,618
+Laporte,WILLS,IN Supreme Court-Massa,,,No,111,16,186,313
+Laporte,WILLS,IN Supreme Court-Molter,,,Yes,251,10,368,629
+Laporte,WILLS,IN Supreme Court-Molter,,,No,109,15,181,305
+Laporte,WILLS,Court of Appeals Dist 4-Pyle III,,,Yes,250,9,358,617
+Laporte,WILLS,Court of Appeals Dist 4-Pyle III,,,No,109,15,192,316
+Laporte,WILLS,Straight Party,,DEM,Democratic Party,,,,133
+Laporte,WILLS,Straight Party,,REP,Republican Party,,,,376


### PR DESCRIPTION
Laporte County stored their election results in a similar format as Lake County, so we were able to apply our algorithm from Lake County, although Laporte skipped index 25 for their precincts and their pdf had a hidden character inside the NEW DURHAM 01 precinct name.