### PR TITLE
el30_parser: narrow bare except to IndexError/ValueError

### DIFF
--- a/el30_parser.py
+++ b/el30_parser.py
@@ -61,7 +61,7 @@ for line in lines:
                 party = party[0:3]
                 candidate = candidate.strip()
                 votes = line.split('    ', 3)[3].split('   ')[0].strip()
-            except:
+            except (IndexError, ValueError):
                 candidate = line.split('  ')[0]
                 party = None
                 votes = line.split('    ', 3)[3].split('   ')[0].strip()


### PR DESCRIPTION
flake8 E722. The `split('    ', 3)[3]` and surrounding ops can only raise IndexError / ValueError when the line doesn't have enough columns - which is exactly the case the fallback block handles. Narrow to those two so we stop swallowing KeyboardInterrupt.